### PR TITLE
Allow null action to be passed to `CKComponentActionAttribute`

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A241C6A41AFCFFDB00D4F661 /* CKComponentActionTests.mm */; };
 		A241C6A71AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A241C6A61AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm */; };
 		A25C02D11AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A25C02D01AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm */; };
+		A273801F1AFD144100E6F222 /* CKTestActionComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = A273801E1AFD144100E6F222 /* CKTestActionComponent.mm */; };
+		A27380311AFD160200E6F222 /* libComponentKitTestHelpers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A273801A1AFD144100E6F222 /* libComponentKitTestHelpers.a */; };
+		A27380321AFD160600E6F222 /* libComponentKitTestHelpers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A273801A1AFD144100E6F222 /* libComponentKitTestHelpers.a */; };
+		A27380341AFD172500E6F222 /* CKTestActionComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = A273801C1AFD144100E6F222 /* CKTestActionComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A27436F71AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A27436F61AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm */; };
 		A27436FA1AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */; };
 		A279EA9E1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A279EA9D1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm */; };
@@ -90,6 +94,9 @@
 		A241C6A41AFCFFDB00D4F661 /* CKComponentActionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentActionTests.mm; sourceTree = "<group>"; };
 		A241C6A61AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentActionAttributeTests.mm; sourceTree = "<group>"; };
 		A25C02D01AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetModificationTests.mm; sourceTree = "<group>"; };
+		A273801A1AFD144100E6F222 /* libComponentKitTestHelpers.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libComponentKitTestHelpers.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A273801C1AFD144100E6F222 /* CKTestActionComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKTestActionComponent.h; sourceTree = "<group>"; };
+		A273801E1AFD144100E6F222 /* CKTestActionComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestActionComponent.mm; sourceTree = "<group>"; };
 		A27436F61AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceReloadModificationTests.mm; sourceTree = "<group>"; };
 		A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTransactionalComponentDataSourceStateTestHelpers.h; sourceTree = "<group>"; };
 		A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateTestHelpers.mm; sourceTree = "<group>"; };
@@ -154,10 +161,18 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		A27380171AFD144100E6F222 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B342DC3D1AC23E8200ACAC53 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A27380321AFD160600E6F222 /* libComponentKitTestHelpers.a in Frameworks */,
 				83EBF589FB5C5611BC1A2D13 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -166,6 +181,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A27380311AFD160200E6F222 /* libComponentKitTestHelpers.a in Frameworks */,
 				0C293C2FE4684CADAB27CA9D /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -203,6 +219,15 @@
 				A6F27DD3FB8E2237F9C39DCE /* Pods.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		A273801B1AFD144100E6F222 /* ComponentKitTestHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				A273801C1AFD144100E6F222 /* CKTestActionComponent.h */,
