### PR TITLE
Add opt-in memoization of component creation

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */; };
 		31EBF255C3C6127E5A3619D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		83EBF589FB5C5611BC1A2D13 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
+		991DE3411B3B308900AA05B2 /* CKComponentMemoizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */; };
 		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
 		A2100E0D1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */; };
 		A22FE3031AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */; };
@@ -95,6 +96,7 @@
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
 		71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentMemoizerTests.mm; sourceTree = "<group>"; };
 		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
 		A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm; sourceTree = "<group>"; };
 		A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateUpdateTests.mm; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				B342DC5F1AC23EA900ACAC53 /* CKComponentViewManagerTests.mm */,
 				B342DC601AC23EA900ACAC53 /* CKComponentViewReuseTests.mm */,
 				994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */,
+				991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */,
 				B342DC611AC23EA900ACAC53 /* CKDimensionTests.mm */,
 				B342DC621AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm */,
 				B342DC631AC23EA900ACAC53 /* CKSectionedArrayControllerTests.mm */,
@@ -719,6 +722,7 @@
 				18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */,
 				B342DC821AC23EA900ACAC53 /* CKSectionedArrayControllerTests.mm in Sources */,
 				A27C72751AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm in Sources */,
+				991DE3411B3B308900AA05B2 /* CKComponentMemoizerTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ComponentKit/Core/CKComponentLifecycleManager.h
+++ b/ComponentKit/Core/CKComponentLifecycleManager.h
@@ -25,6 +25,7 @@ struct CKComponentLifecycleManagerState {
   CKSizeRange constrainedSize;
   CKComponentLayout layout;
   CKComponentScopeRoot *root;
+  id memoizerState;
   CKComponentBoundsAnimation boundsAnimation;
 };
 

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -18,6 +18,7 @@
 #import "CKComponentInternal.h"
 #import "CKComponentLayout.h"
 #import "CKComponentLifecycleManagerAsynchronousUpdateHandler.h"
+#import "CKComponentMemoizer.h"
 #import "CKComponentProvider.h"
 #import "CKComponentScope.h"
 #import "CKComponentScopeFrame.h"
@@ -86,6 +87,9 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
 
   CKComponentScopeRoot *previousRoot = _previousRoot ?: [CKComponentScopeRoot rootWithListener:self];
 
+  // Vend components from the current layout to be available in the new state and layout calculations
+  CKComponentMemoizer memoizer(_state.memoizerState);
+
   CKBuildComponentResult result = CKBuildComponent(previousRoot, _pendingStateUpdates, ^{
     return [_componentProvider componentForModel:model context:context];
   });
@@ -100,6 +104,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
     .context = context,
     .constrainedSize = constrainedSize,
     .layout = layout,
+    .memoizerState = memoizer.nextMemoizerState(),
     .root = result.scopeRoot,
     .boundsAnimation = result.boundsAnimation,
   };

--- a/ComponentKit/Core/CKComponentMemoizer.h
+++ b/ComponentKit/Core/CKComponentMemoizer.h
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <ComponentKit/CKComponentContext.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKSizeRange.h>
+#import <ComponentKit/CKComponentSize.h>
+#import <ComponentKit/CKEqualityHashHelpers.h>
+
+#include <functional>
+
+// Aspect-oriented type erasure of hash/equals on a tuple
+struct CKMemoizationKey;
+
+id CKMemoize(CKMemoizationKey memoizationKey, id (^block)(void));
+
+/**
+ 
+ How to use the component memoization:
+ 
+ + (instancetype)newWithMyModel:(MyModel *)model otherInput:(int)other
+ {
+   return CKMemoize(CKMakeTupleMemoizationKey(model, other), ^{
+     return [self
+            newWithComponent:
+            [CKStackLayoutComponent
+              newWith...
+   });
+ 
+ }
+ 
+ MyKey must consist only of objects that define -hash and -isEqual:.
+
+ If you're building something that calls CKMountComponentLayout() directly,
+ just add a CKComponentMemoizer in the right scope:
+
+ {
+   CKComponentMemoizer memoizer(_memoizerState);
+ 
+   result = CKBuildComponent(...)
+ 
+   layout = [result.component layoutThatFits:constrainedSize parentSize:constrainedSize.max]
+ 
+    ...
+   CKMountComponentLayout(layout)
+
+   _memoizerState = memoizer.nextMemoizerState();
+
+ }
+ */
+
+struct CKComponentMemoizer {
+
+  /**
+   Create a memoizer. If you pass in a memoizer state, components will be vended from reuse from there.
+   Creating a CKComponentMemoizer in a scope will make memoized components available to CKMemoize().
+   This object must remain in scope for objects to be vended.
+   */
+  CKComponentMemoizer(id previousMemoizerState);
+
+  /**
+   Destructor cleans up the intermediate state for the memoizer.
+   */
+  ~CKComponentMemoizer();
+
+  /**
+   Store this state across rebuilding components.
+   Do not use this object from multiple threads simultaneously
+   */
+  id nextMemoizerState();
+
+private:
+  id previousMemoizer_;
+};
+
+struct CKMemoizationKey
+{
+  size_t hash;
+
+  // This is a shared_ptr to const void* so we can have value semantics (just increment refcount),
+  // but use our own equals fn, etc
+  std::shared_ptr<const void> internal;
+
+  // This key's quality function
+  bool (*equals)(const void *, const void *);
+
+  bool operator == (const CKMemoizationKey other) const {
+    // Two keys are the same type if their equality functions are the same
+    return equals == other.equals
+    // The keys are equal if the equality function returns true
+    && (internal == other.internal || equals(internal.get(), other.internal.get()));
+  };
+};
+
+template <typename ...Types, typename Pred = CKTupleOperations::equal_to<std::tuple<Types...>> >
+CKMemoizationKey CKMakeTupleMemoizationKey(Types... args) {
+  using Tuple = std::tuple<Types...>;
+
+  Tuple *tuple = new Tuple(std::forward_as_tuple(args...));
+  size_t hash = CKTupleOperations::hash<Tuple>()(*tuple);
+
+  return {
+    .hash = hash,
+    .internal = std::shared_ptr<const void>(tuple, [](const void *ptr) {
+      delete static_cast<const Tuple *>(ptr);
+    }),
+    .equals = [](const void* a, const void* b) {
+      if (!a || !b) {
+        return false;
+      }
+      const Tuple* aa = static_cast<const Tuple*>(a);
+      const Tuple* bb = static_cast<const Tuple*>(b);
+      return Pred()(*aa, *bb);
+    },
+  };
+
+  return CKMemoizationKey{};
+};
+

