### PR TITLE
Two new asserts to catch invalid animations

### DIFF
--- a/ComponentKit/Core/CKComponentAnimation.mm
+++ b/ComponentKit/Core/CKComponentAnimation.mm
@@ -20,6 +20,9 @@
 
 static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation)
 {
+  CKCAssertNotNil(component, @"Component being animated must be non-nil");
+  CKCAssertNotNil(originalAnimation, @"Animation being added must be non-nil");
+
   // Don't mutate the animation the component returned, in case it is a static or otherwise reused. (Also copy
   // immediately to protect against the *caller* mutating the animation after this point but before it's used.)
   CAAnimation *copiedAnimation = [originalAnimation copy];


### PR DESCRIPTION
These asserts will catch animations that don't have a component to animate or a `CAAnimation` to apply.