### PR TITLE
[debug] Explicitly check whether there are any children in layout

### DIFF
--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -72,12 +72,14 @@ static void CKBuildComponentHierarchyDescription(NSMutableArray *result, const C
                      NSStringFromCGPoint(position),
                      NSStringFromCGSize(layout.size)]];
 
-  for (const auto &child : *layout.children) {
-    CKBuildComponentHierarchyDescription(result,
-                                         child.layout,
-                                         child.position,
-                                         [NSString stringWithFormat:@"| %@", prefix]);
-  }
+  if (layout.children) {
+    for (const auto &child : *layout.children) {
+      CKBuildComponentHierarchyDescription(result,
+                                           child.layout,
+                                           child.position,
+                                           [NSString stringWithFormat:@"| %@", prefix]);
+    }
+  } 
 }
 
 @end


### PR DESCRIPTION
While printing the layout tree, it is possible that the layout has not even been generated, in which case `layout.children` will be `nil`. Dereferencing it without checking can cause a crash.