### PR TITLE
Add CKComponentFadeTransition

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A279EA9E1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A279EA9D1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm */; };
 		A27C72751AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */; };
 		A2CD66321AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */; };
+		A9D816AA1B21BDED0095DB42 /* CKComponentFadeTransitionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A9D816A91B21BDED0095DB42 /* CKComponentFadeTransitionTests.mm */; };
 		B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */; };
 		B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */; };
 		B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */; };
@@ -106,6 +107,7 @@
 		A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateStateModificationTests.mm; sourceTree = "<group>"; };
 		A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateTests.mm; sourceTree = "<group>"; };
 		A6F27DD3FB8E2237F9C39DCE /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		A9D816A91B21BDED0095DB42 /* CKComponentFadeTransitionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentFadeTransitionTests.mm; sourceTree = "<group>"; };
 		B342DC401AC23E8200ACAC53 /* ComponentKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComponentKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKArrayControllerChangesetTests.mm; sourceTree = "<group>"; };
 		B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentAccessibilityTests.mm; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 				B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */,
 				A241C6A41AFCFFDB00D4F661 /* CKComponentActionTests.mm */,
 				B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */,
+				A9D816A91B21BDED0095DB42 /* CKComponentFadeTransitionTests.mm */,
 				B342DC4C1AC23EA900ACAC53 /* CKComponentContextTests.mm */,
 				B342DC4D1AC23EA900ACAC53 /* CKComponentControllerLifecycleMethodTests.mm */,
 				B342DC4E1AC23EA900ACAC53 /* CKComponentControllerTests.mm */,
@@ -662,6 +665,7 @@
 				994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */,
 				B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */,
 				B342DC811AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm in Sources */,
+				A9D816AA1B21BDED0095DB42 /* CKComponentFadeTransitionTests.mm in Sources */,
 				A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */,
 				B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */,
 				B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */,

--- a/ComponentKit/ComponentKit.h
+++ b/ComponentKit/ComponentKit.h
@@ -20,6 +20,7 @@
 #import <ComponentKit/CKComponentAnimation.h>
 #import <ComponentKit/CKComponentAnimationHooks.h>
 #import <ComponentKit/CKComponentBoundsAnimation.h>
+#import <ComponentKit/CKComponentFadeTransition.h>
 #import <ComponentKit/CKComponentController.h>
 #import <ComponentKit/CKComponentLayout.h>
 #import <ComponentKit/CKComponentLifecycleManager.h>

