### PR TITLE
Use new context for reload after updateContextAndEnqueueReload:

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -223,14 +223,12 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
   if (!_processingChangeset && [_changesetQueue count]) {
     ck_changeset_applicator_t headChangeset = _changesetQueue[0];
     [_changesetQueue removeObjectAtIndex:0];
-    [_collectionView performBatchUpdates:^{
-      _processingChangeset = YES;
-      const auto &changeset = headChangeset();
-      applyChangesetToCollectionView(changeset, _collectionView);
-    } completion:^(BOOL){
-      _processingChangeset = NO;
-      [self applyNextChangeset];
-    }];
+    
+    _processingChangeset = YES;
+    const auto &changeset = headChangeset();
+    applyChangesetToCollectionView(changeset, _collectionView);
+    _processingChangeset = NO;
+    [self applyNextChangeset];
   }
 }
 
@@ -277,14 +275,20 @@ static void applyChangesetToCollectionView(const Output::Changeset &changeset, U
   };
   
   changeset.enumerate(sectionsEnumerator, itemEnumerator);
-  if (itemRemovalIndexPaths.count > 0) {
-    [collectionView deleteItemsAtIndexPaths:itemRemovalIndexPaths];
-  }
-  if (itemUpdateIndexPaths.count > 0) {
-    [collectionView reloadItemsAtIndexPaths:itemUpdateIndexPaths];
-  }
-  if (itemInsertionIndexPaths.count > 0) {
-    [collectionView insertItemsAtIndexPaths:itemInsertionIndexPaths];
+  if (itemUpdateIndexPaths.count > 30) {
+    [collectionView reloadData];
+  }else{
+    [collectionView performBatchUpdates:^{
+      if (itemRemovalIndexPaths.count > 0) {
+        [collectionView deleteItemsAtIndexPaths:itemRemovalIndexPaths];
+      }
+      if (itemUpdateIndexPaths.count > 0) {
+        [collectionView reloadItemsAtIndexPaths:itemUpdateIndexPaths];
+      }
+      if (itemInsertionIndexPaths.count > 0) {
+        [collectionView insertItemsAtIndexPaths:itemInsertionIndexPaths];
+      }
+    } completion:nil];
   }
 }
 

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -171,7 +171,19 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   CKAssertMainThread();
   if (_context != newContext) {
     _context = newContext;
-    [self enqueueReload];
+		
+		__block CKArrayControllerInputItems items;
+		[_inputArrayController enumerateObjectsUsingBlock:^(CKComponentDataSourceInputItem *object, NSIndexPath *indexPath, BOOL *stop) {
+			CKComponentDataSourceInputItem *newItem =
+			[[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:object.lifecycleManager
+																																 model:object.model
+																															 context:_context
+																											 constrainedSize:object.constrainedSize
+																																	UUID:object.UUID];
+			items.update(indexPath,newItem);
+		}];
+		CKArrayControllerInputChangeset changeset(items);
+		[self _enqueueChangeset:changeset];
   }
 }
 

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -172,18 +172,17 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   if (_context != newContext) {
     _context = newContext;
 		
-		__block CKArrayControllerInputItems items;
-		[_inputArrayController enumerateObjectsUsingBlock:^(CKComponentDataSourceInputItem *object, NSIndexPath *indexPath, BOOL *stop) {
-			CKComponentDataSourceInputItem *newItem =
-			[[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:object.lifecycleManager
-																																 model:object.model
-																															 context:_context
-																											 constrainedSize:object.constrainedSize
-																																	UUID:object.UUID];
-			items.update(indexPath,newItem);
-		}];
-		CKArrayControllerInputChangeset changeset(items);
-		[self _enqueueChangeset:changeset];
+    __block CKArrayControllerInputItems items;
+    [_inputArrayController enumerateObjectsUsingBlock:^(CKComponentDataSourceInputItem *object, NSIndexPath *indexPath, BOOL *stop) {
+      CKComponentDataSourceInputItem *newItem =
+      [[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:object.lifecycleManager																																 model:object.model
+							       context:_context
+						       constrainedSize:object.constrainedSize
+								  UUID:object.UUID];
+      items.update(indexPath,newItem);
+    }];
+    CKArrayControllerInputChangeset changeset(items);
+    [self _enqueueChangeset:changeset];
   }
 }
 


### PR DESCRIPTION
Updates the context of all the items before the reload, currently the old context is used for the reload.