### PR TITLE
Remove Example project warnings

### DIFF
--- a/Examples/WildeGuess/WildeGuess/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/WildeGuess/WildeGuess/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,21 +1,18 @@
 {
   "images" : [
     {
+      "idiom" : "iphone",
       "size" : "29x29",
-      "idiom" : "iphone",
-      "filename" : "AppIcon29x29@2x.png",
       "scale" : "2x"
     },
     {
+      "idiom" : "iphone",
       "size" : "40x40",
-      "idiom" : "iphone",
-      "filename" : "AppIcon40x40@2x.png",
       "scale" : "2x"
     },
     {
-      "size" : "60x60",
       "idiom" : "iphone",
-      "filename" : "AppIcon60x60@2x.png",
+      "size" : "60x60",
       "scale" : "2x"
     },
     {


### PR DESCRIPTION
Xcode shows warnings for missing icons files for Example project.

I've cleaned up Assets and fixed those warnings.
Those changes are done by Xcode, auto generated not by hand, so the are safe.