### PR TITLE
[CDS] more preparation for moves

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -199,16 +199,15 @@ static void applyChangesetToCollectionView(const Output::Changeset &changeset, U
   NSMutableArray *itemUpdateIndexPaths = [[NSMutableArray alloc] init];
   Output::Items::Enumerator itemEnumerator =
   ^(const Output::Change &change, CKArrayControllerChangeType type, BOOL *stop) {
-    NSIndexPath *indexPath = change.indexPath.toNSIndexPath();
     switch (type) {
       case CKArrayControllerChangeTypeDelete:
-        [itemRemovalIndexPaths addObject:indexPath];
+        [itemRemovalIndexPaths addObject:change.sourceIndexPath.toNSIndexPath()];
         break;
       case CKArrayControllerChangeTypeInsert:
-        [itemInsertionIndexPaths addObject:indexPath];
+        [itemInsertionIndexPaths addObject:change.destinationIndexPath.toNSIndexPath()];
         break;
       case CKArrayControllerChangeTypeUpdate:
-        [itemUpdateIndexPaths addObject:indexPath];
+        [itemUpdateIndexPaths addObject:change.sourceIndexPath.toNSIndexPath()];
         break;
       default:
         CKCFailAssert(@"Unsupported change type for items: %d", type);

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -254,7 +254,8 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
                                                       constrainedSize:constrainedSize
                                                               oldSize:[before lifecycleManager].size
                                                                  UUID:[after UUID]
-                                                            indexPath:change.indexPath.toNSIndexPath()
+                                                      sourceIndexPath:change.sourceIndexPath.toNSIndexPath()
+                                                 destinationIndexPath:change.destinationIndexPath.toNSIndexPath()
                                                            changeType:type
                                                           passthrough:(componentCompliantModel == nil)
                                                               context:_context];
@@ -307,15 +308,15 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
     CKArrayControllerChangeType type = [outputItem changeType];
     switch (type) {
       case CKArrayControllerChangeTypeUpdate: {
-        items.update([outputItem indexPath], outputItem);
+        items.update([outputItem sourceIndexPath], outputItem);
       }
         break;
       case CKArrayControllerChangeTypeInsert: {
-        items.insert([outputItem indexPath], outputItem);
+        items.insert([outputItem destinationIndexPath], outputItem);
       }
         break;
       case CKArrayControllerChangeTypeDelete: {
-        items.remove([outputItem indexPath]);
+        items.remove([outputItem sourceIndexPath]);
       }
         break;
       default:

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -240,7 +240,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
       batchContainsUpdates = YES;
     }
     if (type == CKArrayControllerChangeTypeInsert) {
-      [insertedIndexPaths addObject:change.indexPath.toNSIndexPath()];
+      [insertedIndexPaths addObject:change.destinationIndexPath.toNSIndexPath()];
     }
 
     CKComponentDataSourceInputItem *before = change.before;

--- a/ComponentKit/DataSources/Common/CKComponentPreparationQueue.h
+++ b/ComponentKit/DataSources/Common/CKComponentPreparationQueue.h
@@ -30,7 +30,9 @@
 
 @property (readonly, nonatomic, copy) NSString *UUID;
 
-@property (readonly, nonatomic, copy) NSIndexPath *indexPath;
+@property (readonly, nonatomic, copy) NSIndexPath *sourceIndexPath;
+
+@property (readonly, nonatomic, copy) NSIndexPath *destinationIndexPath;
 
 @property (readonly, nonatomic, assign) CKArrayControllerChangeType changeType;
 
@@ -49,7 +51,8 @@ CKComponentPreparationItem
                          constrainedSize:(CKSizeRange)constrainedSize
                                  oldSize:(CGSize)oldSize
                                     UUID:(NSString *)UUID
-                               indexPath:(NSIndexPath *)indexPath
+                         sourceIndexPath:(NSIndexPath *)sourceIndexPath
+                    destinationIndexPath:(NSIndexPath *)destinationIndexPath
                               changeType:(CKArrayControllerChangeType)changeType
                              passthrough:(BOOL)passthrough
                                  context:(id<NSObject>)context;
@@ -67,7 +70,8 @@ CKComponentPreparationItem
                    lifecycleManagerState:(CKComponentLifecycleManagerState)lifecycleManagerState
                                  oldSize:(CGSize)oldSize
                                     UUID:(NSString *)UUID
-                               indexPath:(NSIndexPath *)indexPath
+                         sourceIndexPath:(NSIndexPath *)sourceIndexPath
+                    destinationIndexPath:(NSIndexPath *)destinationIndexPath
                               changeType:(CKArrayControllerChangeType)changeType
                              passthrough:(BOOL)passthrough
                                  context:(id<NSObject>)context;

--- a/ComponentKit/DataSources/Common/CKComponentPreparationQueue.mm
+++ b/ComponentKit/DataSources/Common/CKComponentPreparationQueue.mm
@@ -28,7 +28,8 @@
                          constrainedSize:(CKSizeRange)constrainedSize
                                  oldSize:(CGSize)oldSize
                                     UUID:(NSString *)UUID
-                               indexPath:(NSIndexPath *)indexPath
+                         sourceIndexPath:(NSIndexPath *)sourceIndexPath
+                    destinationIndexPath:(NSIndexPath *)destinationIndexPath
                               changeType:(CKArrayControllerChangeType)changeType
                              passthrough:(BOOL)passthrough
                                  context:(id<NSObject>)context
@@ -38,7 +39,8 @@
     _lifecycleManager = lifecycleManager;
     _constrainedSize = constrainedSize;
     _UUID = [UUID copy];
-    _indexPath = [indexPath copy];
+    _sourceIndexPath = [sourceIndexPath copy];
+    _destinationIndexPath = [destinationIndexPath copy];
     _changeType = changeType;
     _passthrough = passthrough;
     _oldSize = oldSize;
@@ -55,7 +57,8 @@
 @synthesize replacementModel = _replacementModel;
 @synthesize lifecycleManager = _lifecycleManager;
 @synthesize UUID = _UUID;
-@synthesize indexPath = _indexPath;
+@synthesize sourceIndexPath = _sourceIndexPath;
+@synthesize destinationIndexPath = _destinationIndexPath;
 @synthesize changeType = _changeType;
 @synthesize passthrough = _passthrough;
 @synthesize oldSize = _oldSize;
@@ -78,7 +81,8 @@
                    lifecycleManagerState:(CKComponentLifecycleManagerState)lifecycleManagerState
                                  oldSize:(CGSize)oldSize
                                     UUID:(NSString *)UUID
-                               indexPath:(NSIndexPath *)indexPath
+                         sourceIndexPath:(NSIndexPath *)sourceIndexPath
+                    destinationIndexPath:(NSIndexPath *)destinationIndexPath
                               changeType:(CKArrayControllerChangeType)changeType
                              passthrough:(BOOL)passthrough
                                  context:(id<NSObject>)context
@@ -88,7 +92,8 @@
     _lifecycleManager = lifecycleManager;
     _lifecycleManagerState = lifecycleManagerState;
     _UUID = [UUID copy];
-    _indexPath = [indexPath copy];
+    _sourceIndexPath = [sourceIndexPath copy];
+    _destinationIndexPath = [destinationIndexPath copy];
     _changeType = changeType;
     _passthrough = passthrough;
     _oldSize = oldSize;
@@ -105,7 +110,8 @@
 @synthesize replacementModel = _replacementModel;
 @synthesize lifecycleManager = _lifecycleManager;
 @synthesize UUID = _UUID;
-@synthesize indexPath = _indexPath;
+@synthesize sourceIndexPath = _sourceIndexPath;
+@synthesize destinationIndexPath = _destinationIndexPath;
 @synthesize changeType = _changeType;
 @synthesize passthrough = _passthrough;
 @synthesize oldSize = _oldSize;
@@ -252,7 +258,8 @@
                                                                 lifecycleManagerState:state
                                                                               oldSize:[inputItem oldSize]
                                                                                  UUID:[inputItem UUID]
-                                                                            indexPath:[inputItem indexPath]
+                                                                      sourceIndexPath:[inputItem sourceIndexPath]
+                                                                 destinationIndexPath:[inputItem destinationIndexPath]
                                                                            changeType:[inputItem changeType]
                                                                           passthrough:[inputItem isPassthrough]
                                                                               context:[inputItem context]];
@@ -262,7 +269,8 @@
                                                                 lifecycleManagerState:CKComponentLifecycleManagerStateEmpty
                                                                               oldSize:[inputItem oldSize]
                                                                                  UUID:[inputItem UUID]
-                                                                            indexPath:[inputItem indexPath]
+                                                                      sourceIndexPath:[inputItem sourceIndexPath]
+                                                                 destinationIndexPath:[inputItem destinationIndexPath]
                                                                            changeType:[inputItem changeType]
                                                                           passthrough:[inputItem isPassthrough]
                                                                               context:[inputItem context]];
