### PR TITLE
Replace CKComponentDataSource queue with atomic counter

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -284,7 +284,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   [_componentPreparationQueue enqueueBatch:preparationQueueBatch
                                      block:^(const CKArrayControllerSections &sections, PreparationBatchID ID, NSArray *outputBatch, BOOL isContiguousTailInsertion) {
                                        int32_t newCount = OSAtomicDecrement32(&_activeOperationCount);
-                                       CKInternalConsistencyCheckIf(oldCount >= 0, @"We dequeued more batches than what we enqueued something went really wrong.");
+                                       CKInternalConsistencyCheckIf(newCount >= 0, @"We dequeued more batches than what we enqueued something went really wrong.");
                                        [self _componentPreparationQueueDidPrepareBatch:outputBatch
                                                                               sections:sections];
                                      }];

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -283,8 +283,8 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   OSAtomicIncrement32(&_activeOperationCount);
   [_componentPreparationQueue enqueueBatch:preparationQueueBatch
                                      block:^(const CKArrayControllerSections &sections, PreparationBatchID ID, NSArray *outputBatch, BOOL isContiguousTailInsertion) {
-                                       int32_t oldCount = OSAtomicDecrement32(&_activeOperationCount);
-                                       CKInternalConsistencyCheckIf(oldCount > 0, @"We dequeued more batches than what we enqueued something went really wrong.");
+                                       int32_t newCount = OSAtomicDecrement32(&_activeOperationCount);
+                                       CKInternalConsistencyCheckIf(oldCount >= 0, @"We dequeued more batches than what we enqueued something went really wrong.");
                                        [self _componentPreparationQueueDidPrepareBatch:outputBatch
                                                                               sections:sections];
                                      }];


### PR DESCRIPTION
This change would make this aspect of `CKComponentDataSource` thread safe.

From my reading, the queue here currently fills two needs:

1. Assert that `-enqueueBatch:block:` processes batches serially.
2. Track whether changes are actively being processed (`isComputingChanges`)

The first item isn't necessary, `-enqueueBatch:` uses a serial dispatch queue. Unless there are plans/desires to make the preparation queue operate in parallel, then the first item is essentially asserting that dispatch queues work.

The second item can be implemented with an atomic counter.