+				A273801E1AFD144100E6F222 /* CKTestActionComponent.mm */,
+			);
+			path = ComponentKitTestHelpers;
 			sourceTree = "<group>";
 		};
 		A27436F51AE94FCA00832359 /* TransactionalDataSource */ = {
@@ -318,6 +343,7 @@
 				B342DC411AC23E8200ACAC53 /* ComponentKitTests */,
 				B342DC8C1AC23EC300ACAC53 /* ComponentKitApplicationTests */,
 				B342DCAB1AC23F2A00ACAC53 /* ComponentTextKitApplicationTests */,
+				A273801B1AFD144100E6F222 /* ComponentKitTestHelpers */,
 				B3EECEC31AC2366600BFC5DA /* Products */,
 				9EC07CBC8F809ACF3EC95132 /* Pods */,
 				7683E4B5CB30052819FB3185 /* Frameworks */,
@@ -331,13 +357,42 @@
 				B342DC401AC23E8200ACAC53 /* ComponentKitTests.xctest */,
 				B342DC8B1AC23EC300ACAC53 /* ComponentKitApplicationTests.xctest */,
 				B342DCAA1AC23F2A00ACAC53 /* ComponentTextKitApplicationTests.xctest */,
+				A273801A1AFD144100E6F222 /* libComponentKitTestHelpers.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		A27380331AFD171C00E6F222 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A27380341AFD172500E6F222 /* CKTestActionComponent.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		A27380191AFD144100E6F222 /* ComponentKitTestHelpers */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A273802F1AFD144200E6F222 /* Build configuration list for PBXNativeTarget "ComponentKitTestHelpers" */;
+			buildPhases = (
+				A27380161AFD144100E6F222 /* Sources */,
+				A27380171AFD144100E6F222 /* Frameworks */,
+				A27380331AFD171C00E6F222 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ComponentKitTestHelpers;
+			productName = ComponentKitTestHelpers;
+			productReference = A273801A1AFD144100E6F222 /* libComponentKitTestHelpers.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		B342DC3F1AC23E8200ACAC53 /* ComponentKitTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B342DC461AC23E8200ACAC53 /* Build configuration list for PBXNativeTarget "ComponentKitTests" */;
@@ -422,6 +477,9 @@
 			attributes = {
 				LastUpgradeCheck = 0610;
 				TargetAttributes = {
+					A27380191AFD144100E6F222 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
 					B342DC3F1AC23E8200ACAC53 = {
 						CreatedOnToolsVersion = 6.1;
 					};
@@ -455,6 +513,7 @@
 				B342DC3F1AC23E8200ACAC53 /* ComponentKitTests */,
 				B342DC8A1AC23EC300ACAC53 /* ComponentKitApplicationTests */,
 				B342DCA91AC23F2A00ACAC53 /* ComponentTextKitApplicationTests */,
+				A27380191AFD144100E6F222 /* ComponentKitTestHelpers */,
 			);
 		};
 /* End PBXProject section */
@@ -584,6 +643,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		A27380161AFD144100E6F222 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A273801F1AFD144100E6F222 /* CKTestActionComponent.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B342DC3C1AC23E8200ACAC53 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -680,6 +747,37 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		A273802B1AFD144200E6F222 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		A273802C1AFD144200E6F222 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A6F27DD3FB8E2237F9C39DCE /* Pods.release.xcconfig */;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		B342DC471AC23E8200ACAC53 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */;
@@ -885,6 +983,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		A273802F1AFD144200E6F222 /* Build configuration list for PBXNativeTarget "ComponentKitTestHelpers" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A273802B1AFD144200E6F222 /* Debug */,
+				A273802C1AFD144200E6F222 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B342DC461AC23E8200ACAC53 /* Build configuration list for PBXNativeTarget "ComponentKitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		A2100E0D1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */; };
 		A22FE3031AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */; };
 		A22FE3061AF2CF0C00EC30B8 /* CKStateExposingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22FE3051AF2CF0C00EC30B8 /* CKStateExposingComponent.mm */; };
+		A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A241C6A41AFCFFDB00D4F661 /* CKComponentActionTests.mm */; };
+		A241C6A71AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A241C6A61AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm */; };
 		A25C02D11AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A25C02D01AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm */; };
 		A27436F71AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A27436F61AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm */; };
 		A27436FA1AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */; };
@@ -85,6 +87,8 @@
 		A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateUpdateTests.mm; sourceTree = "<group>"; };
 		A22FE3041AF2CF0C00EC30B8 /* CKStateExposingComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKStateExposingComponent.h; sourceTree = "<group>"; };
 		A22FE3051AF2CF0C00EC30B8 /* CKStateExposingComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStateExposingComponent.mm; sourceTree = "<group>"; };
+		A241C6A41AFCFFDB00D4F661 /* CKComponentActionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentActionTests.mm; sourceTree = "<group>"; };
+		A241C6A61AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentActionAttributeTests.mm; sourceTree = "<group>"; };
 		A25C02D01AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetModificationTests.mm; sourceTree = "<group>"; };
 		A27436F61AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceReloadModificationTests.mm; sourceTree = "<group>"; };
 		A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTransactionalComponentDataSourceStateTestHelpers.h; sourceTree = "<group>"; };
@@ -222,6 +226,7 @@
 			children = (
 				B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */,
 				B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */,
+				A241C6A41AFCFFDB00D4F661 /* CKComponentActionTests.mm */,
 				B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */,
 				B342DC4C1AC23EA900ACAC53 /* CKComponentContextTests.mm */,
 				B342DC4D1AC23EA900ACAC53 /* CKComponentControllerLifecycleMethodTests.mm */,