@@ -275,7 +283,8 @@
                                                               lifecycleManagerState:CKComponentLifecycleManagerStateEmpty
                                                                             oldSize:[inputItem oldSize]
                                                                                UUID:[inputItem UUID]
-                                                                          indexPath:[inputItem indexPath]
+                                                                    sourceIndexPath:[inputItem sourceIndexPath]
+                                                               destinationIndexPath:[inputItem destinationIndexPath]
                                                                          changeType:[inputItem changeType]
                                                                         passthrough:[inputItem isPassthrough]
                                                                             context:[inputItem context]];

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -207,9 +207,6 @@ namespace CK {
     namespace Output {
 
       struct Change {
-        /** soon to be removed, use sourceIndexPath/destinationIndexPath instead */
-        CKArrayControllerIndexPath indexPath;
-        
         /** Valid for updates and removals. */
         CKArrayControllerIndexPath sourceIndexPath;
         /** Valid for insertions. */
@@ -218,7 +215,7 @@ namespace CK {
         id<NSObject> before;
         id<NSObject> after;
 
-        Change(const CKArrayControllerIndexPath &sIP, const CKArrayControllerIndexPath &dIP, id<NSObject> b, id<NSObject> a) : indexPath((sIP.section != NSNotFound)?sIP:dIP), sourceIndexPath(sIP), destinationIndexPath(dIP), before(b), after(a) {};
+        Change(const CKArrayControllerIndexPath &sIP, const CKArrayControllerIndexPath &dIP, id<NSObject> b, id<NSObject> a) : sourceIndexPath(sIP), destinationIndexPath(dIP), before(b), after(a) {};
 
         bool operator==(const Change &other) const {
           return sourceIndexPath == other.sourceIndexPath && destinationIndexPath == other.destinationIndexPath && CKObjectIsEqual(before, other.before) && CKObjectIsEqual(after, other.after);

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -221,14 +221,6 @@ namespace CK {
           return sourceIndexPath == other.sourceIndexPath && destinationIndexPath == other.destinationIndexPath && CKObjectIsEqual(before, other.before) && CKObjectIsEqual(after, other.after);
         }
 
-        bool operator<(const Change &other) const {
-          if (sourceIndexPath.section != NSNotFound) {
-            return sourceIndexPath < other.sourceIndexPath;
-          } else {
-            return destinationIndexPath < other.destinationIndexPath;
-          }
-        }
-
         NSString *description() const {
           return [NSString stringWithFormat:@"sourceIndexPath: <%zd,%zd>, destinationIndexPath: <%zd,%zd>, before: <%@>, after: <%@>",
                   sourceIndexPath.section, sourceIndexPath.item, destinationIndexPath.section, destinationIndexPath.item, before, after];

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -207,23 +207,36 @@ namespace CK {
     namespace Output {
 
       struct Change {
+        /** soon to be removed, use sourceIndexPath/destinationIndexPath instead */
         CKArrayControllerIndexPath indexPath;
+        
+        /** Valid for updates and removals. */
+        CKArrayControllerIndexPath sourceIndexPath;
+        /** Valid for insertions. */
+        CKArrayControllerIndexPath destinationIndexPath;
+
         id<NSObject> before;
         id<NSObject> after;
 
-        Change(const CKArrayControllerIndexPath &iP, id<NSObject> b, id<NSObject> a) : indexPath(iP), before(b), after(a) {};
+        Change(const CKArrayControllerIndexPath &sIP, const CKArrayControllerIndexPath &dIP, id<NSObject> b, id<NSObject> a) : indexPath((sIP.section != NSNotFound)?sIP:dIP), sourceIndexPath(sIP), destinationIndexPath(dIP), before(b), after(a) {};
 
         bool operator==(const Change &other) const {
-          return indexPath == other.indexPath && CKObjectIsEqual(before, other.before) && CKObjectIsEqual(after, other.after);
+          return sourceIndexPath == other.sourceIndexPath && destinationIndexPath == other.destinationIndexPath && CKObjectIsEqual(before, other.before) && CKObjectIsEqual(after, other.after);
         }
 
         bool operator<(const Change &other) const {
-          return indexPath < other.indexPath;
+          if (sourceIndexPath.section != NSNotFound) {
+            return sourceIndexPath < other.sourceIndexPath;
+          } else {
+            return destinationIndexPath < other.destinationIndexPath;
+          }
         }
 
         NSString *description() const {
-          return [NSString stringWithFormat:@"indexPath: <%zd,%zd>, before: <%@>, after: <%@>", indexPath.section, indexPath.item, before, after];
+          return [NSString stringWithFormat:@"sourceIndexPath: <%zd,%zd>, destinationIndexPath: <%zd,%zd>, before: <%@>, after: <%@>",
+                  sourceIndexPath.section, sourceIndexPath.item, destinationIndexPath.section, destinationIndexPath.item, before, after];
         }
+
       };
     }
   }

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -239,7 +239,7 @@ namespace CK {
 
       class Items final {
       public:
-        void update(const CKArrayControllerOutputChange &update);
+        void update(const CKArrayControllerIndexPath &indexPath, id<NSObject> oldObject, id<NSObject> newObject);
         /**
          Note that we pass the removed object here, too. In doing so we can inform clients of what was removed as a
          result of an Input::Changeset

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.mm
@@ -290,9 +290,9 @@ void Output::Items::remove(const CKArrayControllerIndexPath &indexPath, id<NSObj
   _removals.push_back({indexPath, object, nil});
 }
 
-void Output::Items::update(const Change &update)
+void Output::Items::update(const CKArrayControllerIndexPath &indexPath, id<NSObject> oldObject, id<NSObject> newObject)
 {
-  _updates.push_back(update);
+  _updates.push_back({indexPath, oldObject, newObject});
 }
 
 bool Output::Items::operator==(const Items &other) const
@@ -382,7 +382,7 @@ Output::Changeset Output::Changeset::map(Mapper mapper) const
       _validateBeforeAfterPair(mappedPair, change.indexPath, t);
 
       if (t == CKArrayControllerChangeTypeUpdate) {
-        mappedItems.update({change.indexPath, mappedPair.first, mappedPair.second});
+        mappedItems.update(change.indexPath, mappedPair.first, mappedPair.second);
       }
       if (t == CKArrayControllerChangeTypeDelete) {
         mappedItems.remove(change.indexPath, mappedPair.first);

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.mm
@@ -282,17 +282,17 @@ bool Input::Changeset::operator==(const Changeset &other) const
 
 void Output::Items::insert(const CKArrayControllerIndexPath &indexPath, id<NSObject> object)
 {
-  _insertions.push_back({indexPath, nil, object});
+  _insertions.push_back({{}, indexPath, nil, object});
 }
 
 void Output::Items::remove(const CKArrayControllerIndexPath &indexPath, id<NSObject> object)
 {
-  _removals.push_back({indexPath, object, nil});
+  _removals.push_back({indexPath, {}, object, nil});
 }
 
 void Output::Items::update(const CKArrayControllerIndexPath &indexPath, id<NSObject> oldObject, id<NSObject> newObject)
 {
-  _updates.push_back({indexPath, oldObject, newObject});
+  _updates.push_back({indexPath, {}, oldObject, newObject});
 }
 
 bool Output::Items::operator==(const Items &other) const
@@ -348,20 +348,26 @@ void Output::Changeset::enumerate(Sections::Enumerator sectionEnumerator,
 }
 
 /**
- Clients of Output::Changeset::map() may reuturn invalid pairs. For example {nil, <object>} for a deletion, instead of
+ Clients of Output::Changeset::map() may return invalid pairs. For example {nil, <object>} for a deletion, instead of
  {<object>, nil}.
  */
-NS_INLINE void _validateBeforeAfterPair(Output::Changeset::BeforeAfterPair pair, IndexPath indexPath, CKArrayControllerChangeType changeType)
+NS_INLINE void _validateBeforeAfterPair(Output::Changeset::BeforeAfterPair pair, IndexPath sourceIndexPath, IndexPath destinationIndexPath, CKArrayControllerChangeType changeType)
 {
   if (changeType == CKArrayControllerChangeTypeUpdate) {
-    CKInternalConsistencyCheckIf(pair.first != nil, ([NSString stringWithFormat:@"update {%zd, %zd}: before MUST NOT be nil.", indexPath.item, indexPath.section]));
-    CKInternalConsistencyCheckIf(pair.second != nil, ([NSString stringWithFormat:@"update {%zd, %zd}: after MUST NOT be nil.", indexPath.item, indexPath.section]));
+    CKInternalConsistencyCheckIf(pair.first != nil, ([NSString stringWithFormat:@"update {%zd, %zd}: before MUST NOT be nil.", sourceIndexPath.item, sourceIndexPath.section]));
+    CKInternalConsistencyCheckIf(pair.second != nil, ([NSString stringWithFormat:@"update {%zd, %zd}: after MUST NOT be nil.", sourceIndexPath.item, sourceIndexPath.section]));
+    CKInternalConsistencyCheckIf(!(sourceIndexPath == IndexPath(NSNotFound, NSNotFound)), ([NSString stringWithFormat:@"update MUST have sourceIndexPath"]));
+    CKInternalConsistencyCheckIf((destinationIndexPath == IndexPath(NSNotFound, NSNotFound)), ([NSString stringWithFormat:@"update MUST NOT have destinationIndexPath"]));
   } else if (changeType == CKArrayControllerChangeTypeDelete) {
-    CKInternalConsistencyCheckIf(pair.first != nil, ([NSString stringWithFormat:@"remove {%zd, %zd}: before MUST NOT be nil.", indexPath.item, indexPath.section]));
-    CKInternalConsistencyCheckIf(pair.second == nil, ([NSString stringWithFormat:@"remove {%zd, %zd}: after MUST be nil.", indexPath.item, indexPath.section]));
+    CKInternalConsistencyCheckIf(pair.first != nil, ([NSString stringWithFormat:@"remove {%zd, %zd}: before MUST NOT be nil.", sourceIndexPath.item, sourceIndexPath.section]));
+    CKInternalConsistencyCheckIf(pair.second == nil, ([NSString stringWithFormat:@"remove {%zd, %zd}: after MUST be nil.", sourceIndexPath.item, sourceIndexPath.section]));
+    CKInternalConsistencyCheckIf(!(sourceIndexPath == IndexPath(NSNotFound, NSNotFound)), ([NSString stringWithFormat:@"remove MUST have sourceIndexPath"]));
+    CKInternalConsistencyCheckIf((destinationIndexPath == IndexPath(NSNotFound, NSNotFound)), ([NSString stringWithFormat:@"remove MUST NOT have destinationIndexPath"]));
   } else if (changeType == CKArrayControllerChangeTypeInsert) {
-    CKInternalConsistencyCheckIf(pair.first == nil, ([NSString stringWithFormat:@"insert {%zd, %zd}: before MUST be nil.", indexPath.item, indexPath.section]));
-    CKInternalConsistencyCheckIf(pair.second != nil, ([NSString stringWithFormat:@"insert {%zd, %zd}: after MUST NOT be nil.", indexPath.item, indexPath.section]));
+    CKInternalConsistencyCheckIf(pair.first == nil, ([NSString stringWithFormat:@"insert {%zd, %zd}: before MUST be nil.", destinationIndexPath.item, destinationIndexPath.section]));
+    CKInternalConsistencyCheckIf(pair.second != nil, ([NSString stringWithFormat:@"insert {%zd, %zd}: after MUST NOT be nil.", destinationIndexPath.item, destinationIndexPath.section]));
+    CKInternalConsistencyCheckIf((sourceIndexPath == IndexPath(NSNotFound, NSNotFound)), ([NSString stringWithFormat:@"insert MUST NOT have sourceIndexPath"]));
+    CKInternalConsistencyCheckIf(!(destinationIndexPath == IndexPath(NSNotFound, NSNotFound)), ([NSString stringWithFormat:@"insert MUST have destinationIndexPath"]));
   }
 }
 
@@ -379,16 +385,16 @@ Output::Changeset Output::Changeset::map(Mapper mapper) const
     for (const auto &change : changes) {
       auto mappedPair = mapper(change, t, &stop);
 
-      _validateBeforeAfterPair(mappedPair, change.indexPath, t);
+      _validateBeforeAfterPair(mappedPair, change.sourceIndexPath, change.destinationIndexPath, t);
 
       if (t == CKArrayControllerChangeTypeUpdate) {
-        mappedItems.update(change.indexPath, mappedPair.first, mappedPair.second);
+        mappedItems.update(change.sourceIndexPath, mappedPair.first, mappedPair.second);
       }
       if (t == CKArrayControllerChangeTypeDelete) {
-        mappedItems.remove(change.indexPath, mappedPair.first);
+        mappedItems.remove(change.sourceIndexPath, mappedPair.first);
       }
       if (t == CKArrayControllerChangeTypeInsert) {
-        mappedItems.insert(change.indexPath, mappedPair.second);
+        mappedItems.insert(change.destinationIndexPath, mappedPair.second);
       }
       if (stop) {
         break;

--- a/ComponentKit/Utilities/CKSectionedArrayController.mm
+++ b/ComponentKit/Utilities/CKSectionedArrayController.mm
@@ -137,11 +137,11 @@ NS_INLINE NSArray *_createEmptySections(NSUInteger count)
 
   { // 1. item updates
     changeset.items.enumerateItems(^(NSInteger section, NSInteger index, id<NSObject> object, BOOL *stop) {
-      outputItems.update({
+      outputItems.update(
         {section, index},
         _sections[section][index],
         object
-      });
+      );
       [_sections[section] replaceObjectAtIndex:index withObject:object];
     }, nil, nil);
   }

--- a/ComponentKitTests/CKArrayControllerChangesetTests.mm
+++ b/ComponentKitTests/CKArrayControllerChangesetTests.mm
@@ -402,10 +402,10 @@ static Output::Changeset exampleOutputChangeset(void)
   items.remove({15, 9}, @5);
   items.remove({16, 4}, @6);
   items.remove({16, 5}, @7);
-  items.update({{7, 6}, @8, @9});
-  items.update({{7, 5}, @8, @9});
-  items.update({{6, 3}, @8, @9});
-  items.update({{6, 4}, @8, @9});
+  items.update({7, 6}, @8, @9);
+  items.update({7, 5}, @8, @9);
+  items.update({6, 3}, @8, @9);
+  items.update({6, 4}, @8, @9);
 
   return {sections, items};
 }
@@ -661,10 +661,10 @@ static Output::Changeset exampleOutputChangeset(void)
   expectedItems.remove({15, 9}, @6);
   expectedItems.remove({16, 4}, @7);
   expectedItems.remove({16, 5}, @8);
-  expectedItems.update({{7, 6}, @9, @10});
-  expectedItems.update({{7, 5}, @9, @10});
-  expectedItems.update({{6, 3}, @9, @10});
-  expectedItems.update({{6, 4}, @9, @10});
+  expectedItems.update({7, 6}, @9, @10);
+  expectedItems.update({7, 5}, @9, @10);
+  expectedItems.update({6, 3}, @9, @10);
+  expectedItems.update({6, 4}, @9, @10);
 
   Output::Changeset expected = {expectedSections, expectedItems};
 

--- a/ComponentKitTests/CKArrayControllerChangesetTests.mm
+++ b/ComponentKitTests/CKArrayControllerChangesetTests.mm
@@ -497,24 +497,24 @@ static Output::Changeset exampleOutputChangeset(void)
   changeset.enumerate(sectionsEnumerator, itemsEnumerator);
 
   std::set<Output::Change> expectedInsertions = {
-    {{0, 0}, nil, @1},
-    {{0, 1}, nil, @0},
-    {{2, 0}, nil, @2},
-    {{2, 1}, nil, @3}
+    {{}, {0, 0}, nil, @1},
+    {{}, {0, 1}, nil, @0},
+    {{}, {2, 0}, nil, @2},
+    {{}, {2, 1}, nil, @3}
   };
 
   std::set<Output::Change> expectedRemovals = {
-    {{15, 9}, @5, nil},
-    {{15, 10}, @4, nil},
-    {{16, 4}, @6, nil},
-    {{16, 5}, @7, nil}
+    {{15, 9}, {}, @5, nil},
+    {{15, 10}, {}, @4, nil},
+    {{16, 4}, {}, @6, nil},
+    {{16, 5}, {}, @7, nil}
   };
 
   std::set<Output::Change> expectedUpdates = {
-    {{7, 5}, @8, @9},
-    {{7, 6}, @8, @9},
-    {{6, 3}, @8, @9},
-    {{6, 4}, @8, @9}
+    {{7, 5}, {}, @8, @9},
+    {{7, 6}, {}, @8, @9},
+    {{6, 3}, {}, @8, @9},
+    {{6, 4}, {}, @8, @9}
   };
 
   XCTAssertTrue(insertions == expectedInsertions, @"");

--- a/ComponentKitTests/CKComponentDataSourceTestDelegate.h
+++ b/ComponentKitTests/CKComponentDataSourceTestDelegate.h
@@ -29,7 +29,7 @@
 @property (nonatomic, strong) CKComponentDataSourceOutputItem *dataSourcePair;
 @property (nonatomic, strong) CKComponentDataSourceOutputItem *oldDataSourcePair;
 @property (nonatomic, assign) CKArrayControllerChangeType changeType;
-@property (nonatomic, strong) NSIndexPath *beforeIndexPath;
-@property (nonatomic, strong) NSIndexPath *afterIndexPath;
+@property (nonatomic, strong) NSIndexPath *sourceIndexPath;
+@property (nonatomic, strong) NSIndexPath *destinationIndexPath;
 
 @end

--- a/ComponentKitTests/CKComponentDataSourceTestDelegate.mm
+++ b/ComponentKitTests/CKComponentDataSourceTestDelegate.mm
@@ -25,8 +25,8 @@ using namespace CK::ArrayController;
             CKObjectIsEqual(change.dataSourcePair, changeToCompare.dataSourcePair) &&
             CKObjectIsEqual(change.oldDataSourcePair, changeToCompare.oldDataSourcePair) &&
             change.changeType == changeToCompare.changeType &&
-            CKObjectIsEqual(change.beforeIndexPath, changeToCompare.beforeIndexPath) &&
-            CKObjectIsEqual(change.afterIndexPath, changeToCompare.afterIndexPath)
+            CKObjectIsEqual(change.sourceIndexPath, changeToCompare.sourceIndexPath) &&
+            CKObjectIsEqual(change.destinationIndexPath, changeToCompare.destinationIndexPath)
     );
   });
 }
@@ -72,8 +72,8 @@ using namespace CK::ArrayController;
     CKComponentDataSourceTestDelegateChange *delegateChange = [[CKComponentDataSourceTestDelegateChange alloc] init];
     delegateChange.dataSourcePair = change.after;
     delegateChange.oldDataSourcePair = change.before;
-    delegateChange.beforeIndexPath = (type == CKArrayControllerChangeTypeInsert) ? nil : change.indexPath.toNSIndexPath();
-    delegateChange.afterIndexPath = (type == CKArrayControllerChangeTypeDelete) ? nil : change.indexPath.toNSIndexPath();
+    delegateChange.sourceIndexPath = change.sourceIndexPath.toNSIndexPath();
+    delegateChange.destinationIndexPath = change.destinationIndexPath.toNSIndexPath();
     delegateChange.changeType = type;
     [_changes addObject:delegateChange];
 

--- a/ComponentKitTests/CKComponentDataSourceTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceTests.mm
@@ -1145,8 +1145,7 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
   
   for (CKComponentDataSourceTestDelegateChange *change in [_delegate changes]) {
     XCTAssertEqual(change.changeType, CKArrayControllerChangeTypeUpdate);
-    XCTAssertEqualObjects(change.afterIndexPath, change.beforeIndexPath);
-    XCTAssertEqualObjects(change.dataSourcePair, capturedState[change.afterIndexPath]);
+    XCTAssertEqualObjects(change.dataSourcePair, capturedState[change.sourceIndexPath]);
   }
   XCTAssertEqual([[_delegate changes] count], [capturedState count]);
 }

--- a/ComponentKitTests/CKComponentPreparationQueueAsyncTests.mm
+++ b/ComponentKitTests/CKComponentPreparationQueueAsyncTests.mm
@@ -27,7 +27,8 @@ static CKComponentPreparationInputItem *fbcpq_passthroughInputItem(NSString *UUI
                                                            constrainedSize:CKSizeRange()
                                                                    oldSize:{0, 0}
                                                                       UUID:UUID
-                                                                 indexPath:nil
+                                                           sourceIndexPath:nil
+                                                      destinationIndexPath:nil
                                                                 changeType:CKArrayControllerChangeTypeUnknown
                                                                passthrough:YES
                                                                    context:nil];

--- a/ComponentKitTests/CKComponentPreparationQueueTests.mm
+++ b/ComponentKitTests/CKComponentPreparationQueueTests.mm
@@ -84,7 +84,8 @@ static CKComponent *(^_componentBlock)(void);
                                                                                              constrainedSize:{{0,0}, {10, 20}}
                                                                                                      oldSize:{320, 100}
                                                                                                         UUID:@"foo"
-                                                                                                   indexPath:indexPath
+                                                                                             sourceIndexPath:nil
+                                                                                        destinationIndexPath:indexPath
                                                                                                   changeType:changeType
                                                                                                  passthrough:NO
                                                                                                      context:nil];
@@ -93,7 +94,8 @@ static CKComponent *(^_componentBlock)(void);
 
   XCTAssertNotNil(output);
   XCTAssertEqual([output changeType], changeType);
-  XCTAssertEqualObjects([output indexPath], indexPath);
+  XCTAssertEqualObjects([output sourceIndexPath], nil);
+  XCTAssertEqualObjects([output destinationIndexPath], indexPath);
   XCTAssertEqualObjects([output UUID], [input UUID]);
   XCTAssertTrue(CGSizeEqualToSize([input oldSize], [output oldSize]));
 
@@ -122,7 +124,8 @@ static CKComponent *(^_componentBlock)(void);
                                                                                              constrainedSize:{{0,0}, {10, 20}}
                                                                                                      oldSize:{320, 100}
                                                                                                         UUID:@"foo"
-                                                                                                   indexPath:indexPath
+                                                                                             sourceIndexPath:indexPath
+                                                                                        destinationIndexPath:nil
                                                                                                   changeType:changeType
                                                                                                  passthrough:NO
                                                                                                      context:nil];
@@ -131,7 +134,8 @@ static CKComponent *(^_componentBlock)(void);
 
   XCTAssertNotNil(output);
   XCTAssertEqual([output changeType], changeType);
-  XCTAssertEqualObjects([output indexPath], indexPath);
+  XCTAssertEqualObjects([output sourceIndexPath], indexPath);
+  XCTAssertEqualObjects([output destinationIndexPath], nil);
   XCTAssertEqualObjects([output UUID], [input UUID]);
   XCTAssertTrue(CGSizeEqualToSize([input oldSize], [output oldSize]));
 
@@ -159,7 +163,8 @@ static CKComponent *(^_componentBlock)(void);
                                                                                              constrainedSize:{{0,0}, {10, 20}}
                                                                                                      oldSize:{320, 100}
                                                                                                         UUID:@"foo"
-                                                                                                   indexPath:indexPath
+                                                                                             sourceIndexPath:indexPath
+                                                                                        destinationIndexPath:nil
                                                                                                   changeType:changeType
                                                                                                  passthrough:NO
                                                                                                      context:nil];
@@ -169,7 +174,8 @@ static CKComponent *(^_componentBlock)(void);
   XCTAssertNotNil(output);
   XCTAssertNil([output lifecycleManager]);
   XCTAssertEqual([output changeType], changeType);
-  XCTAssertEqualObjects([output indexPath], indexPath);
+  XCTAssertEqualObjects([output sourceIndexPath], indexPath);
+  XCTAssertEqualObjects([output destinationIndexPath], nil);
   XCTAssertEqualObjects([output UUID], [input UUID]);
   XCTAssertTrue(CGSizeEqualToSize([input oldSize], [output oldSize]));
 
@@ -199,7 +205,8 @@ static CKComponent *(^_componentBlock)(void);
                                                                                              constrainedSize:{{0,0}, {10, 20}}
                                                                                                      oldSize:{320, 100}
                                                                                                         UUID:@"foo"
-                                                                                                   indexPath:indexPath
+                                                                                             sourceIndexPath:nil
+                                                                                        destinationIndexPath:indexPath
                                                                                                   changeType:changeType
                                                                                                  passthrough:YES
                                                                                                      context:nil];
