### PR TITLE
Add pure -layoutForModel: method to CKComponentLifecycleManager

### DIFF
--- a/ComponentKit/Core/CKComponentLifecycleManager.h
+++ b/ComponentKit/Core/CKComponentLifecycleManager.h
@@ -44,6 +44,8 @@ extern const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEm
 
 - (CKComponentLifecycleManagerState)prepareForUpdateWithModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context;
 
+- (CKComponentLayout)layoutForModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context;
+
 /**
  Updates the state to the new one without mounting the view.
 

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -105,6 +105,15 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
   };
 }
 
+- (CKComponentLayout)layoutForModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context
+{
+  CKBuildComponentResult result = CKBuildComponent(self, _state.scopeFrame, ^{
+    return [_componentProvider componentForModel:model context:context];
+  });
+
+  return [result.component layoutThatFits:constrainedSize parentSize:constrainedSize.max];
+}
+
 - (void)updateWithState:(const CKComponentLifecycleManagerState &)state
 {
   BOOL sizeChanged = !CGSizeEqualToSize(_state.layout.size, state.layout.size);

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -91,8 +91,8 @@
 - (CGSize)sizeThatFits:(CGSize)size
 {
   CKSizeRange constrainedSize = [_sizeRangeProvider sizeRangeForBoundingSize:size];
-  CKComponentLifecycleManagerState state = [_lifecycleManager prepareForUpdateWithModel:_model constrainedSize:constrainedSize context:_context];
-  return state.layout.size;
+  CKComponentLayout layout = [_lifecycleManager layoutForModel:_model constrainedSize:constrainedSize context:_context];
+  return layout.size;
 }
 
 #pragma mark - Accessors


### PR DESCRIPTION
Currently, calling `-sizeThatFits:` on a `CKComponentHostingView` will break component state. This is because `-sizeThatFits:` calls `-prepareForUpdateWithModel:`, which [modifies an internal state "cache"](https://github.com/facebook/componentkit/blob/b74ebfb788216103711f19247895e83f8206e7c5/ComponentKit/Core/CKComponentLifecycleManager.mm#L97).

This pull request adds a pure layout method on `CKComponentLifecycleManager`, which can be called any number of times without side effects.