### PR TITLE
ComponentKitTestLib.podspec requires some updates to be usable (Cocoapods)

### DIFF
--- a/ComponentKitTestLib/ComponentKitTestLib.podspec
+++ b/ComponentKitTestLib/ComponentKitTestLib.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = "ComponentKitTestLib"
-  s.version          = "0.1.0"
+  s.version          = "0.10"
   s.summary          = "A React-inspired view framework for iOS"
   s.homepage         = "https://componentkit.com"
   s.license          = 'BSD'
   s.source           = { :git => "https://github.com/facebook/ComponentKit.git", :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = '**/*.h', '**/*.m', '**/*.mm'
+  s.source_files = 'ComponentKitTestLib/*.h', 'ComponentKitTestLib/*.m', 'ComponentKitTestLib/*.mm'
   s.dependency 'FBSnapshotTestCase'
   s.frameworks = 'UIKit', 'XCTest'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - ComponentKit (0.10)
-  - ComponentKitTestLib (0.1.0):
+  - ComponentKitTestLib (0.10):
     - FBSnapshotTestCase
   - FBSnapshotTestCase (1.6)
   - OCMock (2.2.4)
@@ -12,13 +12,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   ComponentKit:
-    :path: .
+    :path: "."
   ComponentKitTestLib:
-    :path: ./ComponentKitTestLib
+    :path: "./ComponentKitTestLib"
 
 SPEC CHECKSUMS:
   ComponentKit: b4af3b571640eee92d42c8f78bea6d3b9fae7f77
-  ComponentKitTestLib: 2a3d2e482e316301a0a6c9c298d29fb820f66390
+  ComponentKitTestLib: 95d8aee7b372fed23e34f30d4624bfee1b2ea4a6
   FBSnapshotTestCase: 9d5fe43b29ae3a0ed8fc829477971b281038f748
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
 


### PR DESCRIPTION
Hi all,

Noticed that `ComponentKitTestLib` is available, but not currently in a usable state for Cocoapods. I assume this is coming (as a subspec?) eventually, but in the meantime a few minor updates make this usable until it's publicly available. 

For the benefit of other users, the library can be installed via Cocoapods with:

```
pod 'ComponentKitTestLib', :podspec => 'https://raw.githubusercontent.com/eyeem/componentkit/ComponentKitTestLib.podspec/ComponentKitTestLib/ComponentKitTestLib.podspec'
```

...which links to the main repo, but makes use of the corrected podspec in this fork.

Thanks!