### PR TITLE
[CDS] Remove unecessary restrictions on the changesets

### DIFF
--- a/ComponentKit/Utilities/CKArrayControllerChangeset.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.mm
@@ -129,7 +129,7 @@ void Input::Items::bucketizeObjectBySection(ItemsBucketizedBySection &sectionMap
 
 void Input::Items::update(const IndexPath &indexPath, id<NSObject> object)
 {
-  CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_updates, _removals, _insertions}),
+  CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_updates, _removals}),
                                ([NSString stringWithFormat:@"{item:%zd, section:%zd} already exists in commands",
                                 indexPath.item, indexPath.section]));
 
@@ -148,7 +148,7 @@ void Input::Items::remove(const IndexPath &indexPath)
 
 void Input::Items::insert(const IndexPath &indexPath, id<NSObject> object)
 {
-  CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_insertions, _updates}),
+  CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_insertions}),
                                ([NSString stringWithFormat:@"{item:%zd, section:%zd} already exists in commands",
                                 indexPath.item, indexPath.section]));
 

--- a/ComponentKitTests/CKArrayControllerChangesetTests.mm
+++ b/ComponentKitTests/CKArrayControllerChangesetTests.mm
@@ -119,18 +119,18 @@ typedef NS_ENUM(NSUInteger, CommandType) {
   }
 }
 
-- (void)testThrowsOnUpdateAndInsertWithSameIndexPath
+- (void)testDoesNotThrowOnUpdateAndInsertWithSameIndexPath
 {
   {
     Input::Items items;
     items.update({0, 0}, @1);
-    XCTAssertThrowsSpecificNamed(items.insert({0, 0}, @0), NSException, NSInternalInconsistencyException, @"");
+    XCTAssertNoThrow(items.insert({0, 0}, @0),  @"Insertions can share the same indexes with removals or updates.");
   }
 
   {
     Input::Items items;
     items.insert({0, 0}, @0);
-    XCTAssertThrowsSpecificNamed(items.update({0, 0}, @1), NSException, NSInternalInconsistencyException, @"");
+    XCTAssertNoThrow(items.update({0, 0}, @1), @"Insertions can share the same indexes with removals or updates.");
   }
 }
 

--- a/Examples/WildeGuess/Podfile.lock
+++ b/Examples/WildeGuess/Podfile.lock
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  ComponentKit: 51f51002f13cfc6bb6c5538fc327263485e00d45
+  ComponentKit: 66ee65df1df9983b689cb7df15d9fe59a1a03903
 
 COCOAPODS: 0.36.4


### PR DESCRIPTION
Updates and insertions are not applied towards the same index space. They could very well affect the same indexPath in their respective index spaces and the changeset would still be valid.