### PR TITLE
Request to bump version and tag repo

### DIFF
--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ComponentKit"
-  s.version = "0.10"
+  s.version = "0.11"
   s.summary = "A React-inspired view framework for iOS"
   s.homepage = "https://componentkit.com"
   s.authors = 'adamjernst@fb.com'

--- a/Examples/WildeGuess/Podfile.lock
+++ b/Examples/WildeGuess/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ComponentKit (0.10)
+  - ComponentKit (0.11)
 
 DEPENDENCIES:
   - ComponentKit (from `../..`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  ComponentKit: b4af3b571640eee92d42c8f78bea6d3b9fae7f77
+  ComponentKit: 51f51002f13cfc6bb6c5538fc327263485e00d45
 
-COCOAPODS: 0.36.0
+COCOAPODS: 0.36.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ComponentKit (0.10)
+  - ComponentKit (0.11)
   - ComponentKitTestLib (0.1.0):
     - FBSnapshotTestCase
   - FBSnapshotTestCase (1.6)
@@ -17,9 +17,9 @@ EXTERNAL SOURCES:
     :path: ./ComponentKitTestLib
 
 SPEC CHECKSUMS:
-  ComponentKit: b4af3b571640eee92d42c8f78bea6d3b9fae7f77
+  ComponentKit: 51f51002f13cfc6bb6c5538fc327263485e00d45
   ComponentKitTestLib: 2a3d2e482e316301a0a6c9c298d29fb820f66390
   FBSnapshotTestCase: 9d5fe43b29ae3a0ed8fc829477971b281038f748
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
 
-COCOAPODS: 0.36.3
+COCOAPODS: 0.36.4


### PR DESCRIPTION
A [recent change](https://github.com/facebook/componentkit/commit/d3e5a427b65b792df085899065667c4c37cfbddb) introduced an umbrella header, `ComponetKit.h`, making wrangling `#import`s much simpler (see the [change in the sample project](https://github.com/facebook/componentkit/commit/d1fd3d8bae281c573c3af5dfdcf15dcfd38b5a3e)). This came after `v0.10`, but it’d be nice to be able to use it.

I’m not sure if this change plus whatever else is on `master` warrants a version `0.11`, but it would be nice.

Thanks! Feel free to disregard if this is jumping the gun. I was just confused by the missing header when trying to integrate ComponentKit into a project of mine while using the example project as a guide.