### PR TITLE
Blocking animations in the parent should block animations in the child

### DIFF
--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -126,7 +126,7 @@ struct CKComponentMountInfo {
 
   UIView *v = effectiveContext.viewManager->viewForConfiguration([self class], viewConfiguration);
   if (v) {
-    CKMountAnimationGuard g(v.ck_component, self);
+    CKMountAnimationGuard g(v.ck_component, self, context);
     if (_mountInfo->view != v) {
       [self _relinquishMountedView]; // First release our old view
       [v.ck_component unmount];      // Then unmount old component (if any) from the new view
@@ -143,7 +143,7 @@ struct CKComponentMountInfo {
     [v setBounds:{v.bounds.origin, size}];
 
     _mountInfo->viewContext = {v, {{0,0}, v.bounds.size}};
-    return {.mountChildren = YES, .contextForChildren = effectiveContext.childContextForSubview(v)};
+    return {.mountChildren = YES, .contextForChildren = effectiveContext.childContextForSubview(v, g.didBlockAnimations)};
   } else {
     CKAssertNil(_mountInfo->view, @"Didn't expect to sometimes have a view and sometimes not have a view");
     _mountInfo->viewContext = {effectiveContext.viewManager->view, {effectiveContext.position, size}};

--- a/ComponentKit/Debug/CKComponentDebugController.mm
+++ b/ComponentKit/Debug/CKComponentDebugController.mm
@@ -125,7 +125,7 @@ CK::Component::MountContext CKDebugMountContext(Class componentClass,
 
   UIView *debugView = context.viewManager->viewForConfiguration(componentClass, debugViewConfigurations->at(componentClass));
   debugView.frame = {context.position, size};
-  return context.childContextForSubview(debugView);
+  return context.childContextForSubview(debugView, NO);
 }
 
 #pragma mark - Synchronous Reflow

--- a/ComponentKitTests/CKComponentViewReuseTests.mm
+++ b/ComponentKitTests/CKComponentViewReuseTests.mm
@@ -324,7 +324,7 @@ supercomponent:(CKComponent *)supercomponent
   CKInjectingView *injectingView = (CKInjectingView *)result.contextForChildren.viewManager->view;
   return {
     .mountChildren = YES,
-    .contextForChildren = result.contextForChildren.childContextForSubview(injectingView.injectedView),
+    .contextForChildren = result.contextForChildren.childContextForSubview(injectingView.injectedView, NO),
   };
 }
 


### PR DESCRIPTION
Otherwise, we fix the issue of unwanted animations in a parent component but the children still animate willy-nilly.