### PR TITLE
Open source CKStatefulViewComponent.

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		0C293C2FE4684CADAB27CA9D /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
+		18644AE51B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE11B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm */; };
+		18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */; };
+		18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */; };
 		31EBF255C3C6127E5A3619D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		83EBF589FB5C5611BC1A2D13 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
@@ -87,6 +90,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		18644AE11B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStatefulViewComponentControllerTests.mm; sourceTree = "<group>"; };
+		18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStatefulViewReusePoolTests.mm; sourceTree = "<group>"; };
+		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
+		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
 		71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
 		A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm; sourceTree = "<group>"; };
@@ -206,6 +213,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		18644AE01B3CB8E60028AF87 /* StatefulViews */ = {
+			isa = PBXGroup;
+			children = (
+				18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */,
+				18644AE11B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm */,
+				18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */,
+				18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */,
+			);
+			path = StatefulViews;
+			sourceTree = "<group>";
+		};
 		7683E4B5CB30052819FB3185 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -286,6 +304,7 @@
 				B342DC661AC23EA900ACAC53 /* ComponentKitTests-Info.plist */,
 				B342DC671AC23EA900ACAC53 /* Scope */,
 				A27436F51AE94FCA00832359 /* TransactionalDataSource */,
+				18644AE01B3CB8E60028AF87 /* StatefulViews */,
 			);
 			path = ComponentKitTests;
 			sourceTree = "<group>";
@@ -684,10 +703,12 @@
 				B342DC7D1AC23EA900ACAC53 /* CKComponentViewContextTests.mm in Sources */,
 				A279EA9E1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm in Sources */,
 				B342DC801AC23EA900ACAC53 /* CKDimensionTests.mm in Sources */,
+				18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */,
 				B342DC791AC23EA900ACAC53 /* CKComponentPreparationQueueAsyncTests.mm in Sources */,
 				B342DC6E1AC23EA900ACAC53 /* CKComponentControllerLifecycleMethodTests.mm in Sources */,
 				A2100E0D1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm in Sources */,
 				B342DC7C1AC23EA900ACAC53 /* CKComponentViewAttributeTests.mm in Sources */,
+				18644AE51B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm in Sources */,
 				A22FE3031AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm in Sources */,
 				B342DC861AC23EA900ACAC53 /* CKStateScopeComponentBuilderTests.mm in Sources */,
 				B342DC7F1AC23EA900ACAC53 /* CKComponentViewReuseTests.mm in Sources */,
@@ -695,6 +716,7 @@
 				B342DC701AC23EA900ACAC53 /* CKComponentDataSourceTestDelegate.mm in Sources */,
 				B342DC831AC23EA900ACAC53 /* CKTestRunLoopRunning.mm in Sources */,
 				B342DC731AC23EA900ACAC53 /* CKComponentGestureActionsTests.mm in Sources */,
+				18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */,
 				B342DC821AC23EA900ACAC53 /* CKSectionedArrayControllerTests.mm in Sources */,
 				A27C72751AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm in Sources */,
 			);

--- a/ComponentKit/StatefulViews/CKStatefulViewComponent.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponent.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKMacros.h>
+
+struct CKStatefulViewComponentAccessibility {
+  NSNumber *isAccessibilityElement;
+  NSString *accessibilityLabel;
+};
+
+/**
+ Used with CKStatefulViewComponentController.
+ You must use +newWithSize: or +new to initialize this component. You may not specify a view.
+ */
+@interface CKStatefulViewComponent : CKComponent
+
++ (instancetype)newWithSize:(const CKComponentSize &)size
+              accessibility:(const CKStatefulViewComponentAccessibility &)accessibility;
+
++ (instancetype)newWithView:(const CKComponentViewConfiguration &)view size:(const CKComponentSize &)size CK_NOT_DESIGNATED_INITIALIZER_ATTRIBUTE;
+
+@end

