### PR TITLE
Clean up some cruft in CKComponentHostingView

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -40,32 +40,19 @@
 
 - (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)manager
                        sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                   model:(id<NSObject>)model
-                           containerView:(UIView *)containerView
 {
   if (self = [super initWithFrame:CGRectZero]) {
     // Injected dependencies
     _sizeRangeProvider = sizeRangeProvider;
-    _model = model;
 
     // Internal dependencies
     _lifecycleManager = manager;
     _lifecycleManager.delegate = self;
 
-    _containerView = containerView;
+    _containerView = [[UIView alloc] initWithFrame:CGRectZero];
     [self addSubview:_containerView];
   }
   return self;
-}
-
-- (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)manager
-                       sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                   model:(id<NSObject>)model
-{
-  return [self initWithLifecycleManager:manager
-                      sizeRangeProvider:sizeRangeProvider
-                                  model:model
-                          containerView:[[UIView alloc] initWithFrame:CGRectZero]];
 }
 
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
@@ -73,7 +60,7 @@
                                   context:(id<NSObject>)context
 {
   CKComponentLifecycleManager *manager = [[CKComponentLifecycleManager alloc] initWithComponentProvider:componentProvider context:context sizeRangeProvider:sizeRangeProvider];
-  return [self initWithLifecycleManager:manager sizeRangeProvider:sizeRangeProvider model:nil];
+  return [self initWithLifecycleManager:manager sizeRangeProvider:sizeRangeProvider];
 }
 
 - (void)dealloc

--- a/ComponentKit/HostingView/CKComponentHostingViewInternal.h
+++ b/ComponentKit/HostingView/CKComponentHostingViewInternal.h
@@ -20,12 +20,6 @@
 @property (nonatomic, readonly) CKComponentLifecycleManager *lifecycleManager;
 
 - (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)manager
-                       sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                   model:(id<NSObject>)model
-                           containerView:(UIView *)containerView;
-
-- (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)manager
-                       sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                   model:(id<NSObject>)model;
+                       sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider;
 
 @end

--- a/ComponentKitTests/CKComponentHostingViewTests.mm
+++ b/ComponentKitTests/CKComponentHostingViewTests.mm
@@ -80,8 +80,9 @@
 - (CKComponentHostingView *)newHostingViewWithLifecycleManager:(CKComponentLifecycleManager *)manager
 {
   CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
-  CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithLifecycleManager:manager sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight] model:model];
+  CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithLifecycleManager:manager sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]];
   view.bounds = CGRectMake(0, 0, 100, 100);
+  view.model = model;
   [view layoutIfNeeded];
   return view;
 }
@@ -148,7 +149,8 @@
 {
   CKComponentLifecycleManager *manager = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class] context:nil];
   CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
-  CKComponentHostingView *hostingView = [[CKComponentHostingView alloc] initWithLifecycleManager:manager sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight] model:model];
+  CKComponentHostingView *hostingView = [[CKComponentHostingView alloc] initWithLifecycleManager:manager sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]];
+  hostingView.model = model;
   [hostingView layoutIfNeeded];
 
   XCTAssertFalse([manager isAttachedToView], @"Expect lifecycle manager to not be attached to the view when the bounds rect is empty.");


### PR DESCRIPTION
This cleans up internal APIs in the hosting view. None of this is external API, so it shouldn't break any existing code.