### PR TITLE
Change type of view passed to hit test hooks

### DIFF
--- a/ComponentKit/HostingView/CKComponentRootViewInternal.h
+++ b/ComponentKit/HostingView/CKComponentRootViewInternal.h
@@ -10,7 +10,9 @@
 
 #import <UIKit/UIKit.h>
 
-typedef UIView *(^CKComponentRootViewHitTestHook)(CKComponentRootView *rootView, CGPoint point, UIEvent *event);
+#import <ComponentKit/CKComponentRootView.h>
+
+typedef UIView *(^CKComponentRootViewHitTestHook)(UIView *rootView, CGPoint point, UIEvent *event);
 
 @interface CKComponentRootView ()
 


### PR DESCRIPTION
If we want to support non-CKComponentRootViews that use these hooks, it has to be a generic UIView.