### PR TITLE
Pass CKStackLayoutComponentStyle to CKStackLayoutComponent by reference

### DIFF
--- a/ComponentKit/LayoutComponents/CKStackLayoutComponent.h
+++ b/ComponentKit/LayoutComponents/CKStackLayoutComponent.h
@@ -117,7 +117,7 @@ struct CKStackLayoutComponentChild {
  */
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view
                        size:(const CKComponentSize &)size
-                      style:(CKStackLayoutComponentStyle)style
+                      style:(const CKStackLayoutComponentStyle &)style
                    children:(const std::vector<CKStackLayoutComponentChild> &)children;
 
 @end

--- a/ComponentKit/LayoutComponents/CKStackLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKStackLayoutComponent.mm
@@ -28,7 +28,7 @@
 
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view
                        size:(const CKComponentSize &)size
-                      style:(CKStackLayoutComponentStyle)style
+                      style:(const CKStackLayoutComponentStyle &)style
                    children:(const std::vector<CKStackLayoutComponentChild> &)children
 {
   CKStackLayoutComponent *c = [super newWithView:view size:size];


### PR DESCRIPTION
It's a 4-element struct, probably shouldn't be copied.