### PR TITLE
[CDS] remove the old item enumeration API from CKArrayControllerChangeset

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -341,38 +341,25 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
                                                                         UUID:[item UUID]];
   };
   auto mappedChangeset = changeset.map(mapper);
-  
+
   __block CKComponentDataSourceChangeType changeTypes = 0;
 
-  CKArrayControllerSections::Enumerator sectionEnumerator = ^(NSIndexSet *indexSet, CKArrayControllerChangeType changeType, BOOL *stop){
-    switch (changeType) {
-      case CKArrayControllerChangeTypeInsert: changeTypes |= CKComponentDataSourceChangeTypeInsertSections; break;
-      case CKArrayControllerChangeTypeDelete: changeTypes |= CKComponentDataSourceChangeTypeDeleteSections; break;
-      case CKArrayControllerChangeTypeMove: changeTypes |= CKComponentDataSourceChangeTypeMoveSections; break;
-      default: CKFailAssert(@"Unexpected change type %lu", (unsigned long)changeType); break;
+  changeTypes |= mappedChangeset.sections.insertions().empty() ? 0 : CKComponentDataSourceChangeTypeInsertSections;
+  changeTypes |= mappedChangeset.sections.removals().empty() ? 0 : CKComponentDataSourceChangeTypeDeleteSections;
+
+  mappedChangeset.items.enumerateItems(^(NSInteger, NSInteger, CKComponentDataSourceOutputItem* outputItem, BOOL *stop) {
+    if (!CGSizeEqualToSize([outputItem oldSize], [outputItem lifecycleManagerState].layout.size)) {
+      changeTypes |= CKComponentDataSourceChangeTypeUpdateSize;
+      *stop = YES;
     }
-  };
-  
-CKArrayControllerInputItems::Enumerator itemEnumerator =
-  ^(NSInteger section, NSIndexSet *indexes, NSArray *objects, CKArrayControllerChangeType type, BOOL *stop) {
-    switch (type) {
-      case CKArrayControllerChangeTypeInsert: changeTypes |= CKComponentDataSourceChangeTypeInsertRows; break;
-      case CKArrayControllerChangeTypeDelete: changeTypes |= CKComponentDataSourceChangeTypeDeleteRows; break;
-      case CKArrayControllerChangeTypeMove: changeTypes |= CKComponentDataSourceChangeTypeMoveRows; break;
-      case CKArrayControllerChangeTypeUpdate: {
-        [objects enumerateObjectsUsingBlock:^(CKComponentDataSourceOutputItem *obj, NSUInteger idx, BOOL *innerStop) {
-          if (!CGSizeEqualToSize([obj oldSize], [obj lifecycleManagerState].layout.size)) {
-            changeTypes |= CKComponentDataSourceChangeTypeUpdateSize;
-            *innerStop = YES;
-          }
-        }];
-        break;
-      }
-      default: CKFailAssert(@"Unexpected change type %lu", (unsigned long)type); break;
-    }
-  };
-  mappedChangeset.enumerate(sectionEnumerator, itemEnumerator);
-  
+  }, ^(NSInteger, NSInteger, BOOL *stop) {
+    changeTypes |= CKComponentDataSourceChangeTypeDeleteRows;
+    *stop = YES;
+  }, ^(NSInteger, NSInteger, id<NSObject>, BOOL *stop) {
+    changeTypes |= CKComponentDataSourceChangeTypeInsertRows;
+    *stop = YES;
+  });
+
   [_delegate componentDataSource:self
                hasChangesOfTypes:changeTypes
              changesetApplicator:^{

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -133,21 +133,6 @@ namespace CK {
 
         bool operator==(const Items &other) const;
 
-        /**
-         Called by Changeset::enumerate(). Note that by passing an NSIndexSet the **order** that clients have called
-         Items::insert() is irrelevant. See CKArrayControllerInputChangesetTests for an example. The indexes and objects
-         parameters will always have the same number of elements, unless for CKArrayControllerChangeTypeDelete where
-         only indexes are passed.
-
-         In doing so we can, for example, simply call -[NSArray insertObjects:atIndexes:] and let NSArray do the
-         hard work of index-munging.
-         */
-        typedef void(^Enumerator)(NSInteger section,
-                                  NSIndexSet *indexes,
-                                  NSArray *objects,
-                                  CKArrayControllerChangeType type,
-                                  BOOL *stop);
-
       private:
         friend class Changeset;
 
@@ -181,24 +166,6 @@ namespace CK {
         
         const CKArrayControllerSections sections;
         const CKArrayControllerInputItems items;
-        
-        /**
-         Called by CKSectionedArrayController. Enumeration vends "commands" that the array controller applies to its
-         internal array-of-arrays.
-         
-         The order of block invocation allows us to apply these commands directly to the arrays without having to deal
-         with adjusting/offsetting indexes or index paths.
-         
-         1) item updates
-         2) item removals
-         3) section removals
-         4) section insertions
-         5) item insertions
-         
-         Note that Items::Enumerate is invoked once for each section in which we need to insert/update/remove objects.
-         If there are insertions into N sections it is invoked N times.
-         */
-        void enumerate(CKArrayControllerSections::Enumerator sectionEnumerator, CKArrayControllerInputItems::Enumerator itemEnumerator) const;
         
         typedef id<NSObject> (^Mapper)(const IndexPath &indexPath, id<NSObject> object, CKArrayControllerChangeType type, BOOL *stop);
         

--- a/ComponentKitTests/CKArrayControllerChangesetTests.mm
+++ b/ComponentKitTests/CKArrayControllerChangesetTests.mm
@@ -199,14 +199,16 @@ typedef NS_ENUM(NSUInteger, CommandType) {
 {
   Input::Changeset changeset = {{}, {}};
 
-  Sections::Enumerator sectionsEnumerator =
-  ^(NSIndexSet *sectionIndexes, CKArrayControllerChangeType type, BOOL *stop) {};
+  XCTAssertNoThrow(changeset.items.enumerateItems(nil,
+                                                  ^(NSInteger section, NSInteger index, BOOL *stop) {},
+                                                  ^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {}));
+  XCTAssertNoThrow(changeset.items.enumerateItems(^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {},
+                                                  nil,
+                                                  ^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {}));
+  XCTAssertNoThrow(changeset.items.enumerateItems(^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {},
+                                                  ^(NSInteger section, NSInteger index, BOOL *stop) {},
+                                                  nil));
 
-  Input::Items::Enumerator itemsEnumerator =
-  ^(NSInteger section, NSIndexSet *indexes, NSArray *objects, CKArrayControllerChangeType type, BOOL *stop) {};
-
-  XCTAssertNoThrow(changeset.enumerate(nil, itemsEnumerator), @"");
-  XCTAssertNoThrow(changeset.enumerate(sectionsEnumerator, nil), @"");
 }
 
 static Input::Changeset exampleInputChangeset(void)
@@ -230,118 +232,25 @@ static Input::Changeset exampleInputChangeset(void)
   return {sections, items};
 }
 
-/**
- Enumerating input should order commands (see header) such that we can apply the changes to the internal arrays of
- CKSectionedArrayController **without** having to change any of the index paths in the input commands.
- */
-- (void)testEnumerationOrdersSectionAndItemsCommandsCorrectly
-{
-  __block std::vector<std::pair<CommandType, CKArrayControllerChangeType>> commands;
-
-  Sections::Enumerator sectionsEnumerator =
-  ^(NSIndexSet *sectionIndexes, CKArrayControllerChangeType type, BOOL *stop) {
-    commands.push_back({CommandTypeSection, type});
-  };
-
-  Input::Items::Enumerator itemsEnumerator =
-  ^(NSInteger section, NSIndexSet *indexes, NSArray *objects, CKArrayControllerChangeType type, BOOL *stop) {
-    commands.push_back({CommandTypeItem, type});
-  };
-
-  Input::Changeset changeset = exampleInputChangeset();
-  changeset.enumerate(sectionsEnumerator, itemsEnumerator);
-
-  std::vector<std::pair<CommandType, CKArrayControllerChangeType>> expected = {
-    {CommandTypeItem, CKArrayControllerChangeTypeUpdate},
-    {CommandTypeItem, CKArrayControllerChangeTypeDelete},
-    {CommandTypeSection, CKArrayControllerChangeTypeDelete},
-    {CommandTypeSection, CKArrayControllerChangeTypeInsert},
-    {CommandTypeItem, CKArrayControllerChangeTypeInsert},
-    {CommandTypeItem, CKArrayControllerChangeTypeInsert}, // We insert items in 2 sections, so we expect 2 callbacks.
-  };
-
-  XCTAssertTrue(commands == expected, @"Commands received in incorrect order");
-}
-
-
-- (void)testSectionCommandsAreEnumeratedOnlyIfNecessary
-{
-  Sections sections;
-  Input::Items items;
-
-  Input::Changeset changeset = {sections, items};
-
-  __block BOOL insertions = NO;
-  __block BOOL removals = NO;
-
-  Sections::Enumerator sectionsEnumerator =
-  ^(NSIndexSet *sectionIndexes, CKArrayControllerChangeType type, BOOL *stop) {
-    if (type == CKArrayControllerChangeTypeInsert) {
-      insertions = YES;
-    }
-    if (type == CKArrayControllerChangeTypeDelete) {
-      removals = YES;
-    }
-  };
-
-  Input::Items::Enumerator itemsEnumerator =
-    ^(NSInteger section, NSIndexSet *indexes, NSArray *objects, CKArrayControllerChangeType type, BOOL *stop) {};
-
-  changeset.enumerate(sectionsEnumerator, itemsEnumerator);
-
-  XCTAssertFalse(insertions, @"If there are no insertions, the insertions block should not be called");
-  XCTAssertFalse(removals, @"If there are no removals, the removal block should not be called");
-}
-
 - (void)testEachCommandOfTheSameTypeIsPassedToEnumerationBlocks
 {
-  Sections::Enumerator sectionsEnumerator =
-  ^(NSIndexSet *sectionIndexes, CKArrayControllerChangeType type, BOOL *stop) {
-    if (type == CKArrayControllerChangeTypeInsert) {
-      NSMutableIndexSet *expected = [[NSMutableIndexSet alloc] init];
-      [expected addIndex:0];
-      [expected addIndex:2];
-      XCTAssertEqualObjects(sectionIndexes, expected, @"");
-    }
-    if (type == CKArrayControllerChangeTypeDelete) {
-      NSMutableIndexSet *expected = [[NSMutableIndexSet alloc] init];
-      [expected addIndex:15];
-      [expected addIndex:5];
-      XCTAssertEqualObjects(sectionIndexes, expected, @"");
-    }
-  };
-
-  Input::Items::Enumerator itemsEnumerator =
-  ^(NSInteger section, NSIndexSet *indexes, NSArray *objects, CKArrayControllerChangeType type, BOOL *stop) {
-
-    NSMutableIndexSet *expected = [[NSMutableIndexSet alloc] init];
-
-    if (type == CKArrayControllerChangeTypeInsert) {
-      if (section == 1) {
-        [expected addIndex:5];
-        [expected addIndex:15];
-        XCTAssertEqualObjects(indexes, expected, @"");
-      }
-      if (section == 2) {
-        [expected addIndex:0];
-        [expected addIndex:1];
-        XCTAssertEqualObjects(indexes, expected, @"");
-      }
-    }
-    if (type == CKArrayControllerChangeTypeDelete) {
-      [expected addIndex:8];
-      [expected addIndex:9];
-      XCTAssertEqualObjects(indexes, expected, @"");
-    }
-    if (type == CKArrayControllerChangeTypeUpdate) {
-      [expected addIndex:5];
-      [expected addIndex:6];
-      XCTAssertEqualObjects(indexes, expected, @"");
-    }
-  };
-
   Input::Changeset changeset = exampleInputChangeset();
-  changeset.enumerate(sectionsEnumerator, itemsEnumerator);
+
+  changeset.items.enumerateItems(^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {
+    XCTAssertEqual(section, 6, @"Removal in an unexpected section.");
+    XCTAssert(index == 5 || index == 6, @"Removal at unexpected index path.");
+  }, ^(NSInteger section, NSInteger index, BOOL *stop) {
+    XCTAssertEqual(section, 15, @"Update in an unexpected section.");
+    XCTAssert(index == 8 || index == 9, @"Update at unexpected index path.");
+  }, ^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {
+    if (section == 1) {
+      XCTAssert(index == 5 || index == 15, @"Insertion at unexpected index path.");
+    } else if (section == 2) {
+      XCTAssert(index == 0 || index == 1, @"Insertion at unexpected index path.");
+    } else {
+      XCTFail(@"Insertion in an unexpected section.");
+    }
+  });
 }
 
 - (void)testMapNULLBlock


### PR DESCRIPTION
Another step closer to adding moves.