### PR TITLE
fix hostingView cannot trigger resize issue

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -140,7 +140,8 @@
   }
 
   const CGRect bounds = self.bounds;
-  CKComponentLifecycleManagerState state = [_lifecycleManager prepareForUpdateWithModel:_model constrainedSize:CKSizeRange(bounds.size, bounds.size) context:_context];
+  CKSizeRange constrainedSize = [_sizeRangeProvider sizeRangeForBoundingSize:bounds.size];
+  CKComponentLifecycleManagerState state = [_lifecycleManager prepareForUpdateWithModel:_model constrainedSize:constrainedSize context:_context];
   [_lifecycleManager updateWithState:state];
 
   _isUpdating = NO;


### PR DESCRIPTION
Hi
 I found a issue that hosting view cannot receive invalidateSize message.

 Create a hosting view inside view controller. 
 And resize the frame of itself after layout the components.
```Objective-C
- (void)componentHostingViewDidInvalidateSize:(CKComponentHostingView *)hostingView {
    CGSize s = [hostingView sizeThatFits:CGSizeMake([UIScreen mainScreen].bounds.size.width, 8000)];
    hostingView.frame = (CGRect){.origin=hostingView.frame.origin, .size=s};
    [hostingView setNeedsLayout];//This is necessary because root view in hosting view should be modified too.
}
```
Inside hosting view the component is some simple labels.
StackLayout(Vertical)
   children:[label,label]

The problem is when I assign a new model to the hosting view. The invalidate size delegate do not triggered. And I found the reason is lifecyclemanager use self.bounds as size range (This is not the right one, and could be changed after update the hostingview's bounds )
```Objective-C
const CGRect bounds = self.bounds;
CKComponentLifecycleManagerState state = [_lifecycleManager prepareForUpdateWithModel:_model constrainedSize:CKSizeRange(bounds.size, bounds.size) context:_context];
```
The solutation is use the correct size range simply.