--- a/ComponentKit/StatefulViews/CKStatefulViewComponent.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponent.mm
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKStatefulViewComponent.h"
+
+@implementation CKStatefulViewComponent
+
++ (instancetype)newWithView:(const CKComponentViewConfiguration &)view size:(const CKComponentSize &)size
+{
+  [NSException raise:NSInvalidArgumentException format:@"Not designated initializer."];
+  return nil;
+}
+
++ (instancetype)newWithSize:(const CKComponentSize &)size
+              accessibility:(const CKStatefulViewComponentAccessibility &)accessibility
+{
+  // We need a component-created view in the hierarchy to serve as the stateful view's parent to ensure proper ordering.
+  // This is a temporary solution to add accessibility to stateful view components because
+  // the current feed accessibilityLabel aggregator searches the component tree for accessiblity contexts
+  return [super newWithView:
+          {
+            [UIView class],
+            {},
+            {
+              .isAccessibilityElement = accessibility.isAccessibilityElement,
+              .accessibilityLabel = accessibility.accessibilityLabel,
+            },
+          }
+                       size:size];
+}
+
+@end

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.h
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <ComponentKit/CKComponentController.h>
+
+/**
+ CKStatefulViewComponentController acts as an escape hatch for views that don't play nicely with the assumptions made
+ by the Components infrastructure.
+
+ Stateful views have two distinguishing characteristics from regular component views:
+ - The stateful view will move between superviews if the root mounted view changes.
+   (Normally, an entirely new view in the new root view would be used.)
+ - The controller can delay the relinquishing of a stateful view, preventing it from returning to the reuse pool.
+   (Normally, Components expects to be in control of view lifecycles and may return a view to the pool at any time.)
+
+ Examples of where stateful views may be useful:
+ - Photos, when tapped, may wish to animate the photo to fullscreen. When the photo is dismissed, it should return to
+   the place from which it came, even if table view cell recycling has resulted in an entirely new cell being used for
+   the photo's story.
+ - Swapping from one video view to another (because the underlying table view cell was recycled) will result in a
+   noticeable pause in video playback. By using stateful views, the video view will simply be moved to the new cell
+   instead.
+ - Text fields have lots of state that cannot be accessed externally (autocomplete status; precise scroll position).
+   By making the text field a stateful view, it will be moved between cells and maintain this state.
+
+ This controller's corresponding component must subclass CKStatefulViewComponent.
+ */
+@interface CKStatefulViewComponentController : CKComponentController
+
+/** Return a new instance of the stateful view type used by this controller. Views are automatically recycled. */
++ (UIView *)newStatefulView:(id)context;
+
+/**
+ Optionally override this to return a context that should be passed to +newStatefulView.
+ Views will be recycled based on the context returned here. The default is nil.
+ */
++ (id)contextForNewStatefulView:(CKComponent *)component;
+
+/**
+ Configure a given instance of a stateful view with the state from a given CKComponent instance. This has two purposes:
+ - Configuring a view for the first time, before it appears in the view hierarchy;
+ - Reconfiguring the current view when the CKComponent instance is updated and remounted.
+ */
++ (void)configureStatefulView:(UIView *)statefulView
+                 forComponent:(CKComponent *)component;
+
+/**
+ The current stateful view owned by this controller, if any.
+
+ - Do not override this method. (Override +newStatefulView instead.)
+ - Do not remove this view from its superview. (Its children can be removed from the stateful view itself, of course.)
+ - Do not change this view's size. (Trigger a component reflow to change the value passed to +newWithSize: for the
+   corresponding component instead.)
+ */
+- (UIView *)statefulView;
+
+/**
+ Called when a stateful view has been acquired (either created or recycled) and configured.
+ You could use this method to e.g. set the component controller as the view's delegate.
+ */
+- (void)didAcquireStatefulView:(UIView *)statefulView NS_REQUIRES_SUPER;
+
+/**
+ Called when the controller is about to relinquish the given stateful view, returning it to the reuse pool.
+ This will be called when the component controller is not mounted and -canRelinquishStatefulView returns YES.
+
+ Relinquishing the view happens asynchronously after the component is unmounted. When this method is called
+ the view might already have been removed from its superview so consider carefully where you need to cleanup
+ your view's state.
+ */
+- (void)willRelinquishStatefulView:(UIView *)statefulView NS_REQUIRES_SUPER;
+
+/**
+ Override this method to delay relinquishing a stateful view when the controller's component is unmounted.
+ The default implementation returns YES. See -canRelinquishStatefulViewDidChange for an example of how this may be used.
+ */
+- (BOOL)canRelinquishStatefulView;
+
+/**
+ Call this method when the value returned by -canRelinquishStatefulView has changed. This may trigger the controller
+ to relinquish the stateful view.
+
+ For example, a video component controller may return NO from -canRelinquishStatefulView while the video view is
+ fullscreen. After the video exits fullscreen, call this method to signal that -canRelinquishStatefulView will now
+ return YES.
+ */
+- (void)canRelinquishStatefulViewDidChange;
+
+@end

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKStatefulViewComponentController.h"
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+
+#import "CKStatefulViewComponent.h"
+#import "CKStatefulViewReusePool.h"
+
+#import <objc/runtime.h>
+
+@implementation CKStatefulViewComponentController
+{
+  UIView *_statefulView;
+  BOOL _mounted;
+  id _statefulViewContext;
+}
+
++ (UIView *)newStatefulView:(id)context
+{
+  NSAssert(false, @"Should be implemented by subclasses.");
+  return nil;
+}
+
++ (id)contextForNewStatefulView:(CKComponent *)component
+{
+  return nil;
+}
+
++ (void)configureStatefulView:(UIView *)statefulView
+                 forComponent:(CKComponent *)component
+{
+  NSAssert(false, @"Should be implemented by subclasses.");
+}
+
+- (UIView *)statefulView
+{
+  return _statefulView;
+}
+
+- (void)didAcquireStatefulView:(UIView *)statefulView {}
+- (void)willRelinquishStatefulView:(UIView *)statefulView {}
+
+- (BOOL)canRelinquishStatefulView
+{
+  return YES;
+}
+
+- (void)canRelinquishStatefulViewDidChange
+{
+  [self _relinquishStatefulViewIfPossible];
+}
+
+#pragma mark - Lifecycle
+
+- (void)didMount
+{
+  [super didMount];
+
+  NSAssert([[self component] isKindOfClass:[CKStatefulViewComponent class]], @"Component should be a stateful view component.");
+  NSAssert(
+    method_getImplementation(class_getInstanceMethod([CKStatefulViewComponentController class], @selector(statefulView))) ==
+    method_getImplementation(class_getInstanceMethod([self class], @selector(statefulView))),
+    @"Should not override the method -statefulView.");
+
+  if (_statefulView == nil) {
+    _statefulViewContext = [[self class] contextForNewStatefulView:[self component]];
+    _statefulView = [[CKStatefulViewReusePool sharedPool] dequeueStatefulViewForControllerClass:[self class]
+                                                                             preferredSuperview:[self view]
+                                                                                        context:_statefulViewContext];
+    if (_statefulView == nil) {
+      _statefulView = [[self class] newStatefulView:_statefulViewContext];
+    }
+    [[self class] configureStatefulView:_statefulView forComponent:[self component]];
+    [self didAcquireStatefulView:_statefulView];
+  }
+  [self _presentStatefulView];
+  _mounted = YES;
+}
+
+- (void)didRemount
+{
+  [super didRemount];
+  [self _presentStatefulView];
+}
+
+- (void)didUpdateComponent
+{
+  [super didUpdateComponent];
+  if (_statefulView) {
+    [[self class] configureStatefulView:_statefulView forComponent:[self component]];
+  }
+}
+
+- (void)didUnmount
+{
+  [super didUnmount];
+  _mounted = NO;
+  [self _relinquishStatefulViewIfPossible];
+}
+
+#pragma mark - Helpers
+
+- (void)_presentStatefulView
+{
+  const CKComponentViewContext &context = [[self component] viewContext];
+  [_statefulView setFrame:context.frame];
+
+  NSAssert([context.view.subviews count] <= 1, @"Should never have more than a single stateful subview.");
+  UIView *existingView = [context.view.subviews lastObject];
+  if (existingView != _statefulView) {
+    [existingView removeFromSuperview];
+  }
+
+  [context.view addSubview:_statefulView];
+}
+
+- (void)_relinquishStatefulViewIfPossible
+{
+  // Wait for the run loop to turn over before trying to relinquish the view. That ensures that if we are remounted on
+  // a different root view, we reuse the same view (since didMount will be called immediately after didUnmount).
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (_statefulView && !_mounted && [self canRelinquishStatefulView]) {
+      [self willRelinquishStatefulView:_statefulView];
+      [[CKStatefulViewReusePool sharedPool] enqueueStatefulView:_statefulView
+                                             forControllerClass:[self class]
+                                                        context:_statefulViewContext];
+      _statefulView = nil;
+      _statefulViewContext = nil;
+    }
+  });
+}
+
+@end

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface CKStatefulViewReusePool : NSObject
+
++ (instancetype)sharedPool;
+
+- (UIView *)dequeueStatefulViewForControllerClass:(Class)controllerClass
+                               preferredSuperview:(UIView *)preferredSuperview
+                                          context:(id)context;
+
+- (void)enqueueStatefulView:(UIView *)view
+         forControllerClass:(Class)controllerClass
+                    context:(id)context;
+
+@end

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKStatefulViewReusePool.h"
+
+#import <unordered_map>
+
+class FBStatefulReusePoolItem {
+public:
+  FBStatefulReusePoolItem()
+  : preferredSuperviewMap([NSMapTable weakToStrongObjectsMapTable]), allViews([NSMutableArray array]) {};
+
+  UIView *viewWithPreferredSuperview(UIView *preferredSuperview)
+  {
+    NSMutableArray *matchingViews = [preferredSuperviewMap objectForKey:preferredSuperview];
+    UIView *view = [matchingViews lastObject] ?: [allViews lastObject];
+    if (view) {
+      if ([matchingViews count]) {
+        [matchingViews removeObject:view];
+      } else {
+        [[preferredSuperviewMap objectForKey:[view superview]] removeObject:view];
+      }
+      [allViews removeObject:view];
+    }
+    return view;
+  };
+
+  void addView(UIView *view)
+  {
+    UIView *superview = [view superview];
+    if (superview) {
+      NSMutableArray *matchingViews = [preferredSuperviewMap objectForKey:superview];
+      if (matchingViews == nil) {
+        matchingViews = [[NSMutableArray alloc] init];
+        [preferredSuperviewMap setObject:matchingViews forKey:superview];
+      }
+      [matchingViews addObject:view];
+    }
+    [allViews addObject:view];
+  };
+
+private:
+  // Maps superviews (weakly held keys) to views available for reuse within them.
+  NSMapTable *preferredSuperviewMap;
+  NSMutableArray *allViews;
+};
+
+struct PoolKeyHasher {
+  std::size_t operator()(const std::pair<__unsafe_unretained Class, id> &pair) const
+  {
+    return [pair.first hash] ^ [pair.second hash];
+  }
+};
+
+@implementation CKStatefulViewReusePool
+{
+  std::unordered_map<std::pair<__unsafe_unretained Class, id>, FBStatefulReusePoolItem, PoolKeyHasher> _pool;
+}
+
++ (instancetype)sharedPool
+{
+  static CKStatefulViewReusePool *pool;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    pool = [[CKStatefulViewReusePool alloc] init];
+  });
+  return pool;
+}
+
+- (UIView *)dequeueStatefulViewForControllerClass:(Class)controllerClass
+                               preferredSuperview:(UIView *)preferredSuperview
+                                          context:(id)context
+{
+  NSAssert([NSThread isMainThread], nil);
+  NSParameterAssert(controllerClass != nil);
+  const auto it = _pool.find(std::make_pair(controllerClass, context));
+  if (it == _pool.end()) { // Avoid overhead of creating the item unless it already exists
+    return nil;
+  }
+  return it->second.viewWithPreferredSuperview(preferredSuperview);
+}
+
+- (void)enqueueStatefulView:(UIView *)view
+         forControllerClass:(Class)controllerClass
+                    context:(id)context
+{
+  NSAssert([NSThread isMainThread], nil);
+  NSParameterAssert(view != nil);
+  NSParameterAssert(controllerClass != nil);
+
+  return _pool[std::make_pair(controllerClass, context)].addView(view);
+}
+
+@end