@@ -272,6 +277,7 @@
 			children = (
 				B342DC961AC23EE800ACAC53 /* CKButtonComponentTests.mm */,
 				B342DC971AC23EE800ACAC53 /* CKCenterLayoutComponentsTests.mm */,
+				A241C6A61AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm */,
 				B342DC981AC23EE800ACAC53 /* CKInsetComponentTests.mm */,
 				B342DC991AC23EE800ACAC53 /* CKNetworkImageComponentTests.mm */,
 				B342DC9A1AC23EE800ACAC53 /* CKOverlayLayoutComponentTests.mm */,
@@ -585,6 +591,7 @@
 				B342DC771AC23EA900ACAC53 /* CKComponentMountContextLayoutGuideTests.mm in Sources */,
 				B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */,
 				B342DC811AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm in Sources */,
+				A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */,
 				B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */,
 				B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */,
 				B342DC6F1AC23EA900ACAC53 /* CKComponentControllerTests.mm in Sources */,
@@ -632,6 +639,7 @@
 				B342DC9F1AC23EE800ACAC53 /* CKCenterLayoutComponentsTests.mm in Sources */,
 				B342DCA41AC23EE800ACAC53 /* CKStackLayoutComponentTests.mm in Sources */,
 				B342DC9E1AC23EE800ACAC53 /* CKButtonComponentTests.mm in Sources */,
+				A241C6A71AFD0A6800D4F661 /* CKComponentActionAttributeTests.mm in Sources */,
 				B342DCA01AC23EE800ACAC53 /* CKInsetComponentTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ComponentKit.xcodeproj/xcshareddata/xcschemes/ComponentKit.xcscheme
+++ b/ComponentKit.xcodeproj/xcshareddata/xcschemes/ComponentKit.xcscheme
@@ -28,6 +28,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A27380191AFD144100E6F222"
+               BuildableName = "libComponentKitTestHelpers.a"
+               BlueprintName = "ComponentKitTestHelpers"
+               ReferencedContainer = "container:ComponentKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "B342DC3F1AC23E8200ACAC53"
                BuildableName = "ComponentKitTests.xctest"
                BlueprintName = "ComponentKitTests"
@@ -120,7 +134,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B3EECEC11AC2366600BFC5DA"
@@ -138,7 +153,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B3EECEC11AC2366600BFC5DA"

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -147,10 +147,8 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
     {@selector(setSelected:), @(selected)},
     {@selector(setEnabled:), @(enabled)},
     {@selector(setAccessibilityIdentifier:), accessibilityConfiguration.accessibilityIdentifier},
+    CKComponentActionAttribute(action, UIControlEventTouchUpInside),
   });
-  if (action) {
-    attributes.insert(CKComponentActionAttribute(action, UIControlEventTouchUpInside));
-  }
 
   UIEdgeInsets contentEdgeInsets = UIEdgeInsetsZero;
   auto it = passedAttributes.find(@selector(setContentEdgeInsets:));

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -46,7 +46,7 @@ void CKComponentActionSend(CKComponentAction action, CKComponent *sender, id con
  You can use this with e.g. CKButtonComponent.
 
  @param action Sent up the responder chain when an event occurs. Sender is the component that created the UIControl;
-        context is the UIEvent that triggered the action.
+        context is the UIEvent that triggered the action. May be NULL, in which case no action will be sent.
  @param controlEvents The events that should result in the action being sent. Default is touch up inside.
  */
 CKComponentViewAttributeValue CKComponentActionAttribute(CKComponentAction action,

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -52,10 +52,16 @@ typedef std::unordered_map<CKComponentAction, CKComponentActionControlForwarder 
 CKComponentViewAttributeValue CKComponentActionAttribute(CKComponentAction action,
                                                          UIControlEvents controlEvents)
 {
-  CKCAssertNotNil(action, @"Can't pass a NULL action to CKComponentActionAttribute");
-
   static ForwarderMap *map = new ForwarderMap(); // never destructed to avoid static destruction fiasco
   static CK::StaticMutex lock = CK_MUTEX_INITIALIZER;   // protects map
+
+  if (action == NULL) {
+    return {
+      {"CKComponentActionAttribute-no-op", ^(UIControl *control, id value) {}, ^(UIControl *control, id value) {}},
+      // Use a bogus value for the attribute's "value". All the information is encoded in the attribute itself.
+      @YES
+    };
+  }
 
   // We need a target for the control event. (We can't use the responder chain because we need to jump in and change the
   // sender from the UIControl to the CKComponent.)

--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -18,7 +18,7 @@ typedef void (*CKComponentGestureRecognizerSetupFunction)(UIGestureRecognizer *)
  Returns a view attribute that creates and configures a tap gesture recognizer to send the given CKComponentAction.
 
  @param action Sent up the responder chain when a tap occurs. Sender is the component that created the view.
-        Context is the gesture recognizer.
+        Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
 CKComponentViewAttributeValue CKComponentTapGestureAttribute(CKComponentAction action);
 
@@ -26,7 +26,7 @@ CKComponentViewAttributeValue CKComponentTapGestureAttribute(CKComponentAction a
  Returns a view attribute that creates and configures a pan gesture recognizer to send the given CKComponentAction.
 
  @param action Sent up the responder chain when a pan occurs. Sender is the component that created the view.
-        Context is the gesture recognizer.
+        Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
 CKComponentViewAttributeValue CKComponentPanGestureAttribute(CKComponentAction action);
 
@@ -34,7 +34,7 @@ CKComponentViewAttributeValue CKComponentPanGestureAttribute(CKComponentAction a
  Returns a view attribute that creates and configures a long press gesture recognizer to send the given CKComponentAction.
 
  @param action Sent up the responder chain when a long press occurs. Sender is the component that created the view.
-        Context is the gesture recognizer.
+        Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
 CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(CKComponentAction action);
 
@@ -45,7 +45,7 @@ CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(CKComponentAc
  @param setupFunction Optional; pass nullptr if not needed. Called once for each new gesture recognizer; you may use
         this function to configure the new gesture recognizer.
  @param action Sent up the responder chain when the gesture recognizer recognizes a gesture. Sender is the component
-        that created the view. Context is the gesture recognizer.
+        that created the view. Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -102,6 +102,17 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
                                                           CKComponentAction action)
 {
+  if (action == NULL) {
+    return {
+      {
+        std::string(class_getName(gestureRecognizerClass)) + "-"
+        + CKStringFromPointer((const void *)setupFunction) + "-no-op",
+        ^(UIView *view, id value) {}, ^(UIView *view, id value) {}
+      },
+      @YES  // Bogus value, we don't use it.
+    };
+  }
+
   static auto *reusePoolMap = new std::unordered_map<CKGestureRecognizerReusePoolMapKey, CKGestureRecognizerReusePool *>();
   static CK::StaticMutex reusePoolMapMutex = CK_MUTEX_INITIALIZER;
   CK::StaticMutexLocker l(reusePoolMapMutex);

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "CKComponentAction.h"
+#import "CKCompositeComponent.h"
+#import "CKComponentSubclass.h"
+#import "CKComponentInternal.h"
+#import "CKComponentLayout.h"
+
+@interface CKTestActionComponent : CKCompositeComponent
+/** @param block Executed when "testAction" is invoked on the component */
++ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block
+                   component:(CKComponent *)component;
+- (void)testAction:(CKComponent *)sender context:(id)context;
+@end
+
+@interface CKComponentActionAttributeTests : XCTestCase
+@end
+
+/* This needs to be an application test, otherwise sendActionsForControlEvents: doesn't work since UIApplication is nil */
+@implementation CKComponentActionAttributeTests
+
+- (void)testControlActionAttribute
+{
+  __block CKComponent *actionSender = nil;
+
+  CKComponent *controlComponent =
+  [CKComponent
+   newWithView:{
+     [UIButton class],
+     {CKComponentActionAttribute(@selector(testAction:context:))}
+   }
+   size:{}];
+
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ actionSender = sender; }
+   component:controlComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  [(UIControl *)[controlComponent viewContext].view sendActionsForControlEvents:UIControlEventTouchUpInside];
+  XCTAssert(actionSender == controlComponent, @"Sender should be the component that created the control");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+- (void)testControlActionAttributeWithControlEventSpecified
+{
+  __block BOOL receivedAction = NO;
+
+  CKComponent *controlComponent =
+  [CKComponent
+   newWithView:{
+     [UIButton class],
+     {CKComponentActionAttribute(@selector(testAction:context:), UIControlEventValueChanged)}
+   }
+   size:{}];
+
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   component:controlComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  [(UIControl *)[controlComponent viewContext].view sendActionsForControlEvents:UIControlEventValueChanged];
+  XCTAssertTrue(receivedAction, @"Should have received action");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+- (void)testControlActionIsNotSentForControlEventsThatDoNotMatch
+{
+  __block BOOL receivedAction = NO;
+
+  CKComponent *controlComponent =
+  [CKComponent
+   newWithView:{
+     [UIButton class],
+     {CKComponentActionAttribute(@selector(testAction:context:))}
+   }
+   size:{}];
+
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   component:controlComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  [(UIControl *)[controlComponent viewContext].view sendActionsForControlEvents:UIControlEventTouchDragEnter];
+  XCTAssertFalse(receivedAction, @"Should not have received callback for UIControlEventTouchDragEnter");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+- (void)testControlActionIsNotSentForNullAction
+{
+  __block BOOL receivedAction = NO;
+
+  CKComponent *controlComponent =
+  [CKComponent
+   newWithView:{
+     [UIButton class],
+     {CKComponentActionAttribute(NULL)}
+   }
+   size:{}];
+
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   component:controlComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  [(UIControl *)[controlComponent viewContext].view sendActionsForControlEvents:UIControlEventTouchUpInside];
+  XCTAssertFalse(receivedAction, @"Should not have received callback if no action specified");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+@end
+
+@implementation CKTestActionComponent
+{
+  void (^_block)(CKComponent *, id);
+}
+
++ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block component:(CKComponent *)component
+{
+  CKTestActionComponent *c = [super newWithComponent:component];
+  if (c) {
+    c->_block = block;
+  }
+  return c;
+}
+
+- (void)testAction:(CKComponent *)sender context:(id)context
+{
+  _block(sender, context);
+}
+
+@end

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -11,18 +11,13 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+#import <ComponentKitTestHelpers/CKTestActionComponent.h>
+
 #import "CKComponentAction.h"
 #import "CKCompositeComponent.h"
 #import "CKComponentSubclass.h"
 #import "CKComponentInternal.h"
 #import "CKComponentLayout.h"
-
-@interface CKTestActionComponent : CKCompositeComponent
-/** @param block Executed when "testAction" is invoked on the component */
-+ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block
-                   component:(CKComponent *)component;
-- (void)testAction:(CKComponent *)sender context:(id)context;
-@end
 
 @interface CKComponentActionAttributeTests : XCTestCase
 @end
@@ -136,27 +131,6 @@
   XCTAssertFalse(receivedAction, @"Should not have received callback if no action specified");
 
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
-}
-
-@end
-
-@implementation CKTestActionComponent
-{
-  void (^_block)(CKComponent *, id);
-}
-
-+ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block component:(CKComponent *)component
-{
-  CKTestActionComponent *c = [super newWithComponent:component];
-  if (c) {
-    c->_block = block;
-  }
-  return c;
-}
-
-- (void)testAction:(CKComponent *)sender context:(id)context
-{
-  _block(sender, context);
 }
 
 @end

--- a/ComponentKitTestHelpers/CKTestActionComponent.h
+++ b/ComponentKitTestHelpers/CKTestActionComponent.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKCompositeComponent.h"
+
+@interface CKTestActionComponent : CKCompositeComponent
+/** @param block Executed when "testAction:context:" is invoked on the component */
++ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block
+                   component:(CKComponent *)component;
+- (void)testAction:(CKComponent *)sender context:(id)context;
+@end

--- a/ComponentKitTestHelpers/CKTestActionComponent.mm
+++ b/ComponentKitTestHelpers/CKTestActionComponent.mm
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKTestActionComponent.h"
+
+@implementation CKTestActionComponent
+{
+  void (^_block)(CKComponent *, id);
+}
+
++ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block component:(CKComponent *)component
+{
+  CKTestActionComponent *c = [super newWithComponent:component];
+  if (c) {
+    c->_block = block;
+  }
+  return c;
+}
+
+- (void)testAction:(CKComponent *)sender context:(id)context
+{
+  _block(sender, context);
+}
+
+@end

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "CKComponentAction.h"
+#import "CKCompositeComponent.h"
+#import "CKComponentSubclass.h"
+#import "CKComponentInternal.h"
+#import "CKComponentLayout.h"
+
+@interface CKTestActionComponent : CKCompositeComponent
+/** @param block Executed when "testAction" is invoked on the component */
++ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block
+                   component:(CKComponent *)component;
+- (void)testAction:(CKComponent *)sender context:(id)context;
+@end
+
+@interface CKComponentActionTests : XCTestCase
+@end
+
+@implementation CKComponentActionTests
+
+- (void)testSendActionIncludesSenderComponent
+{
+  __block CKComponent *actionSender = nil;
+
+  CKComponent *innerComponent = [CKComponent new];
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ actionSender = sender; }
+   component:innerComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  CKComponentActionSend(@selector(testAction:context:), innerComponent);
+
+  XCTAssert(actionSender == innerComponent, @"Sender should be inner component");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+- (void)testSendActionIncludesContext
+{
+  __block id actionContext = nil;
+
+  CKComponent *innerComponent = [CKComponent new];
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ actionContext = context; }
+   component:innerComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  id context = @"context";
+
+  CKComponentActionSend(@selector(testAction:context:), innerComponent, context);
+
+  XCTAssert(actionContext == context, @"Context should match what was passed to CKComponentActionSend");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+- (void)testSendActionStartingAtSenderNextResponderReachesParentComponent
+{
+  __block BOOL outerReceivedTestAction = NO;
+  __block BOOL innerReceivedTestAction = NO;
+
+  CKTestActionComponent *innerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ innerReceivedTestAction = YES; }
+   component:[CKComponent new]];
+
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ outerReceivedTestAction = YES; }
+   component:innerComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  CKComponentActionSend(@selector(testAction:context:), innerComponent);
+
+  XCTAssertTrue(outerReceivedTestAction, @"Outer component should have received action sent by inner component");
+  XCTAssertFalse(innerReceivedTestAction, @"Inner component should not have received action sent from it");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+- (void)testSendActionStartingAtSenderDoesNotReachParentComponent
+{
+  __block BOOL outerReceivedTestAction = NO;
+  __block BOOL innerReceivedTestAction = NO;
+
+  CKTestActionComponent *innerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ innerReceivedTestAction = YES; }
+   component:[CKComponent new]];
+
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithBlock:^(CKComponent *sender, id context){ outerReceivedTestAction = YES; }
+   component:innerComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView);
+
+  CKComponentActionSend(@selector(testAction:context:), innerComponent, nil, CKComponentActionSendBehaviorStartAtSender);
+
+  XCTAssertFalse(outerReceivedTestAction, @"Outer component should not have received action since inner component did");
+  XCTAssertTrue(innerReceivedTestAction, @"Inner component should have received action");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
+@end
+
+@implementation CKTestActionComponent
+{
+  void (^_block)(CKComponent *, id);
+}
+
++ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block component:(CKComponent *)component
+{
+  CKTestActionComponent *c = [super newWithComponent:component];
+  if (c) {
+    c->_block = block;
+  }
+  return c;
+}
+
+- (void)testAction:(CKComponent *)sender context:(id)context
+{
+  _block(sender, context);
+}
+
+@end

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -11,18 +11,13 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+#import <ComponentKitTestHelpers/CKTestActionComponent.h>
+
 #import "CKComponentAction.h"
 #import "CKCompositeComponent.h"
 #import "CKComponentSubclass.h"
 #import "CKComponentInternal.h"
 #import "CKComponentLayout.h"
-
-@interface CKTestActionComponent : CKCompositeComponent
-/** @param block Executed when "testAction" is invoked on the component */
-+ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block
-                   component:(CKComponent *)component;
-- (void)testAction:(CKComponent *)sender context:(id)context;
-@end
 
 @interface CKComponentActionTests : XCTestCase
 @end
@@ -125,27 +120,6 @@
   XCTAssertTrue(innerReceivedTestAction, @"Inner component should have received action");
 
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
-}
-
-@end
-
-@implementation CKTestActionComponent
-{
-  void (^_block)(CKComponent *, id);
-}
-
-+ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block component:(CKComponent *)component
-{
-  CKTestActionComponent *c = [super newWithComponent:component];
-  if (c) {
-    c->_block = block;
-  }
-  return c;
-}
-
-- (void)testAction:(CKComponent *)sender context:(id)context
-{
-  _block(sender, context);
 }
 
 @end

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -70,6 +70,16 @@
   XCTAssertTrue([fakeParentComponent receivedTest], @"Expected handler to be called");
 }
 
+- (void)testThatApplyingATapRecognizerAttributeWithNoActionDoesNotAddRecognizerToView
+{
+  CKComponentViewAttributeValue attr = CKComponentTapGestureAttribute(NULL);
+  UIView *view = [[UIView alloc] init];
+
+  attr.first.applicator(view, attr.second);
+  XCTAssertEqual([view.gestureRecognizers count], 0u, @"Expected no gesture recognizer");
+  attr.first.unapplicator(view, attr.second);
+}
+
 @end
 
 @implementation CKFakeActionComponent


### PR DESCRIPTION
This should minimize the places we need to do conditional attributes.

http://componentkit.org/docs/avoid-push-back.html