### PR TITLE
[CDS] Add convenience getters to the arrayControllerChangeset

### DIFF
--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -75,8 +75,8 @@ namespace CK {
       void insert(NSInteger index);
       void remove(NSInteger index);
 
-      const std::set<NSInteger> &insertions(void) const;
-      const std::set<NSInteger> &removals(void) const;
+      NSIndexSet *insertions() const;
+      NSIndexSet *removals() const;
 
       bool operator==(const Sections &other) const;
 
@@ -121,11 +121,15 @@ namespace CK {
         void update(const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
         void remove(const CKArrayControllerIndexPath &indexPath);
         void insert(const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
+        
+        NSDictionary *updates() const;
+        NSSet *removals() const;
+        NSDictionary *insertions() const;
 
         size_t size() const noexcept;
 
         bool operator==(const Items &other) const;
-
+        
         /**
          Called by Changeset::enumerate(). Note that by passing an NSIndexSet the **order** that clients have called
          Items::insert() is irrelevant. See CKArrayControllerInputChangesetTests for an example. The indexes and objects
@@ -140,14 +144,16 @@ namespace CK {
                                   NSArray *objects,
                                   CKArrayControllerChangeType type,
                                   BOOL *stop);
-
+      
       private:
         friend class Changeset;
 
         typedef std::map<NSInteger, id<NSObject>> ItemIndexToObjectMap;
         typedef std::map<NSInteger, ItemIndexToObjectMap> ItemsBucketizedBySection;
+        typedef void(^ItemsBucketizedBySectionEnumerator)(NSIndexPath *indexPath, id<NSObject> object);
 
         void bucketizeObjectBySection(ItemsBucketizedBySection &m, const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
+        void enumerateItemsBucketizedBySection(const ItemsBucketizedBySection &m, ItemsBucketizedBySectionEnumerator enumerator) const;
         bool commandExistsForIndexPath(const CKArrayControllerIndexPath &indexPath,
                                        const std::vector<ItemsBucketizedBySection> &bucketsToCheck) const;
 

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.mm
@@ -36,14 +36,23 @@ void Sections::remove(NSInteger index)
   _removals.insert(index);
 }
 
-const std::set<NSInteger> &Sections::insertions() const
+NS_INLINE NSIndexSet *setOfIndicesToNSIndexSet(std::set<NSInteger> setOfIndices)
 {
-  return _insertions;
+  NSMutableIndexSet *output = [NSMutableIndexSet indexSet];
+  for (auto index : setOfIndices) {
+    [output addIndex:index];
+  }
+  return output;
 }
 
-const std::set<NSInteger> &Sections::removals() const
+NSIndexSet *Sections::insertions() const
 {
-  return _removals;
+  return setOfIndicesToNSIndexSet(_insertions);
+}
+
+NSIndexSet *Sections::removals() const
+{
+  return setOfIndicesToNSIndexSet(_removals);
 }
 
 bool Sections::operator==(const Sections &other) const
@@ -127,6 +136,19 @@ void Input::Items::bucketizeObjectBySection(ItemsBucketizedBySection &sectionMap
   }
 }
 
+void Input::Items::enumerateItemsBucketizedBySection(const ItemsBucketizedBySection &bucketizedItems, ItemsBucketizedBySectionEnumerator enumerator) const
+{
+  if (!enumerator) {
+    return;
+  }
+  
+  for (auto sectionToBucket : bucketizedItems) {
+    for (auto itemObjectPair : sectionToBucket.second) {
+      enumerator([NSIndexPath indexPathForItem:itemObjectPair.first inSection:sectionToBucket.first], itemObjectPair.second);
+    }
+  }
+}
+
 void Input::Items::update(const IndexPath &indexPath, id<NSObject> object)
 {
   CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_updates, _removals}),
@@ -134,6 +156,15 @@ void Input::Items::update(const IndexPath &indexPath, id<NSObject> object)
                                 indexPath.item, indexPath.section]));
 
   bucketizeObjectBySection(_updates, indexPath, object);
+}
+
+NSDictionary *Input::Items::updates() const
+{
+  NSMutableDictionary *updates = [NSMutableDictionary dictionary];
+  enumerateItemsBucketizedBySection(_updates, ^(NSIndexPath *indexPath, id<NSObject> object) {
+    updates[indexPath] = object ?: [NSNull null];
+  });
+  return updates;
 }
 
 void Input::Items::remove(const IndexPath &indexPath)
@@ -146,6 +177,15 @@ void Input::Items::remove(const IndexPath &indexPath)
   bucketizeObjectBySection(_removals, indexPath, nil);
 }
 
+NSSet *Input::Items::removals() const
+{
+  NSMutableSet *removals = [NSMutableSet set];
+  enumerateItemsBucketizedBySection(_removals, ^(NSIndexPath *indexPath, id<NSObject> object) {
+    [removals addObject:indexPath];
+  });
+  return removals;
+}
+
 void Input::Items::insert(const IndexPath &indexPath, id<NSObject> object)
 {
   CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_insertions}),
@@ -153,6 +193,15 @@ void Input::Items::insert(const IndexPath &indexPath, id<NSObject> object)
                                 indexPath.item, indexPath.section]));
 
   bucketizeObjectBySection(_insertions, indexPath, object);
+}
+
+NSDictionary *Input::Items::insertions() const
+{
+  NSMutableDictionary *insertions = [NSMutableDictionary dictionary];
+  enumerateItemsBucketizedBySection(_insertions, ^(NSIndexPath *indexPath, id<NSObject> object) {
+    insertions[indexPath] = object ?: [NSNull null];
+  });
+  return insertions;
 }
 
 size_t Input::Items::size() const noexcept
@@ -179,15 +228,11 @@ void Input::Changeset::enumerate(Sections::Enumerator sectionEnumerator,
 {
   __block BOOL stop = NO;
 
-  void (^emitSectionChanges)(const std::set<NSInteger>&, CKArrayControllerChangeType) =
-  (!sectionEnumerator) ? (void(^)(const std::set<NSInteger>&, CKArrayControllerChangeType))nil :
-  ^(const std::set<NSInteger> &s, CKArrayControllerChangeType t) {
-    if (!s.empty()) {
-      NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
-      for (auto section : s) {
-        [indexes addIndex:section];
-      }
-      sectionEnumerator(indexes, t, &stop);
+  void (^emitSectionChanges)(NSIndexSet *, CKArrayControllerChangeType) =
+  (!sectionEnumerator) ? (void(^)(NSIndexSet *, CKArrayControllerChangeType))nil :
+  ^(NSIndexSet *s, CKArrayControllerChangeType t) {
+    if (s.count > 0) {
+      sectionEnumerator(s, t, &stop);
     }
   };
 
@@ -329,15 +374,11 @@ void Output::Changeset::enumerate(Sections::Enumerator sectionEnumerator,
 {
   __block BOOL stop = NO;
 
-  void (^emitSectionChanges)(const std::set<NSInteger>&, CKArrayControllerChangeType) =
-  (!sectionEnumerator) ? (void(^)(const std::set<NSInteger>&, CKArrayControllerChangeType))nil :
-  ^(const std::set<NSInteger> &s, CKArrayControllerChangeType t){
-    if (!s.empty()) {
-      NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
-      for (auto section : s) {
-        [indexes addIndex:section];
-      }
-      sectionEnumerator(indexes, t, &stop);
+  void (^emitSectionChanges)(NSIndexSet *, CKArrayControllerChangeType) =
+  (!sectionEnumerator) ? (void(^)(NSIndexSet *, CKArrayControllerChangeType))nil :
+  ^(NSIndexSet *s, CKArrayControllerChangeType t) {
+    if (s.count > 0) {
+      sectionEnumerator(s, t, &stop);
     }
   };
 

--- a/ComponentKitTests/CKArrayControllerChangesetTests.mm
+++ b/ComponentKitTests/CKArrayControllerChangesetTests.mm
@@ -149,6 +149,54 @@ typedef NS_ENUM(NSUInteger, CommandType) {
   }
 }
 
+- (void)testInsertions
+{
+  Input::Items items;
+  items.insert({0, 0}, @1);
+  items.insert({1, 1}, @2);
+  
+  NSDictionary *expectedInsertions = @{[NSIndexPath indexPathForItem:0 inSection:0]: @1,
+                                       [NSIndexPath indexPathForItem:1 inSection:1]: @2};
+  NSDictionary *expectedUpdates = @{};
+  NSSet *expectedRemovals = [NSSet set];
+  
+  XCTAssertEqualObjects(expectedInsertions, items.insertions());
+  XCTAssertEqualObjects(expectedRemovals, items.removals());
+  XCTAssertEqualObjects(expectedUpdates, items.updates());
+}
+
+- (void)testUpdates
+{
+  Input::Items items;
+  items.update({0, 0}, @1);
+  items.update({1, 1}, @2);
+  
+  NSDictionary *expectedInsertions = @{};
+  NSDictionary *expectedUpdates = @{[NSIndexPath indexPathForItem:0 inSection:0]: @1,
+                                    [NSIndexPath indexPathForItem:1 inSection:1]: @2};;
+  NSSet *expectedRemovals = [NSSet set];
+  
+  XCTAssertEqualObjects(expectedInsertions, items.insertions());
+  XCTAssertEqualObjects(expectedRemovals, items.removals());
+  XCTAssertEqualObjects(expectedUpdates, items.updates());
+}
+
+- (void)testRemovals
+{
+  Input::Items items;
+  items.remove({0, 0});
+  items.remove({1, 1});
+  
+  NSDictionary *expectedInsertions = @{};
+  NSDictionary *expectedUpdates = @{};
+  NSSet *expectedRemovals = [NSSet setWithArray:@[[NSIndexPath indexPathForItem:0 inSection:0], [NSIndexPath indexPathForItem:1 inSection:1]]];
+  
+  XCTAssertEqualObjects(expectedInsertions, items.insertions());
+  XCTAssertEqualObjects(expectedRemovals, items.removals());
+  XCTAssertEqualObjects(expectedUpdates, items.updates());
+}
+
+
 @end
 
 @interface CKArrayControllerInputSectionsTests : XCTestCase
@@ -186,6 +234,26 @@ typedef NS_ENUM(NSUInteger, CommandType) {
     sections.remove(0);
     XCTAssertNoThrow(sections.insert(0), @"Removals and insertions can share the same indexes.");
   }
+}
+
+- (void)testInsertion
+{
+  Sections sections;
+  sections.insert(0);
+  sections.insert(1);
+  
+  XCTAssertEqualObjects([NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)], sections.insertions());
+  XCTAssertEqualObjects([NSIndexSet indexSet], sections.removals());
+}
+
+- (void)testRemoval
+{
+  Sections sections;
+  sections.remove(0);
+  sections.remove(1);
+  
+  XCTAssertEqualObjects([NSIndexSet indexSet], sections.insertions());
+  XCTAssertEqualObjects([NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)], sections.removals());
 }
 
 @end


### PR DESCRIPTION
Exposes objc datastructures corresponding to each changeset operations, it will be used to convert changesets to the right format for the transactional datasource.

The other option was to leverage the existing enumeration API but this would have been wasteful. The enumeration vends NSIndexSet and NSArrays (so that we can directly do `insertObjects:AtIndexes:`) that are already the product of a conversion from a cpp datastructure that we would then have had to convert back to NSDictionaries. 