### PR TITLE
Adding canPerformAction to the component responder chain

### DIFF
--- a/ComponentKit/Core/CKComponent.h
+++ b/ComponentKit/Core/CKComponent.h
@@ -54,4 +54,12 @@ struct CKComponentViewContext {
  */
 - (id)nextResponder;
 
+/**
+ When an event occurs, if a component implements the canPerformAction method it will be called in the normal responder
+ chain. If the method returns YES, the traversal will end and the action will be called on this component. If the
+ method returns NO, the component will be skipped and the event will continue to traverse the responder chain to the
+ component's next responder.
+ */
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
 @end

--- a/ComponentKit/Core/CKComponent.h
+++ b/ComponentKit/Core/CKComponent.h
@@ -54,12 +54,4 @@ struct CKComponentViewContext {
  */
 - (id)nextResponder;
 
-/**
- When an event occurs, if a component implements the canPerformAction method it will be called in the normal responder
- chain. If the method returns YES, the traversal will end and the action will be called on this component. If the
- method returns NO, the component will be skipped and the event will continue to traverse the responder chain to the
- component's next responder.
- */
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
-
 @end

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -240,7 +240,12 @@ struct CKComponentMountInfo {
 
 - (id)targetForAction:(SEL)action withSender:(id)sender
 {
-  return [self respondsToSelector:action] ? self : [[self nextResponder] targetForAction:action withSender:sender];
+  return [self canPerformAction:action withSender:sender] ? self : [[self nextResponder] targetForAction:action withSender:sender];
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  return [self respondsToSelector:action];
 }
 
 // Because only the root component in each mounted tree will have a non-nil rootComponentMountedView, we use Obj-C

--- a/ComponentKit/Core/CKComponentController.h
+++ b/ComponentKit/Core/CKComponentController.h
@@ -71,10 +71,11 @@
 - (id)nextResponder;
 
 /**
- When an event occurs, if a controller implements the canPerformAction method it will be called in the normal responder
- chain. If the method returns YES, the traversal will end and the action will be called on this controller. If the
- method returns NO, the controller will be skipped and the event will continue to traverse the responder chain to the
- next responder.
+ When an action is triggered, a component controller may use this method to either capture or ignore the given action.
+ The default implementation simply uses respondsToSelector: to determine if the controller can perform the given action.
+
+ In practice, this is useful only for integrations with UIMenuController whose API walks the UIResponder chain to
+ determine which menu items to display. You should not override this method for standard component actions.
  */
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
 

--- a/ComponentKit/Core/CKComponentController.h
+++ b/ComponentKit/Core/CKComponentController.h
@@ -70,4 +70,12 @@
  */
 - (id)nextResponder;
 
+/**
+ When an event occurs, if a controller implements the canPerformAction method it will be called in the normal responder
+ chain. If the method returns YES, the traversal will end and the action will be called on this controller. If the
+ method returns NO, the controller will be skipped and the event will continue to traverse the responder chain to the
+ next responder.
+ */
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
 @end

--- a/ComponentKit/Core/CKComponentController.mm
+++ b/ComponentKit/Core/CKComponentController.mm
@@ -211,7 +211,12 @@ static NSString *componentStateName(CKComponentControllerState state)
 
 - (id)targetForAction:(SEL)action withSender:(id)sender
 {
-  return [self respondsToSelector:action] ? self : [[self nextResponder] targetForAction:action withSender:sender];
+  return [self canPerformAction:action withSender:sender] ? self : [[self nextResponder] targetForAction:action withSender:sender];
+}
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  return [self respondsToSelector:action];
 }
 
 @end

--- a/ComponentKit/Core/CKComponentSubclass.h
+++ b/ComponentKit/Core/CKComponentSubclass.h
@@ -97,6 +97,15 @@ extern CGSize const kCKComponentParentSizeUndefined;
 - (id)targetForAction:(SEL)action withSender:(id)sender;
 
 /**
+ When an action is triggered, a component may use this method to either capture or ignore the given action. The default
+ implementation simply uses respondsToSelector: to determine if the component can perform the given action.
+
+ In practice, this is useful only for integrations with UIMenuController whose API walks the UIResponder chain to
+ determine which menu items to display. You should not override this method for standard component actions.
+ */
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+
+/**
  Override to return a list of animations from the previous version of the same component.
 
  @warning If you override this method, your component MUST declare a scope (see CKComponentScope). This is used to

--- a/ComponentKitTests/CKComponentControllerTests.mm
+++ b/ComponentKitTests/CKComponentControllerTests.mm
@@ -168,7 +168,7 @@
                        @"Root component's controller's nextResponder should be root view");
 }
 
-- (void)testThatResponderChainWorksTargetsCorrectResponder
+- (void)testThatResponderChainTargetsCorrectResponder
 {
   CKComponentLifecycleManager *clm = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
   CKComponentLifecycleManagerState state = [clm prepareForUpdateWithModel:nil constrainedSize:{{0,0}, {100, 100}} context:nil];

--- a/ComponentKitTests/CKComponentControllerTests.mm
+++ b/ComponentKitTests/CKComponentControllerTests.mm
@@ -168,6 +168,20 @@
                        @"Root component's controller's nextResponder should be root view");
 }
 
+- (void)testThatResponderChainWorksTargetsCorrectResponder
+{
+  CKComponentLifecycleManager *clm = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  CKComponentLifecycleManagerState state = [clm prepareForUpdateWithModel:nil constrainedSize:{{0,0}, {100, 100}} context:nil];
+  [clm updateWithState:state];
+  
+  UIView *view = [[UIView alloc] init];
+  [clm attachToView:view];
+  
+  CKFooComponent *fooComponent = (CKFooComponent *)state.layout.component;
+  XCTAssertEqualObjects([fooComponent targetForAction:nil withSender:fooComponent], fooComponent, @"Component should respond to this action");
+  XCTAssertEqualObjects([fooComponent targetForAction:nil withSender:nil], fooComponent.controller, @"Component's controller should respond to this action");
+}
+
 @end
 
 
@@ -194,6 +208,14 @@
     return @YES;
   }];
 }
+
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  if (sender == self)
+    return YES;
+  return NO;
+}
+
 @end
 
 @implementation CKFooComponentController
@@ -215,6 +237,11 @@
 {
   [super componentDidAcquireView];
   _calledDidAcquireView = YES;
+}
+
+-(BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+  return YES;
 }
 
 @end


### PR DESCRIPTION
I added the canPerformAction method to the component responder chain (in CKComponent and CKComponentController) so that subclasses of components can choose to implement this method or not. If they do not, the behavior is the same as it was before the methods were added. If subclasses do implement this they can return YES to handle the the event or NO to be skipped in the responder chain and the event will continue to traverse it.

I also added a test to make sure that the correct object is being returned when a component and its controller (the next responder) both implement the method with different conditions.