### PR TITLE
Remove reason from CKComponentDeciding

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentConstantDecider.m
+++ b/ComponentKit/DataSources/Common/CKComponentConstantDecider.m
@@ -28,8 +28,4 @@
   return _enabled ? model : nil;
 }
 
-- (NSString *)componentComplianceReason:(id)model
-{
-  return _enabled ? nil : @"Decider disabled by default";
-}
 @end

--- a/ComponentKit/DataSources/Common/CKComponentDeciding.h
+++ b/ComponentKit/DataSources/Common/CKComponentDeciding.h
@@ -18,10 +18,4 @@
  */
 - (id)componentCompliantModel:(id)model;
 
-/*
- * In case the model is not component compliant, returns a string explaining why
- * Otherwise returns nil. Used for logging and debugging.
- */
-- (NSString *)componentComplianceReason:(id)model;
-
 @end


### PR DESCRIPTION
Unused and just brings more overhead to the implementation of CKComponentDeciding.