### PR TITLE
[CDS] Fix appearance tracking

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.h
@@ -91,16 +91,16 @@ typedef void(*CKCellConfigurationFunction)(UICollectionViewCell *cell, NSIndexPa
 - (CGSize)sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
- Sends -componentTreeWillAppear to all CKComponentControllers for the given indexPath.
- Call this from -collectionView:willDisplayCell:forItemAtIndexPath:
+ Sends -componentTreeWillAppear to all CKComponentControllers for the given cell.
+ If needed, call this from -collectionView:willDisplayCell:forItemAtIndexPath:
  */
-- (void)announceWillAppearForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (void)announceWillAppearForItemInCell:(UICollectionViewCell *)cell;
 
 /**
- Sends -componentTreeDidDisappear to all CKComponentControllers for the given indexPath.
- Call this from -collectionView:didEndDisplayingCell:forItemAtIndexPath:
+ Sends -componentTreeDidDisappear to all CKComponentControllers for the given cell.
+ If needed, call this from -collectionView:didEndDisplayingCell:forItemAtIndexPath:
  */
-- (void)announceDidDisappearForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (void)announceDidDisappearForItemInCell:(UICollectionViewCell *)cell;
 
 @property (readonly, nonatomic, strong) UICollectionView *collectionView;
 /**

--- a/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
+++ b/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
@@ -97,14 +97,14 @@
        willDisplayCell:(UICollectionViewCell *)cell
     forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  [_dataSource announceWillAppearForItemAtIndexPath:indexPath];
+  [_dataSource announceWillAppearForItemInCell:cell];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
   didEndDisplayingCell:(UICollectionViewCell *)cell
     forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-  [_dataSource announceDidDisappearForItemAtIndexPath:indexPath];
+  [_dataSource announceDidDisappearForItemInCell:cell];
 }
 
 #pragma mark - CKComponentProvider


### PR DESCRIPTION
Fix #129, indexPath is not a reliable thing to use for disappearance announcements on deletion (either the index would be out of bounds if the last item is deleted or it will point to an invalid item).

Calling `- (void)announceWillAppearForItemInCell:(UICollectionViewCell *)cell atIndexPath:(NSIndexPath *)indexPath` and `- (void)announceDidDisappearForItemInCell:(UICollectionViewCell *)cell atIndexPath:(NSIndexPath *)indexPath` guarantees the announcement will be dispatched to the component tree associated to the cell. 

It is however non opinionated in the sense that it won't do deduplication of events, or check for imbalanced calls. 
For instance while reloading a cell on screen, the collection view first send appearance events for the newly created cell and then send disappearance events for the old cell, this situation should be handled properly in the controller layer. #153 has been opened to track these use cases and provide examples/code to deal with them.
