### PR TITLE
Add a view attribute to send a delegate protocol to components

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0C293C2FE4684CADAB27CA9D /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		31EBF255C3C6127E5A3619D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		83EBF589FB5C5611BC1A2D13 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
+		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
 		A2100E0D1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */; };
 		A22FE3031AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */; };
 		A22FE3061AF2CF0C00EC30B8 /* CKStateExposingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22FE3051AF2CF0C00EC30B8 /* CKStateExposingComponent.mm */; };
@@ -87,6 +88,7 @@
 
 /* Begin PBXFileReference section */
 		71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
 		A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm; sourceTree = "<group>"; };
 		A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateUpdateTests.mm; sourceTree = "<group>"; };
 		A22FE3041AF2CF0C00EC30B8 /* CKStateExposingComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKStateExposingComponent.h; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 				B342DC5E1AC23EA900ACAC53 /* CKComponentViewContextTests.mm */,
 				B342DC5F1AC23EA900ACAC53 /* CKComponentViewManagerTests.mm */,
 				B342DC601AC23EA900ACAC53 /* CKComponentViewReuseTests.mm */,
+				994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */,
 				B342DC611AC23EA900ACAC53 /* CKDimensionTests.mm */,
 				B342DC621AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm */,
 				B342DC631AC23EA900ACAC53 /* CKSectionedArrayControllerTests.mm */,
@@ -656,6 +659,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B342DC771AC23EA900ACAC53 /* CKComponentMountContextLayoutGuideTests.mm in Sources */,
+				994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */,
 				B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */,
 				B342DC811AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm in Sources */,
 				A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */,

--- a/ComponentKit/Utilities/CKComponentDelegateAttribute.h
+++ b/ComponentKit/Utilities/CKComponentDelegateAttribute.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <ComponentKit/CKComponentAction.h>
+#import <vector>
+
+/** It's necessary to specify a list of selectors your delegate will implement, because we have to answer the question "respondsToSelector:" without access to the responder chain, since it's is frequently cached as an optimization in objects with delegates. */
+
+using CKComponentDelegateAttributeDefinition = std::vector<SEL>;
+
+/**
+ Returns a view attribute that proxies the delegate onto the component responder chain.
+ You must handle the method in the component for which this is an attribute, or an ancestor,
+ or an assertion will fire (since there is no sensible default for a delegate method to return).
+ 
+ Usage:
+
+ [CKComponent
+ newWithView:{[UIScrollView class], {
+   CKComponentDelegateAttribute(@selector(setDelegate:), {
+   @selector(scrollViewDidScroll:),
+   @selector(scrollViewDidZoom:),
+   })
+ }}
+ size:{}] ...
+ 
+ Then you can implement -scrollViewDidScroll: in your composite component, that potentially has a number of intervening components before the scroll component.
+
+ */
+CKComponentViewAttributeValue CKComponentDelegateAttribute(SEL selector,
+                                                           CKComponentDelegateAttributeDefinition definition);

