### PR TITLE
Allow proxying gesture recognizers' delegates to the component

### DIFF
--- a/ComponentKit/Utilities/CKComponentDelegateAttribute.h
+++ b/ComponentKit/Utilities/CKComponentDelegateAttribute.h
@@ -13,9 +13,7 @@
 #import <ComponentKit/CKComponentAction.h>
 #import <vector>
 
-/** It's necessary to specify a list of selectors your delegate will implement, because we have to answer the question "respondsToSelector:" without access to the responder chain, since it's is frequently cached as an optimization in objects with delegates. */
-
-using CKComponentDelegateAttributeDefinition = std::vector<SEL>;
+#import <ComponentKit/CKComponentDelegateForwarder.h>
 
 /**
  Returns a view attribute that proxies the delegate onto the component responder chain.
@@ -36,5 +34,5 @@ using CKComponentDelegateAttributeDefinition = std::vector<SEL>;
  Then you can implement -scrollViewDidScroll: in your composite component, that potentially has a number of intervening components before the scroll component.
 
  */
-CKComponentViewAttributeValue CKComponentDelegateAttribute(SEL selector,
-                                                           CKComponentDelegateAttributeDefinition definition);
+CKComponentViewAttributeValue CKComponentDelegateAttribute(SEL delegatePropertySelector,
+                                                           CKComponentForwardedSelectors selectors);

