### PR TITLE
Update never-subclass-components.md

### DIFF
--- a/_docs/never-subclass-components.md
+++ b/_docs/never-subclass-components.md
@@ -1,5 +1,5 @@
 ---
-title: Never Subclass Components
+title: Never Subclass Other Components
 layout: docs
 permalink: /docs/never-subclass-components.html
 ---

--- a/_docs/never-subclass-components.md
+++ b/_docs/never-subclass-components.md
@@ -1,10 +1,10 @@
 ---
-title: Never Subclass Other Components
+title: Never Subclass Components
 layout: docs
 permalink: /docs/never-subclass-components.html
 ---
 
-You should always subclass `CKCompositeComponent` when creating a component. (If you need to perform advanced layout by overriding `computeLayoutThatFits:`, you may subclass `CKComponent` directly, but this is rare.) Don't subclass other component classes.
+You should never subclass any other component classes besides `CKCompositeComponent` when creating a component. (If you need to perform advanced layout by overriding computeLayoutThatFits:, you may subclass CKComponent directly, but this is rare.)
 
 - **Subclassing is difficult to reason about.** There is no `final` keyword in Objective-C, so *any* method can be overridden in a subclass. It's impossible to read a superclass and know what is and isn't overridden somewhere.
 - **Subclassing makes refactoring the superclass difficult.** If the superclass is refactored to rename or remove a method, every subclass must be inspected to see if they were overriding the method. This is often skipped or forgotten, leading to silent bugs.


### PR DESCRIPTION
The title "Never Subclass Components" is a bit confusing. It made it seem as if no components should ever be subclassed, not even `CKCompositeComponent `.

When viewing the title and first sentenced, it read as "Never Subclass Components. You should always subclass..." which almost contradicted each other (see image below). My proposed changes makes the title and first sentence flow a little better.

![screen shot 2015-03-25 at 11 50 42 pm](https://cloud.githubusercontent.com/assets/401294/6840612/d7d4109a-d349-11e4-831a-d910310b52e7.png)
