### PR TITLE
Fix memory leak in scope handle

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -19,7 +19,7 @@
 
 @implementation CKComponentScopeHandle
 {
-  id<CKComponentStateListener> _listener;
+  id<CKComponentStateListener> __weak _listener;
   Class _componentClass;
   int32_t _rootIdentifier;
   BOOL _acquired;


### PR DESCRIPTION
When I refactored scope frames, I failed to mark the listener as weak. The result is that every component is leaked forever. Oops.