--- a/ComponentKitTests/StatefulViews/CKStatefulViewComponentControllerTests.mm
+++ b/ComponentKitTests/StatefulViews/CKStatefulViewComponentControllerTests.mm
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentSubclass.h>
+
+#import <ComponentKitTestLib/CKComponentTestRootScope.h>
+
+#import "CKTestRunLoopRunning.h"
+
+#import "CKTestStatefulViewComponent.h"
+
+@interface CKStatefulViewComponentControllerTests : XCTestCase <CKComponentProvider>
+@end
+
+@implementation CKStatefulViewComponentControllerTests
+
++ (CKComponent *)componentForModel:(id<NSObject>)model context:(id<NSObject>)context
+{
+  return [CKTestStatefulViewComponent newWithColor:(UIColor *)model];
+}
+
+- (void)testMountingStatefulViewComponentCreatesStatefulView
+{
+  CKComponentLifecycleManager *m = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  const CKComponentLifecycleManagerState state = [m prepareForUpdateWithModel:[UIColor blueColor] constrainedSize:{{100, 100}, {100, 100}} context:nil];
+  [m updateWithState:state];
+
+  UIView *container = [[UIView alloc] init];
+  [m attachToView:container];
+
+  auto component = (CKTestStatefulViewComponent *)state.layout.component;
+  auto controller = (CKTestStatefulViewComponentController *)[component controller];
+  auto statefulView = [controller statefulView];
+  XCTAssertTrue([statefulView isKindOfClass:[CKTestStatefulView class]], @"Expected stateful view but couldn't find it");
+  XCTAssertTrue(CGRectEqualToRect([statefulView frame], CGRectMake(0, 0, 100, 100)), @"Expected view to be sized to match component");
+  XCTAssertEqualObjects([statefulView backgroundColor], [UIColor blueColor], @"Expected view to be configured");
+}
+
+- (void)testUnmountingStatefulViewComponentEventuallyRelinquishesStatefulView
+{
+  CKComponentLifecycleManager *m = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  const CKComponentLifecycleManagerState state = [m prepareForUpdateWithModel:nil constrainedSize:{{100, 100}, {100, 100}} context:nil];
+  [m updateWithState:state];
+
+  UIView *container = [[UIView alloc] init];
+  [m attachToView:container];
+
+  auto component = (CKTestStatefulViewComponent *)state.layout.component;
+  auto controller = (CKTestStatefulViewComponentController *)[component controller];
+  XCTAssertNotNil([controller statefulView], @"Expected to have a stateful view while mounted");
+
+  [m detachFromView];
+  XCTAssertTrue(CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return [controller statefulView] == nil;
+  }), @"Expected view to be relinquished");
+}
+
+- (void)testMountingStatefulViewComponentOnNewRootViewMovesStatefulView
+{
+  CKComponentLifecycleManager *m = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  const CKComponentLifecycleManagerState state = [m prepareForUpdateWithModel:nil constrainedSize:{{100, 100}, {100, 100}} context:nil];
+  [m updateWithState:state];
+
+  auto controller = (CKTestStatefulViewComponentController *)[(CKTestStatefulViewComponent *)state.layout.component controller];
+
+  UIView *container1 = [[UIView alloc] init];
+  [m attachToView:container1];
+  XCTAssertTrue([[controller statefulView] isDescendantOfView:container1], @"Expected view to be in container1");
+
+  UIView *container2 = [[UIView alloc] init];
+  [m attachToView:container2];
+  XCTAssertTrue([[controller statefulView] isDescendantOfView:container2], @"Expected view to be moved to container2");
+}
+
+- (void)testUpdatingStatefulViewComponentSizeUpdatesStatefulViewSize
+{
+  CKComponentLifecycleManager *m = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  const CKComponentLifecycleManagerState state = [m prepareForUpdateWithModel:nil constrainedSize:{{100, 100}, {100, 100}} context:nil];
+  [m updateWithState:state];
+  UIView *container = [[UIView alloc] init];
+  [m attachToView:container];
+  auto controller = (CKTestStatefulViewComponentController *)[(CKTestStatefulViewComponent *)state.layout.component controller];
+
+  [m updateWithState:[m prepareForUpdateWithModel:nil constrainedSize:{{50, 50}, {50, 50}} context:nil]];
+  XCTAssertTrue(CGRectEqualToRect([[controller statefulView] frame], CGRectMake(0, 0, 50, 50)), @"Stateful view size should be updated to match new size");
+}
+
+- (void)testUpdatingStatefulViewComponentColorUpdatesStatefulViewColor
+{
+  CKComponentLifecycleManager *m = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  const CKComponentLifecycleManagerState state = [m prepareForUpdateWithModel:[UIColor whiteColor] constrainedSize:{{0, 0}, {100, 100}} context:nil];
+  [m updateWithState:state];
+  UIView *container = [[UIView alloc] init];
+  [m attachToView:container];
+  auto controller = (CKTestStatefulViewComponentController *)[(CKTestStatefulViewComponent *)state.layout.component controller];
+
+  [m updateWithState:[m prepareForUpdateWithModel:[UIColor redColor] constrainedSize:{{100, 100}, {100, 100}} context:nil]];
+  XCTAssertEqualObjects([[controller statefulView] backgroundColor], [UIColor redColor], @"Stateful view size should be updated to match new color");
+}
+
+@end