--- a/ComponentKit/Components/CKNetworkImageComponent.h
+++ b/ComponentKit/Components/CKNetworkImageComponent.h
@@ -10,6 +10,7 @@
 
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKNetworkImageDownloading.h>
+#import <ComponentKit/CKComponentFadeTransition.h>
 
 struct CKNetworkImageComponentOptions {
   /** Optional imade displayed while the image is loading, or when url is nil. */
@@ -30,6 +31,7 @@ struct CKNetworkImageComponentOptions {
                  scenePath:(id)scenePath
                       size:(const CKComponentSize &)size
                    options:(const CKNetworkImageComponentOptions &)options
-                attributes:(const CKViewComponentAttributeValueMap &)attributes;
+                attributes:(const CKViewComponentAttributeValueMap &)attributes
+            fadeTransition:(const CKComponentFadeTransition)fadeTransition;
 
 @end

--- a/ComponentKit/Components/CKNetworkImageComponent.mm
+++ b/ComponentKit/Components/CKNetworkImageComponent.mm
@@ -25,6 +25,7 @@
 
 @interface CKNetworkImageComponentView : UIImageView
 @property (nonatomic, strong) CKNetworkImageSpecifier *specifier;
+@property (nonatomic, strong) CATransition *imageChangeTransition;
 - (void)didEnterReusePool;
 - (void)willLeaveReusePool;
 @end
@@ -37,6 +38,7 @@
                       size:(const CKComponentSize &)size
                    options:(const CKNetworkImageComponentOptions &)options
                 attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
+            fadeTransition:(const CKComponentFadeTransition)fadeTransition
 {
   CGRect cropRect = options.cropRect;
   if (CGRectIsEmpty(cropRect)) {
@@ -44,6 +46,7 @@
   }
   CKViewComponentAttributeValueMap attributes(passedAttributes);
   attributes.insert({
+    {@selector(setImageChangeTransition:), CKComponentGenerateTransition(fadeTransition)},
     {@selector(setSpecifier:), [[CKNetworkImageSpecifier alloc] initWithURL:url
                                                                defaultImage:options.defaultImage
                                                             imageDownloader:imageDownloader
@@ -115,6 +118,9 @@
 {
   if (image) {
     self.image = [UIImage imageWithCGImage:image];
+    if (self.imageChangeTransition.duration > 0) {
+      [self.layer addAnimation:self.imageChangeTransition forKey:NSStringFromSelector(@selector(imageChangeTransition))];
+    }
     [self updateContentsRect];
   }
   _download = nil;

--- a/ComponentKit/Core/CKComponentFadeTransition.h
+++ b/ComponentKit/Core/CKComponentFadeTransition.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ Specifies how to animate a fade transition to the component tree.
+ */
+struct CKComponentFadeTransition {
+  NSTimeInterval duration;
+};
+
+/**
+ Creates a CATransition object from a CKComponentFadeTransition.
+ It will use kCAMediaTimingFunctionEaseInEaseOut as timing function.
+ */
+CATransition* CKComponentGenerateTransition(const CKComponentFadeTransition &transition);
+
+/**
+ Wraps the given block in the correct UIView transition block for a given bounds animation.
+ If duration is zero, wraps [UIView +performWithoutAnimation:].
+ */
+void CKComponentFadeTransitionApply(const CKComponentFadeTransition &transition,
+                                    UIView *view,
+                                    void (^transitions)(void),
+                                    void (^completion)(BOOL finished));

--- a/ComponentKit/Core/CKComponentFadeTransition.mm
+++ b/ComponentKit/Core/CKComponentFadeTransition.mm
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKComponentFadeTransition.h"
+
+CATransition* CKComponentGenerateTransition(const CKComponentFadeTransition &transition)
+{
+  CATransition *fadeTransition = [CATransition animation];
+  fadeTransition.duration = transition.duration;
+  fadeTransition.type = kCATransitionFade;
+  fadeTransition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+  return fadeTransition;
+}
+
+void CKComponentFadeTransitionApply(const CKComponentFadeTransition &transition,
+                                    UIView *view,
+                                    void (^transitions)(void),
+                                    void (^completion)(BOOL finished))
+{
+  if (transition.duration == 0) {
+    [UIView performWithoutAnimation:transitions];
+    if (completion) {
+      completion(YES);
+    }
+  } else {
+    [UIView transitionWithView:view
+                      duration:transition.duration
+                       options:UIViewAnimationOptionTransitionCrossDissolve
+                    animations:transitions
+                    completion:completion];
+  }
+}

--- a/ComponentKitApplicationTests/CKNetworkImageComponentTests.mm
+++ b/ComponentKitApplicationTests/CKNetworkImageComponentTests.mm
@@ -102,7 +102,8 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
    options:{}
    attributes:{
      {{@selector(setBackgroundColor:), [UIColor redColor]}},
-   }];
+   }
+   fadeTransition:{}];
 
   static CKSizeRange kSize = {{50, 50}, {50, 50}};
   CKSnapshotVerifyComponent(c, kSize, nil);
@@ -121,7 +122,8 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
    }
    attributes:{
      {{@selector(setBackgroundColor:), [UIColor redColor]}},
-   }];
+   }
+   fadeTransition:{}];
 
   static CKSizeRange kSize = {{50, 50}, {50, 50}};
   CKSnapshotVerifyComponent(c, kSize, nil);
@@ -152,7 +154,8 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
    attributes:{
      // Snapshot will show a red image, not the purple image provided by the image downloader.
      {{@selector(setBackgroundColor:), [UIColor redColor]}},
-   }];
+   }
+   fadeTransition:{}];
 
   static CKSizeRange kSize = {{50, 50}, {50, 50}};
   CKSnapshotVerifyComponent(c, kSize, nil);
@@ -186,7 +189,8 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
    }
    attributes:{
      {{@selector(setBackgroundColor:), [UIColor redColor]}},
-   }];
+   }
+   fadeTransition:{}];
 
   static CKSizeRange kSize = {{50, 50}, {50, 50}};
   CKSnapshotVerifyComponent(c, kSize, nil);
@@ -206,7 +210,8 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
    }
    attributes:{
      {{@selector(setBackgroundColor:), [UIColor redColor]}},
-   }];
+   }
+   fadeTransition:{}];
 
   static CKSizeRange kSize = {{50, 50}, {50, 50}};
   CKSnapshotVerifyComponent(c, kSize, nil);

--- a/ComponentKitTests/CKComponentFadeTransitionTests.mm
+++ b/ComponentKitTests/CKComponentFadeTransitionTests.mm
@@ -1,0 +1,27 @@
+//
+//  CKComponentFadeTransitionTests.m
+//  ComponentKit
+//
+//  Created by Marco Sero on 05/06/2015.
+//
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CKComponentFadeTransition.h"
+
+@interface CKComponentFadeTransitionTests : XCTestCase
+@end
+
+@implementation CKComponentFadeTransitionTests
+
+- (void)testTransitionGeneration
+{
+  NSTimeInterval duration = 0.5;
+  CATransition *fadeTransition = CKComponentGenerateTransition({.duration = duration});
+  XCTAssertEqual(fadeTransition.duration, duration);
+  XCTAssertEqual(fadeTransition.type, kCATransitionFade);
+  XCTAssertEqual(fadeTransition.timingFunction, [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]);
+}
+
+@end


### PR DESCRIPTION
This can be used by CKNetworkImageComponent to specify a fade transition when the image is fetched from the network.