--- a/ComponentKit/Utilities/CKComponentDelegateForwarder.h
+++ b/ComponentKit/Utilities/CKComponentDelegateForwarder.h
@@ -22,16 +22,19 @@ std::string CKIdentifierFromDelegateForwarderSelectors(const CKComponentForwarde
 
 
 /**
- This is intended for ComponentKit internal use only. This will make an object that forwards
+ This class is intended for ComponentKit internal use only.
  */
 @interface CKComponentDelegateForwarder : NSObject
 
+/**
+ This initializer will make an object that forwards calls to the given selectors on to the component, and its nextResponder, etc.
+ */
 + (instancetype)newWithSelectors:(CKComponentForwardedSelectors)selectors;
 
 /**
  The view is used to find out where to start looking in the component responder chain.
 
- The forwarder will call [view.ck_component targetForAction: withSender:] to proxy to the responder chain, so this needs to be accurate.
+ The forwarder will call [view.ck_component targetForAction: withSender:] to proxy to the responder chain, so this needs to be accurate when you mount/unmount.
  */
 @property (nonatomic, weak) UIView *view;
 

--- a/ComponentKit/Utilities/CKComponentDelegateForwarder.h
+++ b/ComponentKit/Utilities/CKComponentDelegateForwarder.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <ComponentKit/CKComponentAction.h>
+#import <vector>
+
+
+/** It's necessary to specify a list of selectors your delegate will implement, because we have to answer the question "respondsToSelector:" without access to the responder chain, since it's is frequently cached as an optimization in objects with delegates. */
+
+using CKComponentForwardedSelectors = std::vector<SEL>;
+
+std::string CKIdentifierFromDelegateForwarderSelectors(const CKComponentForwardedSelectors& first);
+
+
+/**
+ This is intended for ComponentKit internal use only. This will make an object that forwards
+ */
+@interface CKComponentDelegateForwarder : NSObject
+
++ (instancetype)newWithSelectors:(CKComponentForwardedSelectors)selectors;
+
+/**
+ The view is used to find out where to start looking in the component responder chain.
+
+ The forwarder will call [view.ck_component targetForAction: withSender:] to proxy to the responder chain, so this needs to be accurate.
+ */
+@property (nonatomic, weak) UIView *view;
+
+@end
+
+
+@interface NSObject (CKComponentDelegateProxy)
+
+@property (nonatomic, strong, setter=ck_setDelegateProxy:) CKComponentDelegateForwarder *ck_delegateProxy;
+
+@end
+

--- a/ComponentKit/Utilities/CKComponentDelegateForwarder.mm
+++ b/ComponentKit/Utilities/CKComponentDelegateForwarder.mm
@@ -19,6 +19,9 @@
 
 std::string CKIdentifierFromDelegateForwarderSelectors(const CKComponentForwardedSelectors& first)
 {
+  if (first.size() == 0) {
+    return "";
+  }
   std::string so = "Delegate";
   for (auto& s : first) {
     so = so + "-" + sel_getName(s);

--- a/ComponentKit/Utilities/CKComponentDelegateForwarder.mm
+++ b/ComponentKit/Utilities/CKComponentDelegateForwarder.mm
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKComponentDelegateForwarder.h"
+
+#import <vector>
+#import <objc/runtime.h>
+
+#import "CKAssert.h"
+#import "CKComponentViewInterface.h"
+#import "CKComponentSubclass.h"
+
+std::string CKIdentifierFromDelegateForwarderSelectors(const CKComponentForwardedSelectors& first)
+{
+  std::string so = "Delegate";
+  for (auto& s : first) {
+    so = so + "-" + sel_getName(s);
+  }
+  return so;
+}
+
+@interface CKComponentDelegateForwarder () {
+  @package
+  CKComponentForwardedSelectors _selectors;
+}
+
+@end
+
+@implementation CKComponentDelegateForwarder : NSObject
+
++ (instancetype)newWithSelectors:(CKComponentForwardedSelectors)selectors
+{
+  CKComponentDelegateForwarder *f = [[self alloc] init];
+  if (!f) return nil;
+
+  f->_selectors = selectors;
+
+  return f;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+  if ([super respondsToSelector:aSelector]) {
+    return YES;
+  } else {
+    BOOL responds = std::find(_selectors.begin(), _selectors.end(), aSelector) != std::end(_selectors);
+    return responds;
+  }
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  CKComponent *responder = _view.ck_component;
+  return [responder targetForAction:aSelector withSender:responder];
+}
+
+@end
+
+
+@implementation NSObject (CKComponentDelegateForwarder)
+
+static const char kCKComponentDelegateProxyKey = ' ';
+
+- (CKComponentDelegateForwarder *)ck_delegateProxy
+{
+  return objc_getAssociatedObject(self, &kCKComponentDelegateProxyKey);
+}
+
+- (void)ck_setDelegateProxy:(CKComponentDelegateForwarder *)delegateProxy
+{
+  objc_setAssociatedObject(self, &kCKComponentDelegateProxyKey, delegateProxy, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end

--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -11,6 +11,7 @@
 #import <Foundation/Foundation.h>
 
 #import <ComponentKit/CKComponentAction.h>
+#import <ComponentKit/CKComponentDelegateForwarder.h>
 
 typedef void (*CKComponentGestureRecognizerSetupFunction)(UIGestureRecognizer *);
 
@@ -49,4 +50,5 @@ CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(CKComponentAc
  */
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          CKComponentAction action);
+                                                          CKComponentAction action,
+                                                          CKComponentForwardedSelectors delegateSelectors = {});

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -125,7 +125,8 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
     {
       std::string(class_getName(gestureRecognizerClass))
       + "-" + CKStringFromPointer((const void *)setupFunction)
-      + "-" + std::string(sel_getName(action)),
+      + "-" + std::string(sel_getName(action))
+      + CKIdentifierFromDelegateForwarderSelectors(delegateSelectors),
       ^(UIView *view, id value){
         CKCAssertNil(recognizerForAction(view, action),
                      @"Registered two gesture recognizers with the same action %@", NSStringFromSelector(action));

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -100,7 +100,8 @@ namespace std {
 
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          CKComponentAction action)
+                                                          CKComponentAction action,
+                                                          CKComponentForwardedSelectors delegateSelectors)
 {
   if (action == NULL) {
     return {
@@ -130,6 +131,16 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
                      @"Registered two gesture recognizers with the same action %@", NSStringFromSelector(action));
         UIGestureRecognizer *gestureRecognizer = reusePool->get();
         [gestureRecognizer ck_setComponentAction:action];
+
+        // Setup delegate proxying if applicable
+        if (delegateSelectors.size() > 0) {
+          CKCAssertNil(gestureRecognizer.delegate, @"Doesn't make sense to set the gesture delegate and provide selectors to proxy");
+          CKComponentDelegateForwarder *proxy = [CKComponentDelegateForwarder newWithSelectors:delegateSelectors];
+          proxy.view = view;
+          gestureRecognizer.delegate = (id<UIGestureRecognizerDelegate>)proxy;
+          // This will retain it
+          gestureRecognizer.ck_delegateProxy = proxy;
+        }
         [view addGestureRecognizer:gestureRecognizer];
       },
       ^(UIView *view, id value){
@@ -137,6 +148,14 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
         CKCAssertNotNil(recognizer, @"Expected to find recognizer for %@ on teardown", NSStringFromSelector(action));
         [view removeGestureRecognizer:recognizer];
         [recognizer ck_setComponentAction:NULL];
+
+        // Tear down delegate proxying if applicable
+        if (delegateSelectors.size() > 0) {
+          CKComponentDelegateForwarder *proxy = recognizer.ck_delegateProxy;
+          proxy.view = nil;
+          recognizer.delegate = nil;
+          recognizer.ck_delegateProxy = nil;
+        }
         reusePool->recycle(recognizer);
       }
     },


### PR DESCRIPTION
This is the new API:

    CKComponentGestureAttribute([UIPanGestureRecognizer class], nullptr, @selector(test:), {@selector(gestureRecognizerShouldBegin:)});

Then you can write in your component's controller (or super-component etc):

    - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)r
    {
    ...
    return YES;
    }