### PR TITLE
[WildeGuess] Explicitely declare conformance to UICollectionViewDelegateFlowLayout

### DIFF
--- a/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
+++ b/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
@@ -24,7 +24,7 @@
 #import <ComponentKit/CKArrayControllerChangeset.h>
 #import <ComponentKit/CKComponentFlexibleSizeRangeProvider.h>
 
-@interface WildeGuessCollectionViewController () <CKComponentProvider, UIScrollViewDelegate>
+@interface WildeGuessCollectionViewController () <CKComponentProvider, UICollectionViewDelegateFlowLayout>
 @end
 
 @implementation WildeGuessCollectionViewController
@@ -89,7 +89,7 @@
                 constrainedSize:[_sizeRangeProvider sizeRangeForBoundingSize:self.collectionView.bounds.size]];
 }
 
-#pragma mark - UICollectionViewFlowLayoutDelegate
+#pragma mark - UICollectionViewDelegateFlowLayout
 
 - (CGSize)collectionView:(UICollectionView *)collectionView
                   layout:(UICollectionViewLayout *)collectionViewLayout


### PR DESCRIPTION
WildeGuessCollectionViewController have to conform not just to the UIScrollViewDelegate, but to its subclass UICollectionViewDelegateFlowLayout. It's not declared such yet (even that the example project compiles).
This also fixes one typo in a delegate name.