### PR TITLE
Fix subtle issue with component scope frame messaging

### DIFF
--- a/ComponentKit/Core/CKComponentLifecycleManager.h
+++ b/ComponentKit/Core/CKComponentLifecycleManager.h
@@ -32,9 +32,7 @@ extern const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEm
 
 @interface CKComponentLifecycleManager : NSObject
 
-/**
- Designated initializer
- */
+/** Designated initializer */
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider;
 
 /** See @protocol CKComponentLifecycleManagerAsynchronousUpdateHandler */
@@ -83,20 +81,17 @@ extern const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEm
  */
 - (void)detachFromView;
 
-/**
- Returns whether the lifecycle manager is attached to a view.
- */
+/** Returns whether the lifecycle manager is attached to a view. */
 - (BOOL)isAttachedToView;
 
-/**
- Returns the current top-level layout size for the component.
- */
+/** The current top-level layout size for the component */
 - (CGSize)size;
 
-/**
- Returns the last model associated with this lifecycle manager
- */
+/** The last model associated with this lifecycle manager */
 - (id)model;
+
+/** The current scope frame associated with this lifecycle manager */
+- (CKComponentScopeFrame *)scopeFrame;
 
 @end
 

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -198,6 +198,11 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
   return _state.model;
 }
 
+- (CKComponentScopeFrame *)scopeFrame
+{
+  return _state.scopeFrame;
+}
+
 #pragma mark - CKComponentStateListener
 
 - (void)componentStateDidEnqueueStateModificationWithTryAsynchronousUpdate:(BOOL)tryAsynchronousUpdate

--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -116,12 +116,12 @@ CK_FINAL_CLASS([CKCollectionViewDataSource class]);
 
 - (void)announceWillAppearForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  [[[_componentDataSource objectAtIndexPath:indexPath] lifecycleManagerState].scopeFrame announceEventToControllers:CKComponentAnnouncedEventTreeWillAppear];
+  [[[_componentDataSource objectAtIndexPath:indexPath] lifecycleManager].scopeFrame announceEventToControllers:CKComponentAnnouncedEventTreeWillAppear];
 }
 
 - (void)announceDidDisappearForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  [[[_componentDataSource objectAtIndexPath:indexPath] lifecycleManagerState].scopeFrame announceEventToControllers:CKComponentAnnouncedEventTreeDidDisappear];
+  [[[_componentDataSource objectAtIndexPath:indexPath] lifecycleManager].scopeFrame announceEventToControllers:CKComponentAnnouncedEventTreeDidDisappear];
 }
 
 #pragma mark - UICollectionViewDataSource


### PR DESCRIPTION
We actually should always be messaging the *current* scope frame's controllers, not the scope frame from the time the output item was created.

This is confusing, and will be cleaned up during my continuing CLM refactors.