### PR TITLE
Replaced deprecated sizeWithFont: with sizeWithAttributes:

### DIFF
--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -230,7 +230,9 @@ static CGSize intrinsicSize(NSString *title, UIFont *titleFont, UIImage *image,
                             UIImage *backgroundImage, UIEdgeInsets contentEdgeInsets)
 {
   // This computation is based on observing [UIButton -sizeThatFits:].
-  CGSize titleSize = [title sizeWithFont:titleFont ?: [UIFont systemFontOfSize:[UIFont buttonFontSize]]];
+  CGSize titleSize = [title sizeWithAttributes:@{
+    NSFontAttributeName : titleFont ?: [UIFont systemFontOfSize:[UIFont buttonFontSize]]
+  }];
   CGSize imageSize = image.size;
   CGSize contentSize = {
     titleSize.width + imageSize.width + contentEdgeInsets.left + contentEdgeInsets.right,


### PR DESCRIPTION
`sizeWithFont:` has been deprecated and the example project showed a warning.
Unless I'm missing the reason why `sizeWithFont:` was being used over `sizeWithAttributes:`, this should remove the warning and keep the same behavior.