### PR TITLE
Fix black backgrounds in synchronously-rendered opaque text layers

### DIFF
--- a/ComponentTextKit/CKTextComponentLayer.mm
+++ b/ComponentTextKit/CKTextComponentLayer.mm
@@ -103,6 +103,17 @@ static CK::TextKit::Renderer::Cache *rasterContentsCache()
   [renderer drawInContext:context bounds:boundsRect];
 }
 
+- (void)drawInContext:(CGContextRef)ctx
+{
+  // When we're drawing synchronously we need to manually fill the bg color because CKAsyncLayer doesn't.
+  if (self.opaque && self.backgroundColor != NULL) {
+    CGRect boundsRect = CGContextGetClipBoundingBox(ctx);
+    CGContextSetFillColorWithColor(ctx, self.backgroundColor);
+    CGContextFillRect(ctx, boundsRect);
+  }
+  [super drawInContext:ctx];
+}
+
 #pragma mark - Highlighting
 
 - (CKTextComponentLayerHighlighter *)highlighter


### PR DESCRIPTION
Fixes https://github.com/facebook/componentkit/issues/73

Turns out CKAsyncLayer doesn't fill opaque contexts when it's rendering synchronously, only when it's rendering asynchronously.  This overrides the standard drawInContext method and fills in the background color for CKAsyncLayer before it uses its normal rendering functions.