### PR TITLE
Refactor how component tree events are announced.

### DIFF
--- a/ComponentKit/Core/CKComponentLifecycleManager.h
+++ b/ComponentKit/Core/CKComponentLifecycleManager.h
@@ -98,14 +98,6 @@ extern const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEm
  */
 - (id)model;
 
-/**
- Events forwarded to children: note that ALL controllers implementing this selector will be notified
- */
-// This events will be called when the component appears on screen, corresponds to willDisplayCell
-- (void)componentTreeWillAppear;
-// This events will be called when the component disappears, corresponds to willEndDisplayingCell
-- (void)componentTreeDidDisappear;
-
 @end
 
 

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -198,16 +198,6 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
   return _state.model;
 }
 
-- (void)componentTreeWillAppear
-{
-  [_state.scopeFrame announceEventToControllers:@selector(componentTreeWillAppear)];
-}
-
-- (void)componentTreeDidDisappear
-{
-  [_state.scopeFrame announceEventToControllers:@selector(componentTreeDidDisappear)];
-}
-
 #pragma mark - CKComponentStateListener
 
 - (void)componentStateDidEnqueueStateModificationWithTryAsynchronousUpdate:(BOOL)tryAsynchronousUpdate

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.h
@@ -17,6 +17,11 @@
 @class CKComponentController;
 @protocol CKComponentStateListener;
 
+typedef NS_ENUM(NSUInteger, CKComponentAnnouncedEvent) {
+  CKComponentAnnouncedEventTreeWillAppear,
+  CKComponentAnnouncedEventTreeDidDisappear,
+};
+
 @interface CKComponentScopeFrame : NSObject
 
 /**
@@ -59,12 +64,7 @@
 
 - (void)updateState:(id (^)(id))updateFunction tryAsynchronousUpdate:(BOOL)tryAsynchronousUpdate;
 
-/**
- For internal use only; forwards a selector to all component controllers that override it.
- - Only works with a whitelisted set of selectors;
- - Only invokes the selector on a controller if it is *overridden* from the base CKComponentController implementation,
-   for efficiency.
- */
-- (void)announceEventToControllers:(SEL)selector;
+/** For internal use only; sends the given event to all component controllers that implement it. */
+- (void)announceEventToControllers:(CKComponentAnnouncedEvent)event;
 
 @end

--- a/ComponentKitTests/CKComponentLifecycleManagerTests.mm
+++ b/ComponentKitTests/CKComponentLifecycleManagerTests.mm
@@ -189,15 +189,6 @@ static const CKSizeRange size = {{40, 40}, {40, 40}};
                         @"Expect the manager to leave view untouched after detach");
 }
 
-- (void)testNotifyingControllerThroughLifecycleManager
-{
-  notified = NO;
-  CKComponentLifecycleManager *lifeManager = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
-  [lifeManager updateWithState:[lifeManager prepareForUpdateWithModel:[UIColor redColor] constrainedSize:size context:nil]];
-  [lifeManager componentTreeWillAppear];
-  XCTAssertTrue(notified, @"Expect the controller to be notified of the event");
-}
-
 - (void)testCallingUpdateWithStateTriggersSizeDidChangeCallback
 {
   CKComponentLifecycleManager *lifeManager = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];


### PR DESCRIPTION
This removes cruft from the `CKComponentLifecycleManager` in the name of minimizing its responsibilities.