### PR TITLE
Fix completely broken hash function

### DIFF
--- a/ComponentKit/Utilities/CKInternalHelpers.h
+++ b/ComponentKit/Utilities/CKInternalHelpers.h
@@ -16,7 +16,7 @@ BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 
 std::string CKStringFromPointer(const void *ptr);
 
-extern NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count);
+NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count);
 
 CGFloat CKScreenScale();
 

--- a/ComponentKit/Utilities/CKInternalHelpers.mm
+++ b/ComponentKit/Utilities/CKInternalHelpers.mm
@@ -31,13 +31,48 @@ std::string CKStringFromPointer(const void *ptr)
   return buf;
 }
 
+
+// From folly:
+
+// This is the Hash128to64 function from Google's cityhash (available
+// under the MIT License).  We use it to reduce multiple 64 bit hashes
+// into a single hash.
+inline uint64_t CKHashCombine(const uint64_t upper, const uint64_t lower) {
+  // Murmur-inspired hashing.
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  uint64_t a = (lower ^ upper) * kMul;
+  a ^= (a >> 47);
+  uint64_t b = (upper ^ a) * kMul;
+  b ^= (b >> 47);
+  b *= kMul;
+  return b;
+}
+
+/*
+ * Thomas Wang downscaling hash function
+ */
+
+inline uint32_t twang_32from64(uint64_t key) {
+  key = (~key) + (key << 18);
+  key = key ^ (key >> 31);
+  key = key * 21;
+  key = key ^ (key >> 11);
+  key = key + (key << 6);
+  key = key ^ (key >> 22);
+  return (uint32_t) key;
+}
+
 NSUInteger CKIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count)
 {
-  NSUInteger result = subhashes[0];
+  uint64_t result = subhashes[0];
   for (int ii = 1; ii < count; ++ii) {
-    result = std::hash<unsigned long long>()((((unsigned long long)result) << 32 | subhashes[ii]));
+    result = CKHashCombine(result, subhashes[ii]);
   }
+#if __LP64__
   return result;
+#else
+  return twang_32from64(result);
+#endif
 }
 
 CGFloat CKScreenScale()

--- a/ComponentTextKitApplicationTests/CKTextKitTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextKitTests.mm
@@ -88,6 +88,34 @@ static BOOL checkAttributes(const CKTextKitAttributes &attributes, const CGSize 
   XCTAssert(checkAttributes(attributes, { 100, 100 }));
 }
 
+- (void)testChangingAPropertyChangesHash
+{
+  NSAttributedString *as = [[NSAttributedString alloc] initWithString:@"hello" attributes:@{NSFontAttributeName : [UIFont systemFontOfSize:12]}];
+
+  CKTextKitAttributes attrib1 {
+    .attributedString = as,
+    .lineBreakMode =  NSLineBreakByClipping,
+  };
+  CKTextKitAttributes attrib2 {
+    .attributedString = as,
+  };
+
+  XCTAssertNotEqual(attrib1.hash(), attrib2.hash(), @"Hashes should differ when NSLineBreakByClipping changes.");
+}
+
+- (void)testSameStringHashesSame
+{
+  CKTextKitAttributes attrib1 {
+    .attributedString = [[NSAttributedString alloc] initWithString:@"hello" attributes:@{NSFontAttributeName : [UIFont systemFontOfSize:12]}],
+  };
+  CKTextKitAttributes attrib2 {
+    .attributedString = [[NSAttributedString alloc] initWithString:@"hello" attributes:@{NSFontAttributeName : [UIFont systemFontOfSize:12]}],
+  };
+
+  XCTAssertEqual(attrib1.hash(), attrib2.hash(), @"Hashes should be the same!");
+}
+
+
 - (void)testStringsWithVariableAttributes
 {
   NSMutableAttributedString *attrStr = [[NSMutableAttributedString alloc] initWithString:@"hello" attributes:@{NSFontAttributeName : [UIFont systemFontOfSize:12]}];


### PR DESCRIPTION
Previously, it would often return 0 since left shifting all previous results by 32-bits deletes a lot of information. Most importantly, the actual text hash!