### PR TITLE
Enable accessibility in CKLabelComponent by default

### DIFF
--- a/ComponentTextKit/CKLabelComponent.mm
+++ b/ComponentTextKit/CKLabelComponent.mm
@@ -22,7 +22,7 @@
           [CKTextComponent
            newWithTextAttributes:textKitAttributes(attributes)
            viewAttributes:std::move(copiedMap)
-           accessibilityContext:{}]];
+           accessibilityContext:{.isAccessibilityElement = @(YES)}]];
 }
 
 static const CKTextKitAttributes textKitAttributes(const CKLabelAttributes &labelAttributes)

--- a/ComponentTextKit/CKTextComponent.mm
+++ b/ComponentTextKit/CKTextComponent.mm
@@ -109,6 +109,8 @@ static CKTextKitRenderer *rendererForAttributes(CKTextKitAttributes &attributes,
   CKTextComponentView *view = (CKTextComponentView *)result.contextForChildren.viewManager->view;
   CKTextKitRenderer *renderer = rendererForAttributes(_attributes, size);
   view.renderer = renderer;
+  view.isAccessibilityElement = _accessibilityContext.isAccessibilityElement.boolValue;
+  view.accessibilityLabel = _accessibilityContext.accessibilityLabel.hasText() ? _accessibilityContext.accessibilityLabel.value() : _attributes.attributedString.string;
   return result;
 }
 

--- a/ComponentTextKit/CKTextComponentView.mm
+++ b/ComponentTextKit/CKTextComponentView.mm
@@ -134,11 +134,4 @@
   return [super gestureRecognizerShouldBegin:recognizer];
 }
 
-#pragma mark - Accessibility
-
-- (NSString *)accessibilityLabel
-{
-  return self.renderer.attributes.attributedString.string;
-}
-
 @end


### PR DESCRIPTION
Enables accessibility by default in CKLabelComponent, and provides an example on how to do more advanced accessibility setups for CKTextComponent.

Should fix https://github.com/facebook/componentkit/issues/127