--- a/ComponentKit/Utilities/CKComponentDelegateAttribute.mm
+++ b/ComponentKit/Utilities/CKComponentDelegateAttribute.mm
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKComponentDelegateAttribute.h"
+
+#import <vector>
+#import <objc/runtime.h>
+
+#import "CKAssert.h"
+#import "CKComponentViewInterface.h"
+#import "CKComponentSubclass.h"
+
+std::string identifierFromDefinition(const CKComponentDelegateAttributeDefinition& first)
+{
+  std::string so = "Delegate";
+  for (auto& s : first) {
+    so = so + "-" + sel_getName(s);
+  }
+  return so;
+}
+
+@interface CKComponentDelegateForwarder : NSObject {
+  @package
+  // Weak ref to our view, to grab the component.
+  __weak UIView *_view;
+  CKComponentDelegateAttributeDefinition _defn;
+}
+
+@end
+
+@interface UIView (CKDelegateProxy)
+
+@property (nonatomic, strong, setter=ck_setDelegateProxy:) CKComponentDelegateForwarder *ck_delegateProxy;
+
+@end
+
+CKComponentViewAttributeValue CKComponentDelegateAttribute(SEL selector,
+                                                           CKComponentDelegateAttributeDefinition definition)
+{
+  if (selector == NULL) {
+    return {
+      {
+        std::string("Delegate-noop-") + sel_getName(selector) + "-",
+        ^(UIView *view, id value) {}, ^(UIView *view, id value) {}
+      },
+      @YES  // Bogus value, we don't use it.
+    };
+  }
+
+  return {
+    {
+      std::string(sel_getName(selector)) + identifierFromDefinition(definition),
+      ^(UIView *view, id value){
+
+        // Create a proxy for this set of selectors
+
+        CKCAssertNil(view.ck_delegateProxy,
+                     @"Unsupported: registered two delegate proxies for the same view: %@ %@", view, view.ck_delegateProxy);
+
+        CKComponentDelegateForwarder *proxy = [[CKComponentDelegateForwarder alloc] init];
+        proxy->_view = view;
+        proxy->_defn = definition;
+        view.ck_delegateProxy = proxy;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [view performSelector:selector withObject:proxy];
+#pragma clang diagnostic pop
+
+      },
+      ^(UIView *view, id value){
+
+        // When unapplied, remove association with the view
+        CKComponentDelegateForwarder *proxy = view.ck_delegateProxy;
+        proxy->_view = nil;
+        view.ck_delegateProxy = nil;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [view performSelector:selector withObject:nil];
+#pragma clang diagnostic pop
+
+      }
+    },
+    @YES // Bogus value, we don't use it.
+  };
+}
+
+@implementation CKComponentDelegateForwarder : NSObject
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+  if ([super respondsToSelector:aSelector]) {
+    return YES;
+  } else {
+    return std::find(_defn.begin(), _defn.end(), aSelector) != std::end(_defn);
+  }
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  CKComponent *responder = _view.ck_component;
+  return [responder targetForAction:aSelector withSender:responder];
+}
+
+@end
+
+
+@implementation UIView (CKDelegateProxy)
+
+static const char kCKComponentDelegateProxyKey = ' ';
+
+- (CKComponentDelegateForwarder *)ck_delegateProxy
+{
+  return objc_getAssociatedObject(self, &kCKComponentDelegateProxyKey);
+}
+
+- (void)ck_setDelegateProxy:(CKComponentDelegateForwarder *)delegateProxy
+{
+  objc_setAssociatedObject(self, &kCKComponentDelegateProxyKey, delegateProxy, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end

--- a/ComponentKitTests/CKComponentDelegateAttributeTests.mm
+++ b/ComponentKitTests/CKComponentDelegateAttributeTests.mm
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import "CKCompositeComponent.h"
+#import "CKComponent.h"
+#import "CKComponentDelegateAttribute.h"
+#import "CKComponentViewInterface.h"
+#import "CKComponentLayout.h"
+#import "CKComponentSubclass.h"
+#import "CKComponentInternal.h"
+
+
+@interface CKDetectScrollComponent : CKCompositeComponent <UIScrollViewDelegate>
+@property (nonatomic, assign) BOOL receivedScroll;
+@end
+
+@interface CKComponentGestureActionsTests : XCTestCase
+@end
+
+@interface CKComponentDelegateAttributeTests : XCTestCase
+@end
+
+@implementation CKComponentDelegateAttributeTests
+
+- (void)testApplicationApplies
+{
+  CKComponentViewAttributeValue attr = CKComponentDelegateAttribute(@selector(setDelegate:), {
+    @selector(scrollViewDidScroll:)
+  });
+
+  UIScrollView *scrollView = [[UIScrollView alloc] init];
+
+  attr.first.applicator(scrollView, attr.second);
+  XCTAssertNotNil(scrollView.delegate, @"Expected delegate to be set");
+
+  attr.first.unapplicator(scrollView, attr.second);
+  XCTAssertNil(scrollView.delegate, @"Expected delegate to be unset");
+}
+
+static UIScrollView *findScrollView(UIView *v)
+{
+  if ([v isKindOfClass:[UIScrollView class]]) {
+    return (UIScrollView *)v;
+  } else {
+    for (UIView *sub in v.subviews) {
+      return findScrollView(sub);
+    }
+  }
+  return nil;
+};
+
+
+- (void)testProxiedEventsProxy
+{
+  CKDetectScrollComponent *hierarchy =
+  [CKDetectScrollComponent
+   newWithComponent:[CKComponent
+   newWithView:{[UIScrollView class],
+     {CKComponentDelegateAttribute(@selector(setDelegate:), {
+       @selector(scrollViewDidScroll:),
+     })}}
+   size:{}]];
+
+
+  CKComponentLayout layout = [hierarchy layoutThatFits:{} parentSize:{NAN, NAN}];
+
+  UIView *container = [UIView new];
+  NSSet *mounted = CKMountComponentLayout(layout, container);
+
+  XCTAssertFalse(hierarchy.receivedScroll, @"Should not have triggered yet");
+
+  UIScrollView *scroll = findScrollView(container);
+
+  scroll.contentOffset = CGPointMake(0, 100);
+
+  XCTAssertTrue(hierarchy.receivedScroll, @"Should have recived scroll event");
+
+  // Temporary hack because there's not a good way to unmount components. An assert fires otherwise.
+  // TODO: CKComponentUnmount(mounted);
+  [mounted makeObjectsPerformSelector:@selector(unmount)];
+
+  CKDetectScrollComponent *noScrollHierarchy =
+  [CKDetectScrollComponent
+   newWithComponent:[CKComponent
+                     newWithView:{[UIScrollView class],
+                       {CKComponentDelegateAttribute(@selector(setDelegate:), {})}}
+                     size:{}]];
+
+  layout = [noScrollHierarchy layoutThatFits:{} parentSize:{NAN, NAN}];
+
+  CKMountComponentLayout(layout, container);
+
+  XCTAssertFalse(noScrollHierarchy.receivedScroll, @"Should not have triggered yet");
+  hierarchy.receivedScroll = NO;
+
+  scroll.contentOffset = CGPointMake(0, 100);
+
+  XCTAssertFalse(noScrollHierarchy.receivedScroll, @"Should not have triggered because we don't want scroll events.");
+  XCTAssertFalse(hierarchy.receivedScroll, @"Should not have triggered on old hierarchy either.");
+
+}
+
+@end
+
+
+@implementation CKDetectScrollComponent
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+  _receivedScroll = YES;
+}
+
+ @end


### PR DESCRIPTION
Purpose:

Avoid always needing to have a controller just because you need events from a view. This goes along with the `CKComponentActionAttribute` where you can get events from `UIControl`s sent up to your component or controller subclass.

I could see this being used to allow editing of UITextFields with some work  #222); the obvious uses are scroll views for gestures, etc. that I take advantage of with the combiners example.

Test plan:

I've tried to write some basic unit tests, but I'm interested in hearing what cases are interesting / things that I've missed.

Limitations:

- only allows one delegate to be set per view (can't think of a situation where this is an issue)
- uses associated objects