### PR TITLE
Use new context in updateContextAndEnqueueReload

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -177,9 +177,9 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
       CKComponentDataSourceInputItem *newItem =
       [[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:object.lifecycleManager																																 
                                                                  model:object.model
-							                                                 context:_context
-						                                           constrainedSize:object.constrainedSize
-								                                                  UUID:object.UUID];
+							       context:_context
+						       constrainedSize:object.constrainedSize
+								  UUID:object.UUID];
       items.update(indexPath, newItem);
     }];
     CKArrayControllerInputChangeset changeset(items);

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -171,7 +171,19 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   CKAssertMainThread();
   if (_context != newContext) {
     _context = newContext;
-    [self enqueueReload];
+    
+    __block CKArrayControllerInputItems items;
+    [_inputArrayController enumerateObjectsUsingBlock:^(CKComponentDataSourceInputItem *object, NSIndexPath *indexPath, BOOL *stop) {
+      CKComponentDataSourceInputItem *newItem =
+      [[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:object.lifecycleManager																																 
+                                                                 model:object.model
+							                                                 context:_context
+						                                           constrainedSize:object.constrainedSize
+								                                                  UUID:object.UUID];
+      items.update(indexPath, newItem);
+    }];
+    CKArrayControllerInputChangeset changeset(items);
+    [self _enqueueChangeset:changeset];
   }
 }
 


### PR DESCRIPTION
Updates the context of all the items before the reload, currently the old context is used for the reload.