### PR TITLE
[CKComponentViewClass] add friend class for FB internal needs

### DIFF
--- a/ComponentKit/Core/CKComponentViewConfiguration.h
+++ b/ComponentKit/Core/CKComponentViewConfiguration.h
@@ -73,6 +73,9 @@ struct CKComponentViewClass {
   bool operator!=(const CKComponentViewClass &other) const { return other.identifier != identifier; }
 
   const std::string &getIdentifier() const { return identifier; }
+
+  /** FB specific internal extension for supporting deprecated API. */
+  friend class CKComponentViewClassFBInternal;
 private:
   std::string identifier;
   UIView *(^factory)(void);


### PR DESCRIPTION
We need this internally to provide easier transition to the function based constructor for CKComponentViewClass. This change will be followed by removal of the block based constructor in the near future.