### PR TITLE
"[CDS] Remove convenience objc getters for now"

### DIFF
--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -75,8 +75,8 @@ namespace CK {
       void insert(NSInteger index);
       void remove(NSInteger index);
 
-      NSIndexSet *insertions() const;
-      NSIndexSet *removals() const;
+      const std::set<NSInteger> &insertions(void) const;
+      const std::set<NSInteger> &removals(void) const;
 
       bool operator==(const Sections &other) const;
 
@@ -121,15 +121,11 @@ namespace CK {
         void update(const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
         void remove(const CKArrayControllerIndexPath &indexPath);
         void insert(const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
-        
-        NSDictionary *updates() const;
-        NSSet *removals() const;
-        NSDictionary *insertions() const;
 
         size_t size() const noexcept;
 
         bool operator==(const Items &other) const;
-        
+
         /**
          Called by Changeset::enumerate(). Note that by passing an NSIndexSet the **order** that clients have called
          Items::insert() is irrelevant. See CKArrayControllerInputChangesetTests for an example. The indexes and objects
@@ -144,16 +140,14 @@ namespace CK {
                                   NSArray *objects,
                                   CKArrayControllerChangeType type,
                                   BOOL *stop);
-      
+
       private:
         friend class Changeset;
 
         typedef std::map<NSInteger, id<NSObject>> ItemIndexToObjectMap;
         typedef std::map<NSInteger, ItemIndexToObjectMap> ItemsBucketizedBySection;
-        typedef void(^ItemsBucketizedBySectionEnumerator)(NSIndexPath *indexPath, id<NSObject> object);
 
         void bucketizeObjectBySection(ItemsBucketizedBySection &m, const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
-        void enumerateItemsBucketizedBySection(const ItemsBucketizedBySection &m, ItemsBucketizedBySectionEnumerator enumerator) const;
         bool commandExistsForIndexPath(const CKArrayControllerIndexPath &indexPath,
                                        const std::vector<ItemsBucketizedBySection> &bucketsToCheck) const;
 

--- a/ComponentKitTests/CKArrayControllerChangesetTests.mm
+++ b/ComponentKitTests/CKArrayControllerChangesetTests.mm
@@ -149,54 +149,6 @@ typedef NS_ENUM(NSUInteger, CommandType) {
   }
 }
 
-- (void)testInsertions
-{
-  Input::Items items;
-  items.insert({0, 0}, @1);
-  items.insert({1, 1}, @2);
-  
-  NSDictionary *expectedInsertions = @{[NSIndexPath indexPathForItem:0 inSection:0]: @1,
-                                       [NSIndexPath indexPathForItem:1 inSection:1]: @2};
-  NSDictionary *expectedUpdates = @{};
-  NSSet *expectedRemovals = [NSSet set];
-  
-  XCTAssertEqualObjects(expectedInsertions, items.insertions());
-  XCTAssertEqualObjects(expectedRemovals, items.removals());
-  XCTAssertEqualObjects(expectedUpdates, items.updates());
-}
-
-- (void)testUpdates
-{
-  Input::Items items;
-  items.update({0, 0}, @1);
-  items.update({1, 1}, @2);
-  
-  NSDictionary *expectedInsertions = @{};
-  NSDictionary *expectedUpdates = @{[NSIndexPath indexPathForItem:0 inSection:0]: @1,
-                                    [NSIndexPath indexPathForItem:1 inSection:1]: @2};;
-  NSSet *expectedRemovals = [NSSet set];
-  
-  XCTAssertEqualObjects(expectedInsertions, items.insertions());
-  XCTAssertEqualObjects(expectedRemovals, items.removals());
-  XCTAssertEqualObjects(expectedUpdates, items.updates());
-}
-
-- (void)testRemovals
-{
-  Input::Items items;
-  items.remove({0, 0});
-  items.remove({1, 1});
-  
-  NSDictionary *expectedInsertions = @{};
-  NSDictionary *expectedUpdates = @{};
-  NSSet *expectedRemovals = [NSSet setWithArray:@[[NSIndexPath indexPathForItem:0 inSection:0], [NSIndexPath indexPathForItem:1 inSection:1]]];
-  
-  XCTAssertEqualObjects(expectedInsertions, items.insertions());
-  XCTAssertEqualObjects(expectedRemovals, items.removals());
-  XCTAssertEqualObjects(expectedUpdates, items.updates());
-}
-
-
 @end
 
 @interface CKArrayControllerInputSectionsTests : XCTestCase
@@ -234,26 +186,6 @@ typedef NS_ENUM(NSUInteger, CommandType) {
     sections.remove(0);
     XCTAssertNoThrow(sections.insert(0), @"Removals and insertions can share the same indexes.");
   }
-}
-
-- (void)testInsertion
-{
-  Sections sections;
-  sections.insert(0);
-  sections.insert(1);
-  
-  XCTAssertEqualObjects([NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)], sections.insertions());
-  XCTAssertEqualObjects([NSIndexSet indexSet], sections.removals());
-}
-
-- (void)testRemoval
-{
-  Sections sections;
-  sections.remove(0);
-  sections.remove(1);
-  
-  XCTAssertEqualObjects([NSIndexSet indexSet], sections.insertions());
-  XCTAssertEqualObjects([NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)], sections.removals());
 }
 
 @end


### PR DESCRIPTION
Will actually expose the C++ objects and make the conversion in objc structures external for the transactional DS.

Also, given the current work on moves where we eventually get rid of enumeration and the fact that the session getters are actually used internally it makes sense to keep them C++ to avoid the perf penalty of conversion.