@@ -208,7 +215,8 @@ static CKComponent *(^_componentBlock)(void);
 
   XCTAssertNotNil(output);
   XCTAssertEqual([output changeType], changeType);
-  XCTAssertEqualObjects([output indexPath], indexPath);
+  XCTAssertEqualObjects([output sourceIndexPath], nil);
+  XCTAssertEqualObjects([output destinationIndexPath], indexPath);
   XCTAssertEqualObjects(output.replacementModel, input.replacementModel);
   XCTAssertEqualObjects([output UUID], [input UUID]);
   XCTAssertTrue(CGSizeEqualToSize([input oldSize], [output oldSize]));

--- a/ComponentKitTests/CKSectionedArrayControllerTests.mm
+++ b/ComponentKitTests/CKSectionedArrayControllerTests.mm
@@ -412,7 +412,7 @@ using namespace CK::ArrayController;
   XCTAssertEqual([_controller numberOfObjectsInSection:0], 1, @"");
 
   Output::Items expectedItems;
-  expectedItems.update({{0, 0}, @0, @1});
+  expectedItems.update({0, 0}, @0, @1);
   Output::Changeset expected = {{}, expectedItems};
 
   XCTAssertTrue(output == expected, @"");


### PR DESCRIPTION
New updates in `CKArrayControllerOutputItems` are no longer specified as `CKArrayControllerOutputChange`, but only as a minimal set of values which specify update command. 
Extends `CKArrayControllerOutputChange` and `CKComponentPreparationItem` to work with two indexPaths.