### PR TITLE
Refactor ComponentHostingView

### DIFF
--- a/ComponentKit/Core/CKComponentLifecycleManager.h
+++ b/ComponentKit/Core/CKComponentLifecycleManager.h
@@ -42,8 +42,6 @@ extern const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEm
 
 - (CKComponentLifecycleManagerState)prepareForUpdateWithModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context;
 
-- (CKComponentLayout)layoutForModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context;
-
 /**
  Updates the state to the new one without mounting the view.
 

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -105,15 +105,6 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
   };
 }
 
-- (CKComponentLayout)layoutForModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context
-{
-  CKBuildComponentResult result = CKBuildComponent(_state.root ?: [CKComponentScopeRoot rootWithListener:nil], {}, ^{
-    return [_componentProvider componentForModel:model context:context];
-  });
-
-  return [result.component layoutThatFits:constrainedSize parentSize:constrainedSize.max];
-}
-
 - (void)updateWithState:(const CKComponentLifecycleManagerState &)state
 {
   BOOL sizeChanged = !CGSizeEqualToSize(_state.layout.size, state.layout.size);

--- a/ComponentKit/HostingView/CKComponentHostingViewInternal.h
+++ b/ComponentKit/HostingView/CKComponentHostingViewInternal.h
@@ -10,6 +10,7 @@
 
 #import <ComponentKit/CKComponentHostingView.h>
 #import <ComponentKit/CKDimension.h>
+#import <ComponentKit/CKComponentLayout.h>
 
 @class CKComponentLifecycleManager;
 
@@ -17,10 +18,8 @@
 
 @property (nonatomic, strong, readonly) UIView *containerView;
 @property (nonatomic, readonly) CKSizeRange constrainedSize;
-@property (nonatomic, readonly) CKComponentLifecycleManager *lifecycleManager;
 
-- (instancetype)initWithLifecycleManager:(CKComponentLifecycleManager *)manager
-                       sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                 context:(id<NSObject>)context;
+/** Returns the layout that's currently mounted. Main thread only. */
+- (const CKComponentLayout &)mountedLayout;
 
 @end

--- a/ComponentKitTests/CKComponentHostingViewTests.mm
+++ b/ComponentKitTests/CKComponentHostingViewTests.mm
@@ -19,51 +19,26 @@
 #import "CKComponentHostingView.h"
 #import "CKComponentHostingViewDelegate.h"
 #import "CKComponentHostingViewInternal.h"
-#import "CKComponentLifecycleManager.h"
 #import "CKComponentViewInterface.h"
 
 @interface CKComponentHostingViewTests : XCTestCase <CKComponentProvider, CKComponentHostingViewDelegate>
 @end
 
-@interface CKFakeComponentLifecycleManager : NSObject
-@property (nonatomic, assign) BOOL updateWithStateWasCalled;
-@end
-
-@implementation CKFakeComponentLifecycleManager {
-  BOOL _isAttached;
-}
-
-- (CKComponentLifecycleManagerState)prepareForUpdateWithModel:(id)model constrainedSize:(CKSizeRange)constrainedSize context:(id<NSObject>)context
+static CKComponentHostingView *hostingView()
 {
-  return CKComponentLifecycleManagerStateEmpty;
+  CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
+  CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithComponentProvider:[CKComponentHostingViewTests class]
+                                                                         sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]
+                                                                                   context:nil];
+  view.bounds = CGRectMake(0, 0, 100, 100);
+  view.model = model;
+  [view layoutIfNeeded];
+  return view;
 }
-
-- (void)updateWithState:(const CKComponentLifecycleManagerState &)state
-{
-  self.updateWithStateWasCalled = YES;
-}
-
-- (void)attachToView:(UIView *)view
-{
-  _isAttached = YES;
-}
-
-- (void)detachFromView
-{
-  _isAttached = NO;
-}
-
-- (BOOL)isAttachedToView
-{
-  return _isAttached;
-}
-
-- (void)setDelegate:(id<CKComponentLifecycleManagerDelegate>)delegate {}
-
-@end
 
 @implementation CKComponentHostingViewTests {
   BOOL _calledSizeDidInvalidate;
+  CKComponentHostingView *_hostingView;
 }
 
 + (CKComponent *)componentForModel:(CKComponentHostingViewTestModel *)model context:(id<NSObject>)context
@@ -71,93 +46,71 @@
   return CKComponentWithHostingViewTestModel(model);
 }
 
-- (CKComponentHostingView *)newHostingView
+- (void)setUp
 {
-  CKComponentLifecycleManager *manager = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
-  return [self newHostingViewWithLifecycleManager:manager];
-}
-
-- (CKComponentHostingView *)newHostingViewWithLifecycleManager:(CKComponentLifecycleManager *)manager
-{
-  CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
-  CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithLifecycleManager:manager
-                                                                        sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]
-                                                                                  context:nil];
-  view.bounds = CGRectMake(0, 0, 100, 100);
-  view.model = model;
-  [view layoutIfNeeded];
-  return view;
-}
-
-- (void)tearDown
-{
+  [super setUp];
   _calledSizeDidInvalidate = NO;
-  [super tearDown];
 }
 
 - (void)testInitializationInsertsContainerViewInHierarchy
 {
-  CKComponentHostingView *hostingView = [self newHostingView];
-  XCTAssertTrue(hostingView.subviews.count == 1, @"Expect hosting view to have a single subview.");
+  CKComponentHostingView *view = hostingView();
+  XCTAssertTrue(view.subviews.count == 1, @"Expect hosting view to have a single subview.");
 }
 