--- a/ComponentKitTests/StatefulViews/CKStatefulViewReusePoolTests.mm
+++ b/ComponentKitTests/StatefulViews/CKStatefulViewReusePoolTests.mm
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import <ComponentKit/CKStatefulViewReusePool.h>
+
+#import "CKTestStatefulViewComponent.h"
+
+@interface CKStatefulViewReusePoolTests : XCTestCase
+@end
+
+@interface CKOtherStatefulViewComponentController : CKStatefulViewComponentController
+@end
+
+@implementation CKStatefulViewReusePoolTests
+
+- (void)testDequeueingFromEmptyPoolReturnsNil
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  UIView *container = [[UIView alloc] init];
+  XCTAssertNil([pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                       preferredSuperview:container
+                                                  context:nil], @"Didn't expect to vend view from empty pool");
+}
+
+- (void)testEnqueueingViewThenDequeueingReturnsSameView
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil];
+  UIView *container = [[UIView alloc] init];
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                  preferredSuperview:container
+                                                             context:nil];
+  XCTAssertTrue(dequeuedView == view, @"Expected enqueued view to be returned");
+}
+
+- (void)testEnqueueingViewThenDequeueingWithDifferentControllerClassReturnsNil
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil];
+  UIView *container = [[UIView alloc] init];
+  XCTAssertNil([pool dequeueStatefulViewForControllerClass:[CKOtherStatefulViewComponentController class]
+                                       preferredSuperview:container
+                                                  context:nil], @"Didn't expect to vend view, controller mismatch");
+}
+
+- (void)testEnqueueingTwoViewsThenDequeueingWithPreferredSuperviewReturnsViewWithMatchingSuperview
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+
+  UIView *container1 = [[UIView alloc] init];
+  CKTestStatefulView *view1 = [[CKTestStatefulView alloc] init];
+  [container1 addSubview:view1];
+  [pool enqueueStatefulView:view1
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil];
+
+  UIView *container2 = [[UIView alloc] init];
+  CKTestStatefulView *view2 = [[CKTestStatefulView alloc] init];
+  [container2 addSubview:view2];
+  [pool enqueueStatefulView:view2
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil];
+
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                  preferredSuperview:container1
+                                                             context:nil];
+  XCTAssertTrue(dequeuedView == view1, @"Expected view in container1 to be returned");
+}
+
+- (void)testDequeueingViewDoesNotLaterDequeueTheSameViewForTheOriginalSuperview
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+
+  UIView *container1 = [[UIView alloc] init];
+  [container1 addSubview:view];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil];
+
+  UIView *container2 = [[UIView alloc] init];
+  [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                           preferredSuperview:container2
+                                      context:nil];
+
+  XCTAssertNil([pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                       preferredSuperview:container1
+                                                  context:nil], @"Didn't expect to vend view.");
+}
+
+- (void)testEnqueueingViewThenDequeueingWithDifferentContextReturnsNewView
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  UIView *containerView = [[UIView alloc] init];
+
+  UIView *firstView =[[UIView alloc] init];
+  [pool enqueueStatefulView:firstView
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:@"context1"];
+
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                     preferredSuperview:containerView
+                                                                context:@"context2"];
+  XCTAssertTrue(firstView != dequeuedView, @"Expected different view to be vended.");
+}
+
+@end
+
+@implementation CKOtherStatefulViewComponentController
+@end

