### PR TITLE
Fix a bug that hash() doesn’t generate unique value

### DIFF
--- a/ComponentKit/Core/CKDimension.mm
+++ b/ComponentKit/Core/CKDimension.mm
@@ -131,12 +131,11 @@ NSString *CKSizeRange::description() const
 }
 size_t CKSizeRange::hash() const
 {
-  std::hash<CGFloat> hasher;
   NSUInteger subhashes[] = {
-    hasher(min.width),
-    hasher(min.height),
-    hasher(max.width),
-    hasher(max.height)
+      NSUInteger(min.width),
+      NSUInteger(min.height),
+      NSUInteger(max.width),
+      NSUInteger(max.height)
   };
   return CKIntegerArrayHash(subhashes, CK_ARRAY_COUNT(subhashes));
 }

--- a/ComponentKit/Utilities/CKInternalHelpers.mm
+++ b/ComponentKit/Utilities/CKInternalHelpers.mm
@@ -35,7 +35,7 @@ NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count)
 {
   NSUInteger result = subhashes[0];
   for (int ii = 1; ii < count; ++ii) {
-    result = std::hash<unsigned long long>()((((unsigned long long)result) << 32 | subhashes[ii]));
+    result = std::hash<unsigned long long>()((((unsigned long long)result) << sizeof(NSUInteger) | subhashes[ii]));
   }
   return result;
 }


### PR DESCRIPTION
Hi there,
I just found a potential but probably minor issue. I'm assuming hash() function for CKSizeRange should always be able to generate a unique value as a fingerprint on iPhone simulator.

A.    NSLog(@"%ld", CKSizeRange(CGSizeMake(50, 90), CGSizeMake(60, 100)).hash());
B.    NSLog(@"%ld", CKSizeRange(CGSizeMake(50, 60), CGSizeMake(90, 100)).hash());
C.    NSLog(@"%ld", CKSizeRange(CGSizeMake(50, 91), CGSizeMake(60, 100)).hash());

For example, case A, B and C will generate a output below in console:
2015-04-23 16:14:37.286 WildeGuess[16181:1546643] 4636737291354636288
2015-04-23 16:14:37.287 WildeGuess[16181:1546643] 4636737291354636288
2015-04-23 16:14:37.287 WildeGuess[16181:1546643] 4636737291354636288

Contrary, output for iPhone 5 device will look like the below:
2015-04-23 16:16:29.911 WildeGuess[896:208289] 1008150498
2015-04-23 16:16:29.912 WildeGuess[896:208289] -1940518087
2015-04-23 16:16:29.913 WildeGuess[896:208289] -31152360

Therefore, I made a minor change to have unique hash value output on both iPhone simulator and device.

The following is a summary of my change. 
- Each element has to be NSUInteger type in CKIntegerArrayHash()
- Bitwise left shift according to the size of NSUInteger type

Cheers,

Allen