### PR TITLE
Patch CKCollectionViewDataSource to remount views for existing components

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -123,11 +123,7 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
 {
   CKComponentDataSourceOutputItem *outputItem = [_componentDataSource objectAtIndexPath:indexPath];
   CKCollectionViewDataSourceCell *cell = [_collectionView dequeueReusableCellWithReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
-  if (_cellConfigurationFunction) {
-    _cellConfigurationFunction(cell, indexPath, [outputItem model]);
-  }
-  CKComponentLifecycleManager *lifecycleManager = [outputItem lifecycleManager];
-  [lifecycleManager attachToView:[cell rootView]];
+  attachToCell(cell, indexPath, _cellConfigurationFunction, outputItem);
   // We maintain this map to be able to announce appearance events.
   [_cellToItemMap setObject:outputItem forKey:cell];
   return cell;
@@ -173,7 +169,7 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
 {
   [_collectionView performBatchUpdates:^{
     const auto &changeset = changesetApplicator();
-    applyChangesetToCollectionView(changeset, _collectionView);
+    applyChangesetToCollectionView(changeset, _collectionView, _componentDataSource, _cellConfigurationFunction);
   } completion:nil];
 }
 
@@ -193,7 +189,16 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
 
 #pragma mark - Private
 
-static void applyChangesetToCollectionView(const Output::Changeset &changeset, UICollectionView *collectionView)
+static void attachToCell(CKCollectionViewDataSourceCell *cell, NSIndexPath *indexPath, CKCellConfigurationFunction cellConfigurationFunction, CKComponentDataSourceOutputItem *outputItem) {
+  if (cellConfigurationFunction) {
+    cellConfigurationFunction(cell, indexPath, [outputItem model]);
+  }
+
+  CKComponentLifecycleManager *lifecycleManager = [outputItem lifecycleManager];
+  [lifecycleManager attachToView:[cell rootView]];
+}
+
+static void applyChangesetToCollectionView(const Output::Changeset &changeset, UICollectionView *collectionView, CKComponentDataSource *_componentDataSource, CKCellConfigurationFunction cellConfigurationFunction)
 {
   NSMutableArray *itemRemovalIndexPaths = [[NSMutableArray alloc] init];
   NSMutableArray *itemInsertionIndexPaths = [[NSMutableArray alloc] init];
@@ -237,6 +242,16 @@ static void applyChangesetToCollectionView(const Output::Changeset &changeset, U
     [collectionView deleteItemsAtIndexPaths:itemRemovalIndexPaths];
   }
   if (itemUpdateIndexPaths.count > 0) {
+		[itemUpdateIndexPaths enumerateObjectsWithOptions:NSEnumerationReverse
+                                           usingBlock:^(NSIndexPath *indexPath,
+                                                        NSUInteger idx,
+                                                        BOOL *stop)
+    {
+      if (CKCollectionViewDataSourceCell *cell = [collectionView cellForItemAtIndexPath:indexPath]) {
+        attachToCell(cell, indexPath, cellConfigurationFunction, [_componentDataSource objectAtIndexPath:indexPath]);
+        [itemUpdateIndexPaths removeObject:indexPath];
+      }
+    }];
     [collectionView reloadItemsAtIndexPaths:itemUpdateIndexPaths];
   }
   if (itemInsertionIndexPaths.count > 0) {

--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -247,7 +247,8 @@ static void applyChangesetToCollectionView(const Output::Changeset &changeset, U
                                                         NSUInteger idx,
                                                         BOOL *stop)
     {
-      if (CKCollectionViewDataSourceCell *cell = [collectionView cellForItemAtIndexPath:indexPath]) {
+      if (CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell*) [collectionView cellForItemAtIndexPath:indexPath])
+      {
         attachToCell(cell, indexPath, cellConfigurationFunction, [_componentDataSource objectAtIndexPath:indexPath]);
         [itemUpdateIndexPaths removeObject:indexPath];
       }


### PR DESCRIPTION
Hi all,

As discussed in https://github.com/facebook/componentkit/issues/114, I've patched `CKCollectionViewDataSource` to use an approximation of the same reattachment method.

This *appears* to do exactly as desired - ensuring that for a cell reload, all components and child components correctly enter the "remount" state. Thus animations for a change of model are now easily defined using `-animationsFromPreviousComponent:`.

No arguments that this is somewhat Quick and Dirty™. I haven't had much time to test this yet, but am creating this PR right away to get some feedback. In particular, I haven't yet given much consideration to threading issues. 

In any case, since it appears `CKCollectionViewDataSource` is EOL (?), this may benefit others in the meantime until its successor is ready.

Please let me know!

