### PR TITLE
[componentkit] Fix TextKit build issues in Xcode 6.3

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRendererCache.h
+++ b/ComponentTextKit/TextKit/CKTextKitRendererCache.h
@@ -66,7 +66,7 @@ namespace CK {
         CKTextKitAttributes attributes;
         CGSize constrainedSize;
 
-        const Key(CKTextKitAttributes a, CGSize cs);
+        Key(CKTextKitAttributes a, CGSize cs);
 
         size_t hash;
 


### PR DESCRIPTION
This didn’t need to be const and the new version of the compiler was
complaining.

Should fix https://github.com/facebook/componentkit/issues/1