### PR TITLE
Remove 'treat warnings as errors' flag

### DIFF
--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -18,6 +18,5 @@ Pod::Spec.new do |s|
   s.xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
     'CLANG_CXX_LIBRARY' => 'libc++',
-    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES'
   }
 end

--- a/Examples/WildeGuess/Podfile.lock
+++ b/Examples/WildeGuess/Podfile.lock
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  ComponentKit: 9dbaf4759c1125cf618c848ded3a37f4472fd0da
+  ComponentKit: 78d73c354af113de9cdd4605b825c9ca315da773
 
 COCOAPODS: 0.36.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
     :path: ./ComponentKitTestLib
 
 SPEC CHECKSUMS:
-  ComponentKit: 9dbaf4759c1125cf618c848ded3a37f4472fd0da
+  ComponentKit: 78d73c354af113de9cdd4605b825c9ca315da773
   ComponentKitTestLib: 2a3d2e482e316301a0a6c9c298d29fb820f66390
   FBSnapshotTestCase: 9d5fe43b29ae3a0ed8fc829477971b281038f748
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2


### PR DESCRIPTION
CocoaPods doesn't scope these flags to the pod