### PR TITLE
Add -numberOfSections and -numberOfObjectsInSection:

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.h
@@ -75,6 +75,10 @@ typedef void(*CKCellConfigurationFunction)(UICollectionViewCell *cell, NSIndexPa
  */
 - (void)updateContextAndEnqeueReload:(id)newContext;
 
+- (NSInteger)numberOfSections;
+
+- (NSInteger)numberOfObjectsInSection:(NSInteger)section;
+
 /**
  @return The model associated with a certain index path in the collectionView.
  

--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -104,6 +104,16 @@ CK_FINAL_CLASS([CKCollectionViewDataSource class]);
   [_componentDataSource updateContextAndEnqeueReload:newContext];
 }
 
+- (NSInteger)numberOfSections
+{
+  return [_componentDataSource numberOfSections];
+}
+
+- (NSInteger)numberOfObjectsInSection:(NSInteger)section
+{
+  return [_componentDataSource numberOfObjectsInSection:section];
+}
+
 - (id<NSObject>)modelForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   return [[_componentDataSource objectAtIndexPath:indexPath] model];


### PR DESCRIPTION
`-numberOfSections` and `-numberOfObjectsInSection:` were not exposed in
`CKCollectionViewDataSource`'s interface.
Internally they simply bridge to `_componentDataSource`.

See my question https://github.com/facebook/componentkit/issues/64