### PR TITLE
Clean up CKComponentHostingView's API

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.h
+++ b/ComponentKit/HostingView/CKComponentHostingView.h
@@ -16,25 +16,18 @@
 @protocol CKComponentHostingViewDelegate;
 @protocol CKComponentSizeRangeProviding;
 
-/**
- A view the can host a component tree and automatically update it when the model or internal state changes.
- */
+/** A view that renders a single component. */
 @interface CKComponentHostingView : UIView
 
-/**
- The delegate of the view.
- */
+/** Notified when the view's ideal size (measured by -sizeThatFits:) may have changed. */
 @property (nonatomic, weak) id<CKComponentHostingViewDelegate> delegate;
 
-/**
- Designated initializer.
- */
+/** Designated initializer. */
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
-                        sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                  context:(id<NSObject>)context;
+                        sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider;
 
 /**
- The model object used to generate the component-tree hosted by the view.
+ The model object used to generate the view's component.
 
  Setting a new model will synchronously construct and mount a new component tree and the
  delegate will be notified if there is a change in size.

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -50,12 +50,10 @@
 
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
                         sizeRangeProvider:(id<CKComponentSizeRangeProviding>)sizeRangeProvider
-                                  context:(id<NSObject>)context
 {
   if (self = [super initWithFrame:CGRectZero]) {
     _componentProvider = componentProvider;
     _sizeRangeProvider = sizeRangeProvider;
-    _context = context;
     _scopeRoot = [CKComponentScopeRoot rootWithListener:self];
 
     _containerView = [[CKComponentRootView alloc] initWithFrame:CGRectZero];

--- a/ComponentKit/HostingView/CKComponentHostingViewInternal.h
+++ b/ComponentKit/HostingView/CKComponentHostingViewInternal.h
@@ -17,7 +17,6 @@
 @interface CKComponentHostingView ()
 
 @property (nonatomic, strong, readonly) UIView *containerView;
-@property (nonatomic, readonly) CKSizeRange constrainedSize;
 
 /** Returns the layout that's currently mounted. Main thread only. */
 - (const CKComponentLayout &)mountedLayout;

--- a/ComponentKitTests/CKComponentHostingViewTests.mm
+++ b/ComponentKitTests/CKComponentHostingViewTests.mm
@@ -28,8 +28,7 @@ static CKComponentHostingView *hostingView()
 {
   CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
   CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithComponentProvider:[CKComponentHostingViewTests class]
-                                                                         sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]
-                                                                                   context:nil];
+                                                                         sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]];
   view.bounds = CGRectMake(0, 0, 100, 100);
   view.model = model;
   [view layoutIfNeeded];
@@ -105,8 +104,7 @@ static CKComponentHostingView *hostingView()
 {
   CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
   CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithComponentProvider:[self class]
-                                                                         sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]
-                                                                                   context:nil];
+                                                                         sizeRangeProvider:[CKComponentFlexibleSizeRangeProvider providerWithFlexibility:CKComponentSizeRangeFlexibleWidthAndHeight]];
   view.model = model;
   [view layoutIfNeeded];
 


### PR DESCRIPTION
- Since context is now mutable and is optional in any case, we shouldn't pass it to init.
- Clean up documentation.