### PR TITLE
Add missing header

### DIFF
--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceState.m
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceState.m
@@ -11,6 +11,8 @@
 #import "CKTransactionalComponentDataSourceState.h"
 #import "CKTransactionalComponentDataSourceStateInternal.h"
 
+#import <UIKit/UIKit.h>
+
 @implementation CKTransactionalComponentDataSourceState
 
 - (instancetype)initWithConfiguration:(CKTransactionalComponentDataSourceConfiguration *)configuration


### PR DESCRIPTION
If we're going to use the UIKit extensions to NSIndexPath, we have to import UIKit.