-- (void)testInitializationInsertsComponentViewInHierarcy
+- (void)testInitializationInsertsComponentViewInHierarchy
 {
-  CKComponentHostingView *hostingView = [self newHostingView];
-
-  XCTAssertTrue([hostingView.containerView.subviews count] > 0, @"Expect that initialization should insert component view as subview of container view.");
+  CKComponentHostingView *view = hostingView();
+  XCTAssertTrue([view.containerView.subviews count] > 0, @"Expect that initialization should insert component view as subview of container view.");
 }
 
-- (void)testLifecycleManagerAttachedToContainerAndNotRoot
+- (void)testUpdatingHostingViewBoundsResizesComponentView
 {
-  CKComponentHostingView *hostingView = [self newHostingView];
-  XCTAssertNil(hostingView.ck_componentLifecycleManager, @"Expect hosting view to have no lifecycle manager.");
-  XCTAssertNotNil(hostingView.containerView.ck_componentLifecycleManager, @"Expect container view to have a lifecycle manager.");
-}
+  CKComponentHostingView *view = hostingView();
+  view.bounds = CGRectMake(0, 0, 200, 200);
+  [view layoutIfNeeded];
 
-- (void)testUpdatesOnBoundsChange
-{
-  id fakeManager = [[CKFakeComponentLifecycleManager alloc] init];
-  CKComponentHostingView *hostingView = [self newHostingViewWithLifecycleManager:fakeManager];
-
-  hostingView.bounds = CGRectMake(0, 0, 100, 100);
-
-  XCTAssertTrue([fakeManager updateWithStateWasCalled], @"Expect update to be triggered on bounds change.");
+  UIView *componentView = [view.containerView.subviews firstObject];
+  XCTAssertEqualObjects(componentView.backgroundColor, [UIColor orangeColor], @"Expected to find orange component view");
+  XCTAssertTrue(CGRectEqualToRect(componentView.bounds, CGRectMake(0, 0, 200, 200)));
 }
 
 - (void)testUpdatesOnModelChange
 {
-  id fakeManager = [[CKFakeComponentLifecycleManager alloc] init];
-  CKComponentHostingView *hostingView = [self newHostingViewWithLifecycleManager:fakeManager];
-  CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor redColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
+  CKComponentHostingView *view = hostingView();
+  view.model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor redColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
+  [view layoutIfNeeded];
 
-  hostingView.model = model;
-
-  XCTAssertTrue([fakeManager updateWithStateWasCalled], @"Expect update to be triggered on bounds change.");
+  UIView *componentView = [view.containerView.subviews firstObject];
+  XCTAssertEqualObjects(componentView.backgroundColor, [UIColor redColor], @"Expected component view to become red");
 }
 
-- (void)testCallsDelegateOnSizeChange
+- (void)testInformsDelegateSizeIsInvalidatedOnModelChange
 {
-  CKComponentHostingView *hostingView = [self newHostingView];
-  hostingView.delegate = self;
-  hostingView.model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(75, 75))];
-  hostingView.bounds = (CGRect){ .size = [hostingView sizeThatFits:CGSizeMake(75, CGFLOAT_MAX)] };
-  [hostingView layoutIfNeeded];
-
-  XCTAssertTrue(_calledSizeDidInvalidate, @"Expect -componentHostingViewSizeDidInvalidate: to be called when component size changes.");
+  CKComponentHostingView *view = hostingView();
+  view.delegate = self;
+  view.model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(75, 75))];
+  XCTAssertTrue(_calledSizeDidInvalidate);
 }
 
-- (void)testUpdateWithEmptyBoundsDoesntAttachLifecycleManager
+- (void)testInformsDelegateSizeIsInvalidatedOnContextChange
 {
-  CKComponentLifecycleManager *manager = [[CKComponentLifecycleManager alloc] initWithComponentProvider:[self class]];
+  CKComponentHostingView *view = hostingView();
+  view.delegate = self;
+  view.context = @"foo";
+  XCTAssertTrue(_calledSizeDidInvalidate);
+}
+
+- (void)testUpdateWithEmptyBoundsDoesntMountLayout
+{
   CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
-  CKComponentHostingView *hostingView = [[CKComponentHostingView alloc] initWithLifecycleManager:manager
-                                                                               sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]
-                                                                                         context:nil];
-  hostingView.model = model;
-  [hostingView layoutIfNeeded];
+  CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithComponentProvider:[self class]
+                                                                         sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]
+                                                                                   context:nil];
+  view.model = model;
+  [view layoutIfNeeded];
 
-  XCTAssertFalse([manager isAttachedToView], @"Expect lifecycle manager to not be attached to the view when the bounds rect is empty.");
+  XCTAssertEqual([view.containerView.subviews count], 0u, @"Expect the component is not mounted with empty bounds");
 }
 
 #pragma mark - CKComponentHostingViewDelegate


### PR DESCRIPTION
- No longer uses `CKComponentLifecycleManager`, freeing us from that cruft.
- If only the size of the view changes, but not the model or context, the component is not regenerated. This is more efficient.
- Similarly we cache the computed layout, so if for some reason `layoutSubviews` is called twice with no change to the component or size, we won't expensively re-layout the component.
- Added thread safety asserts.

Next up is to add asynchronous modes for model, state, and context updates.