### PR TITLE
[CDS] remove usage of CKArrayControllerInputItems enumeration

### DIFF
--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -121,6 +121,12 @@ namespace CK {
         void update(const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
         void remove(const CKArrayControllerIndexPath &indexPath);
         void insert(const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
+        typedef std::map<NSInteger, id<NSObject>> ItemIndexToObjectMap;
+        typedef std::map<NSInteger, ItemIndexToObjectMap> ItemsBucketizedBySection;
+
+        const ItemsBucketizedBySection &updates() const;
+        const ItemsBucketizedBySection &removals() const;
+        const ItemsBucketizedBySection &insertions() const;
 
         size_t size() const noexcept;
 
@@ -143,9 +149,6 @@ namespace CK {
 
       private:
         friend class Changeset;
-
-        typedef std::map<NSInteger, id<NSObject>> ItemIndexToObjectMap;
-        typedef std::map<NSInteger, ItemIndexToObjectMap> ItemsBucketizedBySection;
 
         void bucketizeObjectBySection(ItemsBucketizedBySection &m, const CKArrayControllerIndexPath &indexPath, id<NSObject> object);
         bool commandExistsForIndexPath(const CKArrayControllerIndexPath &indexPath,

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.mm
@@ -127,6 +127,11 @@ void Input::Items::bucketizeObjectBySection(ItemsBucketizedBySection &sectionMap
   }
 }
 
+const CK::ArrayController::Input::Items::ItemsBucketizedBySection &Input::Items::updates() const
+{
+  return _updates;
+}
+
 void Input::Items::update(const IndexPath &indexPath, id<NSObject> object)
 {
   CKInternalConsistencyCheckIf(!commandExistsForIndexPath(indexPath, {_updates, _removals}),
@@ -134,6 +139,11 @@ void Input::Items::update(const IndexPath &indexPath, id<NSObject> object)
                                 indexPath.item, indexPath.section]));
 
   bucketizeObjectBySection(_updates, indexPath, object);
+}
+
+const CK::ArrayController::Input::Items::ItemsBucketizedBySection &Input::Items::removals() const
+{
+  return _removals;
 }
 
 void Input::Items::remove(const IndexPath &indexPath)
@@ -144,6 +154,11 @@ void Input::Items::remove(const IndexPath &indexPath)
 
   // We can insert nil in a std::map.
   bucketizeObjectBySection(_removals, indexPath, nil);
+}
+
+const CK::ArrayController::Input::Items::ItemsBucketizedBySection &Input::Items::insertions() const
+{
+  return _insertions;
 }
 
 void Input::Items::insert(const IndexPath &indexPath, id<NSObject> object)


### PR DESCRIPTION
This is a first step in removing enumeration API motivated by incoming moves support in the changeset.
Exposing moves though enumeration would be a bit cumbersome (since we have always assumed each change needs only one indexPath so far) and several callsites assume changes are enumerated in a specific order, which is not really enforced anywhere (and not documented in all places either).

This PR does not remove the enumeration itself yet, since I need to sync this internally a remove all usages there first.