### PR TITLE
Remove context form the input item

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -171,19 +171,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   CKAssertMainThread();
   if (_context != newContext) {
     _context = newContext;
-    
-    __block CKArrayControllerInputItems items;
-    [_inputArrayController enumerateObjectsUsingBlock:^(CKComponentDataSourceInputItem *object, NSIndexPath *indexPath, BOOL *stop) {
-      CKComponentDataSourceInputItem *newItem =
-      [[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:object.lifecycleManager																																 
-                                                                 model:object.model
-							       context:_context
-						       constrainedSize:object.constrainedSize
-								  UUID:object.UUID];
-      items.update(indexPath, newItem);
-    }];
-    CKArrayControllerInputChangeset changeset(items);
-    [self _enqueueChangeset:changeset];
+    [self enqueueReload];
   }
 }
 
@@ -213,7 +201,6 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
     }
     return [[CKComponentDataSourceInputItem alloc] initWithLifecycleManager:lifecycleManager
                                                                       model:object
-                                                                    context:_context
                                                             constrainedSize:constrainedSize
                                                                        UUID:UUID ];
   };
@@ -269,7 +256,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
                                                             indexPath:change.indexPath.toNSIndexPath()
                                                            changeType:type
                                                           passthrough:(componentCompliantModel == nil)
-                                                              context:[after context]];
+                                                              context:_context];
     preparationQueueBatch.items.push_back(queueItem);
   };
 

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceInputItem.h
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceInputItem.h
@@ -18,14 +18,12 @@
 
 - (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)lifecycleManager
                                    model:(id<NSObject>)model
-                                 context:(id<NSObject>)context
                          constrainedSize:(CKSizeRange)constrainedSize
                                     UUID:(NSString *)UUID;
 
 @property (readonly, nonatomic, strong) CKComponentLifecycleManager *lifecycleManager;
 
 @property (readonly, nonatomic, strong) id<NSObject> model;
-@property (readonly, nonatomic, strong) id<NSObject> context;
 
 - (CKSizeRange)constrainedSize;
 

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceInputItem.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceInputItem.mm
@@ -23,21 +23,18 @@
 
 - (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)lifecycleManager
                                    model:(id<NSObject>)model
-                                 context:(id<NSObject>)context
                          constrainedSize:(CKSizeRange)constrainedSize
                                     UUID:(NSString *)UUID
 {
   if (self = [super init]) {
     _lifecycleManager = lifecycleManager;
     _model = model;
-    _context = context;
     _constrainedSize = constrainedSize;
     _UUID = [UUID copy];
 
     NSUInteger subhashes[] = {
       [_lifecycleManager hash],
       [_model hash],
-      [_context hash],
       _constrainedSize.hash(),
       [_UUID hash],
     };
@@ -62,7 +59,6 @@
   CKComponentDataSourceInputItem *other = (CKComponentDataSourceInputItem *)object;
   return (CKObjectIsEqual(_lifecycleManager, other->_lifecycleManager) &&
           CKObjectIsEqual(_model, other->_model) &&
-          CKObjectIsEqual(_context, other->_context) &&
           _constrainedSize == other->_constrainedSize &&
           CKObjectIsEqual(_UUID, other->_UUID));
 }

--- a/ComponentKitTests/CKComponentDataSourceTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceTests.mm
@@ -10,6 +10,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentConstantDecider.h>
 #import <ComponentKit/CKComponentDataSource.h>
 #import <ComponentKit/CKComponentDataSourceOutputItem.h>
@@ -1079,6 +1080,102 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
   XCTAssertTrue([_dataSource isComputingChanges]);
   [self waitUntilChangeCountIs:2];
   XCTAssertFalse([_dataSource isComputingChanges]);
+}
+
+@end
+
+@interface CKComponentDataSourceReloadTest : XCTestCase <CKComponentProvider>
+@end
+
+@implementation CKComponentDataSourceReloadTest
+{
+  CKComponentDataSource *_dataSource;
+  CKComponentDataSourceTestDelegate *_delegate;
+}
+
+- (void)setUp
+{
+  [super setUp];
+  
+  CKComponentDataSourceTestDelegate *delegate = [[CKComponentDataSourceTestDelegate alloc] init];
+  
+  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:YES];
+  CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:[self class]
+                                                                                       context:@"context"
+                                                                                       decider:decider];
+  
+  dataSource.delegate = delegate;
+  
+  _dataSource = dataSource;
+  _delegate = delegate;
+}
+
+- (void)waitUntilChangeCountIs:(NSUInteger)changeCount
+{
+  XCTAssertTrue(CKRunRunLoopUntilBlockIsTrue(^BOOL(void){
+    if (_delegate.changeCount > changeCount) {
+      XCTFail(@"%lu", (unsigned long)_delegate.changeCount);
+    }
+    return (_delegate.changeCount == changeCount);
+  }), @"timeout");
+}
+
+- (void)testReloadCorrectlyEnqueuesUpdatesForTheContainedItems
+{
+  Sections sections;
+  sections.insert(0);
+  sections.insert(1);
+  
+  Input::Items items;
+  items.insert({0, 0}, @"Hello");
+  items.insert({0, 1}, @"World");
+  items.insert({1, 0}, @"Batman");
+  items.insert({1, 1}, @"Robin");
+  
+  [_dataSource enqueueChangeset:{sections, items} constrainedSize:{}];
+  [self waitUntilChangeCountIs:1];
+  [_delegate reset];
+  
+  NSMutableDictionary *capturedState = [NSMutableDictionary dictionary];
+  [_dataSource enumerateObjectsUsingBlock:^(CKComponentDataSourceOutputItem *o, NSIndexPath *ip, BOOL *stop) {
+    capturedState[ip] = o;
+  }];
+  [_dataSource enqueueReload];
+  [self waitUntilChangeCountIs:1];
+  
+  for (CKComponentDataSourceTestDelegateChange *change in [_delegate changes]) {
+    XCTAssertEqual(change.changeType, CKArrayControllerChangeTypeUpdate);
+    XCTAssertEqualObjects(change.afterIndexPath, change.beforeIndexPath);
+    XCTAssertEqualObjects(change.dataSourcePair, capturedState[change.afterIndexPath]);
+  }
+  XCTAssertEqual([[_delegate changes] count], [capturedState count]);
+}
+
+- (void)testUpdateContextAndReloadUpdateTheContextForAllTheContainedItems
+{
+  Sections sections;
+  sections.insert(0);
+  
+  Input::Items items;
+  items.insert({0, 0}, @"Hello");
+  items.insert({0, 1}, @"World");
+  
+  [_dataSource enqueueChangeset:{sections, items} constrainedSize:{}];
+  [self waitUntilChangeCountIs:1];
+  [_delegate reset];
+  
+  NSString *newContext = @"newContext";
+  [_dataSource updateContextAndEnqeueReload:newContext];
+  [self waitUntilChangeCountIs:1];
+  
+  for (CKComponentDataSourceTestDelegateChange *change in [_delegate changes]) {
+    XCTAssertEqualObjects(change.dataSourcePair.lifecycleManagerState.context, newContext);
+  }
+}
+
++ (CKComponent *)componentForModel:(id<NSObject>)model context:(id<NSObject>)context
+{
+  return [CKComponent newWithView:{[UIView class]} size:{}];
 }
 
 @end


### PR DESCRIPTION
Not needed and was adding some churn on the reload APIs for no reasons.

Also added unit tests for `enqueueReload`, and `updateContextAndEnqueueReload`