### PR TITLE
Provide a way to map back to the actual action selector on a gesture.

### DIFF
--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -52,3 +52,9 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
                                                           CKComponentAction action,
                                                           CKComponentForwardedSelectors delegateSelectors = {});
+
+/**
+ Allows mapping a UIGestureRecognizer back to the original CKComponentAction selector,
+ since ComponentKit internally changes the selector to be able send to the component responder chain.
+ */
+CKComponentAction CKComponentGestureGetAction(UIGestureRecognizer *gesture);

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -185,6 +185,11 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
 
 @end
 
+CKComponentAction CKComponentGestureGetAction(UIGestureRecognizer *gesture)
+{
+  return [gesture ck_componentAction];
+};
+
 @implementation UIGestureRecognizer (CKComponent)
 
 static const char kCKComponentActionGestureRecognizerKey = ' ';


### PR DESCRIPTION
For #236

Example usage:

````objc++
    - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer 
    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
    {
      std::set<std::pair<SEL, SEL>> allowed{
        {@selector(mouseDown:gesture:), @selector(mouseDragged:gesture:)},
        {@selector(mouseDown:gesture:), @selector(doubleClick:gesture:)},
        {@selector(mouseDown:gesture:), @selector(doubleClickedRedacted:gesture:)},
      };

      return allowed.find({CKComponentGestureGetAction(gestureRecognizer), CKComponentGestureGetAction(otherGestureRecognizer)}) != allowed.end();
    }
````