--- a/ComponentKitTests/StatefulViews/CKTestStatefulViewComponent.h
+++ b/ComponentKitTests/StatefulViews/CKTestStatefulViewComponent.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <ComponentKit/CKStatefulViewComponent.h>
+#import <ComponentKit/CKStatefulViewComponentController.h>
+
+@interface CKTestStatefulViewComponentController : CKStatefulViewComponentController
+@end
+
+@interface CKTestStatefulViewComponent : CKStatefulViewComponent
++ (instancetype)newWithColor:(UIColor *)color;
+@end
+
+@interface CKTestStatefulView : UIView
+@end

--- a/ComponentKitTests/StatefulViews/CKTestStatefulViewComponent.mm
+++ b/ComponentKitTests/StatefulViews/CKTestStatefulViewComponent.mm
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKTestStatefulViewComponent.h"
+
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKStatefulViewComponentController.h>
+
+@interface CKTestStatefulViewComponent ()
+@property (nonatomic, strong) UIColor *color;
+@end
+
+@implementation CKTestStatefulViewComponent
++ (instancetype)newWithColor:(UIColor *)color
+{
+  CKComponentScope scope(self);
+  CKTestStatefulViewComponent *c = [super newWithSize:{} accessibility:{}];
+  if (c) {
+    c->_color = color;
+  }
+  return c;
+}
+@end
+
+@implementation CKTestStatefulViewComponentController
+
++ (UIView *)newStatefulView:(id)context
+{
+  return [[CKTestStatefulView alloc] init];
+}
+
++ (void)configureStatefulView:(UIView *)statefulView forComponent:(CKComponent *)component
+{
+  statefulView.backgroundColor = [(CKTestStatefulViewComponent *)component color];
+}
+
+@end
+
+@implementation CKTestStatefulView
+@end


### PR DESCRIPTION
Just a 1:1 import of CKStatefulViewCompontent from the internal repo. This component lets you wrap a view that maintains internal state that you don't control, while still having a stateless API. It's mostly useful for text editing by wrapping UITextView and UITextField. No specific component subclasses are included here, but they can be built as subclasses of CKStatefulViewComponentController.