### PR TITLE
Silence warnings related to sizeWithFont

### DIFF
--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.library = 'c++'
   s.xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
-    'CLANG_CXX_LIBRARY' => 'libc++'
+    'CLANG_CXX_LIBRARY' => 'libc++',
+    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES'
   }
 end

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -229,8 +229,12 @@ static T valueForState(const std::unordered_map<UIControlState, T> &m, UIControl
 static CGSize intrinsicSize(NSString *title, UIFont *titleFont, UIImage *image,
                             UIImage *backgroundImage, UIEdgeInsets contentEdgeInsets)
 {
-  // This computation is based on observing [UIButton -sizeThatFits:].
+  // This computation is based on observing [UIButton -sizeThatFits:], which uses the deprecated method
+  // sizeWithFont in iOS 7 and iOS 8
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   CGSize titleSize = [title sizeWithFont:titleFont ?: [UIFont systemFontOfSize:[UIFont buttonFontSize]]];
+#pragma clang diagnostic pop
   CGSize imageSize = image.size;
   CGSize contentSize = {
     titleSize.width + imageSize.width + contentEdgeInsets.left + contentEdgeInsets.right,

--- a/Examples/WildeGuess/Podfile.lock
+++ b/Examples/WildeGuess/Podfile.lock
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  ComponentKit: 78d73c354af113de9cdd4605b825c9ca315da773
+  ComponentKit: 9dbaf4759c1125cf618c848ded3a37f4472fd0da
 
 COCOAPODS: 0.36.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: ./ComponentKitTestLib
 
 SPEC CHECKSUMS:
-  ComponentKit: 78d73c354af113de9cdd4605b825c9ca315da773
+  ComponentKit: 9dbaf4759c1125cf618c848ded3a37f4472fd0da
   ComponentKitTestLib: 2a3d2e482e316301a0a6c9c298d29fb820f66390
   FBSnapshotTestCase: 9d5fe43b29ae3a0ed8fc829477971b281038f748
   OCMock: 6db79185520e24f9f299548f2b8b07e41d881bd5


### PR DESCRIPTION
ComponentKit intentionally uses the deprecated method sizeWithFont: to match UIButton's sizing logic. However, some projects are configured to treat warnings as errors, so let's squash this warning and treat any warnings as errors.