### PR TITLE
Fixed context update for updating items in the data source.

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -229,6 +229,8 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
       batchContainsSectionInserts = YES;
     }
   };
+  
+  id currentContext = _context;
 
   NSMutableSet *insertedIndexPaths = [[NSMutableSet alloc] init];
   CKArrayControllerOutputItems::Enumerator itemsEnumerator =
@@ -257,7 +259,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
                                                             indexPath:change.indexPath.toNSIndexPath()
                                                            changeType:type
                                                           passthrough:(componentCompliantModel == nil)
-                                                              context:[after context]];
+                                                              context:currentContext];
     preparationQueueBatch.items.push_back(queueItem);
   };
 


### PR DESCRIPTION
The -[CKDataSource updateContextAndEnqueueReload:] updates context for newly inserted items in the data source, but reloaded items still have old context. This diff fixed the issue.