--- a/ComponentKit/Core/CKComponentMemoizer.mm
+++ b/ComponentKit/Core/CKComponentMemoizer.mm
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKComponentMemoizer.h"
+
+#import "CKComponentInternal.h"
+#import "CKComponentSubclass.h"
+#import "CKMacros.h"
+#import "CKInternalHelpers.h"
+
+#include <map>
+
+static NSString *CKComponentMemoizerThreadKey = @"CKComponentMemoizer";
+
+// Define hash as just pulling out the precomputed hash field
+namespace std {
+  template <>
+  struct hash<CKMemoizationKey> {
+    size_t operator ()(CKMemoizationKey a) const {
+      return a.hash;
+    };
+  };
+}
+
+@interface _CKComponentMemoizerImpl : NSObject {
+  @package
+
+  // Store into the next state, read from the current
+  _CKComponentMemoizerImpl *_next;
+
+  // maps CKMemoizationKey -> any number of CKComponent *
+  std::unordered_multimap<CKMemoizationKey, CKComponent *> componentCache_;
+}
+
+@end
+
+
+@implementation _CKComponentMemoizerImpl
+
+- (CKComponent *)dequeueComponentForKey:(CKMemoizationKey)key
+{
+  auto it = componentCache_.find(key);
+  if (it != componentCache_.end()) {
+    CKComponent *c = it->second;
+    // Remove this component from the cache, since you can't mount a component twice
+    componentCache_.erase(it);
+    return c;
+  }
+  return nil;
+}
+
+- (_CKComponentMemoizerImpl *)next
+{
+  if (!_next) {
+    _next = [[_CKComponentMemoizerImpl alloc] init];
+  }
+  return _next;
+}
+
+- (void)enqueueComponent:(CKComponent *)component forKey:(CKMemoizationKey)key
+{
+  self.next->componentCache_.insert({key, component});
+}
+
++ (_CKComponentMemoizerImpl *)currentMemoizer
+{
+  return [[NSThread currentThread] threadDictionary][CKComponentMemoizerThreadKey];
+}
+
++ (void)setCurrentMemoizer:(_CKComponentMemoizerImpl *)memoizer
+{
+  if (memoizer) {
+    [[NSThread currentThread] threadDictionary][CKComponentMemoizerThreadKey] = memoizer;
+  } else {
+    [[[NSThread currentThread] threadDictionary] removeObjectForKey:CKComponentMemoizerThreadKey];
+  }
+}
+
+@end
+
+CKComponentMemoizer::CKComponentMemoizer(id previousMemoizerState)
+{
+  _CKComponentMemoizerImpl *mipl = previousMemoizerState ?: [[_CKComponentMemoizerImpl alloc] init];
+
+  // Push this memoizer onto the current thread
+  id current = [_CKComponentMemoizerImpl currentMemoizer];
+  previousMemoizer_ = current;
+  [_CKComponentMemoizerImpl setCurrentMemoizer:mipl];
+};
+
+CKComponentMemoizer::~CKComponentMemoizer()
+{
+  // Pop memoizer
+  [_CKComponentMemoizerImpl setCurrentMemoizer:previousMemoizer_];
+}
+
+id CKMemoize(CKMemoizationKey memoizationKey, id (^block)(void))
+{
+  _CKComponentMemoizerImpl *impl = [_CKComponentMemoizerImpl currentMemoizer];
+  CKComponent *component = [impl dequeueComponentForKey:memoizationKey];
+  if (!component && block) {
+    component = block();
+  }
+  if (component) {
+    [impl enqueueComponent:component forKey:memoizationKey];
+  }
+  return component;
+}
+
+id CKComponentMemoizer::nextMemoizerState()
+{
+  _CKComponentMemoizerImpl *impl = [_CKComponentMemoizerImpl currentMemoizer];
+  return impl ? impl->_next : nil;
+}

