### PR TITLE
Change instructions to clone over HTTPS [minor]

### DIFF
--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -9,7 +9,7 @@ Let's get a sample app powered by ComponentKit up and running, then make some tw
 Clone the Github repo and run `pod install` to set up the example app, then open the workspace:
 
 ```sh
-$ git clone git@github.com:facebook/componentkit.git
+$ git clone https://github.com/facebook/componentkit
 $ cd componentkit/Examples/WildeGuess/
 $ pod install
 $ open WildeGuess.xcworkspace


### PR DESCRIPTION
The ‘Getting Started’ instructions were having users clone over SSH which would result in an error if one doesn’t have the proper access rights:

```
❯ git clone git@github.com:facebook/componentkit.git
Cloning into 'componentkit'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Switching over to HTTPS is just an easier sane default.

ComponentKit looks super awesome! I’ve been anticipating checking it out for some time, so I’m excited!
