### PR TITLE
[CDS] safer access to CKArrayControllerInputItems

### DIFF
--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -124,9 +124,10 @@ namespace CK {
         typedef std::map<NSInteger, id<NSObject>> ItemIndexToObjectMap;
         typedef std::map<NSInteger, ItemIndexToObjectMap> ItemsBucketizedBySection;
 
-        const ItemsBucketizedBySection &updates() const;
-        const ItemsBucketizedBySection &removals() const;
-        const ItemsBucketizedBySection &insertions() const;
+        typedef void (^UpdatesEnumerator)(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop);
+        typedef void (^RemovalsEnumerator)(NSInteger section, NSInteger index, BOOL *stop);
+        typedef void (^InsertionsEnumerator)(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop);
+        void enumerateItems(UpdatesEnumerator updatesBlock, RemovalsEnumerator removalsBlock, InsertionsEnumerator insertionsBlock) const;
 
         size_t size() const noexcept;
 


### PR DESCRIPTION
After chatting more with @benlodotcom and considering this is a pretty important part of the datasource, I have decided to go with the safest way possible for exposing input items on CKArrayControllerInputItems.

Using a separate enumeration for each operation at once is safer,
since we won't forget update any processing of input items once we add moves.
Also it explicitly shows what kind of items are there to handle, so it's harder to forgot anything when adding a new consumer.