--- a/ComponentKit/Core/CKComponentViewAttribute.mm
+++ b/ComponentKit/Core/CKComponentViewAttribute.mm
@@ -15,7 +15,7 @@
 
 #import <ComponentKit/CKAssert.h>
 #import <ComponentKit/CKAssert.h>
-#import <ComponentKit/CKInternalHelpers.h>
+#import <ComponentKit/CKEqualityHashHelpers.h>
 #import <ComponentKit/CKMacros.h>
 
 /**

--- a/ComponentKit/Core/CKSizeRange.mm
+++ b/ComponentKit/Core/CKSizeRange.mm
@@ -13,7 +13,7 @@
 #import <functional>
 
 #import <ComponentKit/CKDimension.h>
-#import <ComponentKit/CKInternalHelpers.h>
+#import <ComponentKit/CKEqualityHashHelpers.h>
 #import <ComponentKit/CKMacros.h>
 
 CKSizeRange::CKSizeRange(const CGSize &_min, const CGSize &_max) : min(_min), max(_max)

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -19,7 +19,7 @@
 #import "CKComponentScopeHandle.h"
 #import "CKComponentScopeRootInternal.h"
 #import "CKComponentSubclass.h"
-#import "CKInternalHelpers.h"
+#import "CKEqualityHashHelpers.h"
 #import "CKMacros.h"
 #import "CKThreadLocalComponentScope.h"
 

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceInputItem.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceInputItem.mm
@@ -10,7 +10,7 @@
 
 #import "CKComponentDataSourceInputItem.h"
 
-#import "CKInternalHelpers.h"
+#import "CKEqualityHashHelpers.h"
 #import "ComponentUtilities.h"
 #import "CKComponentLifecycleManager.h"
 #import "CKMacros.h"

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceOutputItem.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceOutputItem.mm
@@ -10,7 +10,7 @@
 
 #import "CKComponentDataSourceOutputItem.h"
 
-#import "CKInternalHelpers.h"
+#import "CKEqualityHashHelpers.h"
 #import "ComponentUtilities.h"
 #import "CKComponentLifecycleManager.h"
 #import "CKMacros.h"

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.mm
@@ -12,7 +12,7 @@
 #import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
 
 #import "ComponentUtilities.h"
-#import "CKInternalHelpers.h"
+#import "CKEqualityHashHelpers.h"
 #import "CKMacros.h"
 
 @implementation CKTransactionalComponentDataSourceAppliedChanges

--- a/ComponentKit/Utilities/CKEqualityHashHelpers.h
+++ b/ComponentKit/Utilities/CKEqualityHashHelpers.h
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <string>
+
+// From folly:
+// This is the Hash128to64 function from Google's cityhash (available
+// under the MIT License).  We use it to reduce multiple 64 bit hashes
+// into a single hash.
+inline uint64_t CKHashCombine(const uint64_t upper, const uint64_t lower) {
+  // Murmur-inspired hashing.
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  uint64_t a = (lower ^ upper) * kMul;
+  a ^= (a >> 47);
+  uint64_t b = (upper ^ a) * kMul;
+  b ^= (b >> 47);
+  b *= kMul;
+  return b;
+}
+
+NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count);
+
+namespace CK {
+  // Default is not an ObjC class
+  template<typename T, typename V = bool>
+  struct is_objc_class : std::false_type { };
+
+  // Conditionally enable this template specialization on whether T is convertible to id, makes the is_objc_class a true_type
+  template<typename T>
+  struct is_objc_class<T, typename std::enable_if<std::is_convertible<T, id>::value, bool>::type> : std::true_type { };
+
+  // CKUtils::hash<T>()(value) -> either std::hash<T> if c++ or [o hash] if ObjC object.
+  template <typename T, typename Enable = void> struct hash;
+
+  // For non-objc types, defer to std::hash
+  template <typename T> struct hash<T, typename std::enable_if<!is_objc_class<T>::value>::type> {
+    bool operator ()(const T& a) {
+      return std::hash<T>()(a);
+    }
+  };
+
+  // For objc types, call [o hash]
+  template <typename T> struct hash<T, typename std::enable_if<is_objc_class<T>::value>::type> {
+    bool operator ()(id o) {
+      return [o hash];
+    }
+  };
+
+  template <typename T, typename Enable = void> struct is_equal;
+
+  // For non-objc types use == operator
+  template <typename T> struct is_equal<T, typename std::enable_if<!is_objc_class<T>::value>::type> {
+    bool operator ()(const T& a, const T& b) {
+      return a == b;
+    }
+  };
+
+  // For objc types, check pointer equality, then use -isEqual:
+  template <typename T> struct is_equal<T, typename std::enable_if<is_objc_class<T>::value>::type> {
+    bool operator ()(id a, id b) {
+      return a == b || [a isEqual:b];
+    }
+  };
+
+};
+
+namespace CKTupleOperations
+{
+  // Recursive case (hash up to Index)
+  template <class Tuple, size_t Index = std::tuple_size<Tuple>::value - 1>
+  struct _hash_helper
+  {
+    static size_t hash(Tuple const& tuple)
+    {
+      size_t prev = _hash_helper<Tuple, Index-1>::hash(tuple);
+      using TypeForIndex = typename std::tuple_element<Index,Tuple>::type;
+      size_t thisHash = CK::hash<TypeForIndex>()(std::get<Index>(tuple));
+      return CKHashCombine(prev, thisHash);
+    }
+  };
+
+  // Base case (hash 0th element)
+  template <class Tuple>
+  struct _hash_helper<Tuple, 0>
+  {
+    static size_t hash(Tuple const& tuple)
+    {
+      using TypeForIndex = typename std::tuple_element<0,Tuple>::type;
+      return CK::hash<TypeForIndex>()(std::get<0>(tuple));
+    }
+  };
+
+  // Recursive case (elements equal up to Index)
+  template <class Tuple, size_t Index = std::tuple_size<Tuple>::value - 1>
+  struct _eq_helper
+  {
+    static bool equal(Tuple const& a, Tuple const& b)
+    {
+      bool prev = _eq_helper<Tuple, Index-1>::equal(a, b);
+      using TypeForIndex = typename std::tuple_element<Index,Tuple>::type;
+      auto aValue = std::get<Index>(a);
+      auto bValue = std::get<Index>(b);
+      return prev && CK::is_equal<TypeForIndex>()(aValue, bValue);
+    }
+  };
+
+  // Base case (0th elements equal)
+  template <class Tuple>
+  struct _eq_helper<Tuple, 0>
+  {
+    static bool equal(Tuple const& a, Tuple const& b)
+    {
+      using TypeForIndex = typename std::tuple_element<0,Tuple>::type;
+      auto& aValue = std::get<0>(a);
+      auto& bValue = std::get<0>(b);
+      return CK::is_equal<TypeForIndex>()(aValue, bValue);
+    }
+  };
+
+
+  template <typename ... TT> struct hash;
+
+  template <typename ... TT>
+  struct hash<std::tuple<TT...>>
+  {
+    size_t operator()(std::tuple<TT...> const& tt) const
+    {
+      return _hash_helper<std::tuple<TT...>>::hash(tt);
+    }
+  };
+
+
+  template <typename ... TT> struct equal_to;
+
+  template <typename ... TT>
+  struct equal_to<std::tuple<TT...>>
+  {
+    bool operator()(std::tuple<TT...> const& a, std::tuple<TT...> const& b) const
+    {
+      return _eq_helper<std::tuple<TT...>>::equal(a, b);
+    }
+  };
+  
+}

--- a/ComponentKit/Utilities/CKEqualityHashHelpers.mm
+++ b/ComponentKit/Utilities/CKEqualityHashHelpers.mm
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKEqualityHashHelpers.h"
+
+#import <functional>
+#import <objc/runtime.h>
+#import <stdio.h>
+#import <string>
+
+/*
+ * Thomas Wang downscaling hash function
+ */
+
+inline uint32_t twang_32from64(uint64_t key) {
+  key = (~key) + (key << 18);
+  key = key ^ (key >> 31);
+  key = key * 21;
+  key = key ^ (key >> 11);
+  key = key + (key << 6);
+  key = key ^ (key >> 22);
+  return (uint32_t) key;
+}
+
+NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count)
+{
+  uint64_t result = subhashes[0];
+  for (int ii = 1; ii < count; ++ii) {
+    result = CKHashCombine(result, subhashes[ii]);
+  }
+#if __LP64__
+  return result;
+#else
+  return twang_32from64(result);
+#endif
+}
+

--- a/ComponentKit/Utilities/CKInternalHelpers.h
+++ b/ComponentKit/Utilities/CKInternalHelpers.h
@@ -16,8 +16,6 @@ BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 
 std::string CKStringFromPointer(const void *ptr);
 
-NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count);
-
 CGFloat CKScreenScale();
 
 CGFloat CKFloorPixelValue(CGFloat f);

--- a/ComponentKit/Utilities/CKInternalHelpers.mm
+++ b/ComponentKit/Utilities/CKInternalHelpers.mm
@@ -31,50 +31,6 @@ std::string CKStringFromPointer(const void *ptr)
   return buf;
 }
 
-
-// From folly:
-
-// This is the Hash128to64 function from Google's cityhash (available
-// under the MIT License).  We use it to reduce multiple 64 bit hashes
-// into a single hash.
-inline uint64_t CKHashCombine(const uint64_t upper, const uint64_t lower) {
-  // Murmur-inspired hashing.
-  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
-  uint64_t a = (lower ^ upper) * kMul;
-  a ^= (a >> 47);
-  uint64_t b = (upper ^ a) * kMul;
-  b ^= (b >> 47);
-  b *= kMul;
-  return b;
-}
-
-/*
- * Thomas Wang downscaling hash function
- */
-
-inline uint32_t twang_32from64(uint64_t key) {
-  key = (~key) + (key << 18);
-  key = key ^ (key >> 31);
-  key = key * 21;
-  key = key ^ (key >> 11);
-  key = key + (key << 6);
-  key = key ^ (key >> 22);
-  return (uint32_t) key;
-}
-
-NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count)
-{
-  uint64_t result = subhashes[0];
-  for (int ii = 1; ii < count; ++ii) {
-    result = CKHashCombine(result, subhashes[ii]);
-  }
-#if __LP64__
-  return result;
-#else
-  return twang_32from64(result);
-#endif
-}
-
 CGFloat CKScreenScale()
 {
   static CGFloat _scale;

--- a/ComponentKitTests/CKComponentMemoizerTests.mm
+++ b/ComponentKitTests/CKComponentMemoizerTests.mm
@@ -1,0 +1,183 @@
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "CKComponent.h"
+#import "CKComponentMemoizer.h"
+#import "CKComponentScopeRoot.h"
+#import "CKComponentSubclass.h"
+#import "CKComponentInternal.h"
+#import "CKInternalHelpers.h"
+#import "CKMacros.h"
+
+#import "CKStackLayoutComponent.h"
+
+@interface CKComponentMemoizerTests : XCTestCase
+
+@end
+
+@interface CKTestMemoizedComponent : CKComponent
+
+@property (nonatomic, copy) NSString *string;
+@property (nonatomic, assign) NSInteger number;
+
+@property (nonatomic, assign, readonly) NSInteger computeCount;
+
+@end
+
+@implementation CKTestMemoizedComponent
+
++ (instancetype)newWithString:(NSString *)string number:(NSInteger)number
+{
+  auto key = CKMakeTupleMemoizationKey(string, number);
+  return
+  CKMemoize(key, ^{
+    CKTestMemoizedComponent *c =
+    [self
+     newWithView:{{[UIView class]}}
+     size:{}];
+
+    c->_string = [string copy];
+    c->_number = number;
+
+    return c;
+  });
+}
+
+- (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize restrictedToSize:(const CKComponentSize &)size relativeToParentSize:(CGSize)parentSize
+{
+  CKComponentLayout l = [super computeLayoutThatFits:constrainedSize restrictedToSize:size relativeToParentSize:parentSize];
+  _computeCount++;
+  return l;
+}
+
+- (BOOL)shouldMemoizeLayout
+{
+  return YES;
+}
+
+@end
+
+@implementation CKComponentMemoizerTests {
+}
+
+- (void)testThatMemoizableComponentsAreMemoized
+{
+  CKComponentScopeRoot *scopeRoot = [CKComponentScopeRoot rootWithListener:nil];
+  CKComponentStateUpdateMap pendingStateUpdates;
+
+  auto build = ^{
+    return [CKTestMemoizedComponent newWithString:@"ABCD" number:123];
+  };
+
+  id memoizerState;
+  CKBuildComponentResult result;
+  CKComponentLayout layout;
+  {
+    // Vend components from the current layout to be available in the new state and layout calculations
+    CKComponentMemoizer memoizer(nil);
+    result = CKBuildComponent(scopeRoot, pendingStateUpdates, build);
+    memoizerState = memoizer.nextMemoizerState();
+  }
+
+  CKBuildComponentResult result2;
+  {
+    CKComponentMemoizer memoizer(memoizerState);
+    result2 = CKBuildComponent(scopeRoot, pendingStateUpdates, build);
+  }
+
+  XCTAssertEqualObjects(result.component, result2.component, @"Should return the original component the second time");
+}
+
+- (void)testThatWhenMultipleComponentsAreMutuallyMemoizableTheyAreStillDistict
+{
+  CKComponentScopeRoot *scopeRoot = [CKComponentScopeRoot rootWithListener:nil];
+  CKComponentStateUpdateMap pendingStateUpdates;
+
+  auto build = ^{
+    return [CKStackLayoutComponent
+            newWithView:{}
+            size:{}
+            style:{}
+            children:{
+              {[CKTestMemoizedComponent newWithString:@"ABCD" number:123]},
+              {[CKTestMemoizedComponent newWithString:@"D" number:0]},
+              {[CKTestMemoizedComponent newWithString:@"ABCD" number:123]},
+            }];
+  };
+
+  
+  CKBuildComponentResult result1;
+  CKComponentLayout layout1;
+  id memoizerState;
+  {
+    CKComponentMemoizer memoizer(nil);
+    
+    result1 = CKBuildComponent(scopeRoot, pendingStateUpdates, build);
+    layout1 = [result1.component layoutThatFits:{CGSizeZero, CGSizeZero} parentSize:CGSizeZero];
+    memoizerState = memoizer.nextMemoizerState();
+  }
+
+  // Vend components from the current layout to be available in the new state and layout calculations
+  CKBuildComponentResult result2;
+  CKComponentLayout layout2;
+  {
+    CKComponentMemoizer memoize(memoizerState);
+
+    result2 = CKBuildComponent(scopeRoot, pendingStateUpdates, build);
+    layout2 = [result2.component layoutThatFits:{CGSizeZero, CGSizeZero} parentSize:CGSizeZero];
+  }
+
+  std::function<NSSet *(const CKComponentLayout &, NSString *)> findAllMatching =
+  [&findAllMatching](const CKComponentLayout &layout, NSString *string){
+    NSMutableSet *result = [NSMutableSet set];
+    if (layout.component && [layout.component isKindOfClass:[CKTestMemoizedComponent class]]) {
+      CKTestMemoizedComponent *tc = (CKTestMemoizedComponent *)layout.component;
+      if ([tc.string isEqualToString:string]) {
+        [result addObject:layout.component];
+      }
+    }
+    for (auto sublayout : *layout.children) {
+      [result unionSet:findAllMatching(sublayout.layout, string)];
+    }
+    return result;
+  };
+
+  NSSet *components1 = findAllMatching(layout1, @"ABCD");
+  NSSet *components2 = findAllMatching(layout2, @"ABCD");
+
+  XCTAssertEqual(components1.count, 2, @"Should have created 2 distinct ABCD components.");
+  XCTAssertEqual(components2.count, 2, @"Should have created 2 distinct ABCD components.");
+  XCTAssertEqualObjects(components1, components2, @"Should have reused both distinct components for <ACBD, 123>.");
+}
+
+
+- (void)testComponentMemoizationKeysCompareObjCObjectsWithIsEqual
+{
+  CKComponentScopeRoot *scopeRoot = [CKComponentScopeRoot rootWithListener:nil];
+  CKComponentStateUpdateMap pendingStateUpdates;
+
+  // Make two objects here that are mutable copies
+  auto build = ^{
+    return [CKTestMemoizedComponent newWithString:[@"ABCD" mutableCopy] number:123];
+  };
+
+  id memoizerState;
+  CKBuildComponentResult result;
+  CKComponentLayout layout;
+  {
+    // Vend components from the current layout to be available in the new state and layout calculations
+    CKComponentMemoizer memoizer(nil);
+    result = CKBuildComponent(scopeRoot, pendingStateUpdates, build);
+    memoizerState = memoizer.nextMemoizerState();
+  }
+
+  CKBuildComponentResult result2;
+  {
+    CKComponentMemoizer memoizer(memoizerState);
+    result2 = CKBuildComponent(scopeRoot, pendingStateUpdates, build);
+  }
+
+  XCTAssertEqualObjects(result.component, result2.component, @"Should return the original component the second time");
+}
+
+@end

--- a/ComponentTextKit/TextKit/CKTextKitAttributes.mm
+++ b/ComponentTextKit/TextKit/CKTextKitAttributes.mm
@@ -10,7 +10,7 @@
 
 #import <ComponentKit/CKTextKitAttributes.h>
 
-#import <ComponentKit/CKInternalHelpers.h>
+#import <ComponentKit/CKEqualityHashHelpers.h>
 
 #include <functional>
 

--- a/ComponentTextKit/TextKit/CKTextKitRendererCache.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRendererCache.mm
@@ -10,7 +10,7 @@
 
 #import <ComponentKit/CKTextKitRendererCache.h>
 
-#import <ComponentKit/CKInternalHelpers.h>
+#import <ComponentKit/CKEqualityHashHelpers.h>
 
 namespace CK {
   namespace TextKit {


### PR DESCRIPTION
This is still pretty rough, but wanted to get it up before I chat with @adamjernst in person tomorrow.

The basic idea is twofold:

1. If you created a component last time with a given set of parameters, when rebuilding the component tree, you can just reuse the previous component. This is easiest done in `+newWithMyModel...`. The only caveat here is that you can't reuse components within a tree, since one component can't be mounted to multiple views.

~~2. If you did a potentially-expensive layout calculation one generation, you don't need to redo it the next one. This ties in directly with component creation, since it doesn't help to reuse components if layout is just going to eat those gains away again.~~ moving to another PR

Rough edges:

- Needs documentation
- Maybe update an example to memoize?
- Tests aren't elegant
- Haven't tested the runtime performance yet
- Some cleanup of these thread-local things should be done

Advantage vs previously-tried approach:

- No longer any iterating over the whole CKComponentLayout looking for components to memoize
- Don't need to make ObjC classes to memoize