### PR TITLE
pcomponents now outputs coupled component and view descriptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: objective-c
 
 before_install:
   - gem install activesupport
-  - gem update cocoapods
-  - gem install slather
+  - gem install cocoapods -v 0.37.2
+  - gem install slather -v 1.8
 
 script: ./build.sh ci
 

--- a/ComponentKit/Core/CKComponentLayout.h
+++ b/ComponentKit/Core/CKComponentLayout.h
@@ -29,14 +29,15 @@ struct CKComponentLayout {
   CKComponent *component;
   CGSize size;
   std::shared_ptr<const std::vector<CKComponentLayoutChild>> children;
+  NSDictionary *extra;
 
-  CKComponentLayout(CKComponent *c, CGSize s, std::vector<CKComponentLayoutChild> ch = {})
-  : component(c), size(s), children(new std::vector<CKComponentLayoutChild>(std::move(ch)), CKOffMainThreadDeleter()) {
+  CKComponentLayout(CKComponent *c, CGSize s, std::vector<CKComponentLayoutChild> ch = {}, NSDictionary *e = nil)
+  : component(c), size(s), children(new std::vector<CKComponentLayoutChild>(std::move(ch)), CKOffMainThreadDeleter()), extra(e) {
     CKCAssertNotNil(c, @"Nil components are not allowed");
   };
 
   CKComponentLayout()
-  : component(nil), size({0, 0}), children(new std::vector<CKComponentLayoutChild>(), CKOffMainThreadDeleter()) {};
+  : component(nil), size({0, 0}), children(new std::vector<CKComponentLayoutChild>(), CKOffMainThreadDeleter()), extra(nil) {};
 };
 
 struct CKComponentLayoutChild {

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -210,7 +210,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
 
 #pragma mark - Debug
 
-- (CKComponentLifecycleManagerState)state
+- (const CKComponentLifecycleManagerState &)state
 {
   return _state;
 }

--- a/ComponentKit/Core/CKComponentLifecycleManagerInternal.h
+++ b/ComponentKit/Core/CKComponentLifecycleManagerInternal.h
@@ -16,6 +16,6 @@
  */
 @interface CKComponentLifecycleManager () <CKComponentStateListener>
 
-- (CKComponentLifecycleManagerState)state;
+- (const CKComponentLifecycleManagerState &)state;
 
 @end

--- a/ComponentKit/Core/CKComponentMemoizer.mm
+++ b/ComponentKit/Core/CKComponentMemoizer.mm
@@ -167,9 +167,11 @@ id CKComponentMemoizer::nextMemoizerState()
 CKComponentLayout CKMemoizeOrComputeLayout(CKComponent *component, CKSizeRange constrainedSize, const CKComponentSize& size, CGSize parentSize)
 {
   if (component && [component shouldMemoizeLayout]) {
-    return [[_CKComponentMemoizerImpl currentMemoizer] cachedLayout:component thatFits:constrainedSize restrictedToSize:size parentSize:parentSize];
-  } else {
-    return [component computeLayoutThatFits:constrainedSize restrictedToSize:size relativeToParentSize:parentSize];
+    _CKComponentMemoizerImpl *impl = [_CKComponentMemoizerImpl currentMemoizer];
+    if (impl) { // If component wants layout memoization but there isn't a current memoizer, fall down to compute case
+      return [impl cachedLayout:component thatFits:constrainedSize restrictedToSize:size parentSize:parentSize];
+    }
   }
+  return [component computeLayoutThatFits:constrainedSize restrictedToSize:size relativeToParentSize:parentSize];
 }
 

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.h
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.h
@@ -26,4 +26,12 @@
  */
 + (NSString *)componentHierarchyDescription;
 
+/**
+ @param view the view to begin the recursive search
+ @param upwards a boolean which if true, returns the ancestors of view, and if false returns the downward hierarchy
+
+ @return A string with a description of the hierarchy starting or ending at view, depending on upwards
+ */
++ (NSString *)componentHierarchyDescriptionForView:(UIView *)view searchUpwards:(BOOL)upwards;
+
 @end

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.h
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.h
@@ -26,12 +26,4 @@
  */
 + (NSString *)componentHierarchyDescription;
 
-/**
- @param view the view to begin the recursive search
- @param upwards a boolean which if true, returns the ancestors of view, and if false returns the downward hierarchy
-
- @return A string with a description of the hierarchy starting or ending at view, depending on upwards
- */
-+ (NSString *)componentHierarchyDescriptionForView:(UIView *)view searchUpwards:(BOOL)upwards;
-
 @end

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -49,19 +49,19 @@ static NSString *const indentString = @"| ";
 
 static NSString *ancestorComponentHierarchyDescriptionForView(UIView *view)
 {
-  NSString *ancestors;
+  NSString *ancestorDescription;
   if (view.ck_component) {
-    // Views including and above root view are isolated
     CKComponentRootView *rootView = rootViewForView(view);
-    NSString *viewAncestors = ancestorDescriptionForView(rootView);
-    NSString *componentAncestors = componentAncestorDescriptionForView(view, rootView, [@"" stringByPaddingToLength:depthOfViewInViewHierarchy(rootView) * indentString.length
+    NSString *viewAncestorDescription = ancestorDescriptionForView(rootView);
+    NSString *componentAncestorDescription = componentAncestorDescriptionForView(view, rootView, [@"" stringByPaddingToLength:depthOfViewInViewHierarchy(rootView) * indentString.length
                                                                                                          withString:indentString
                                                                                                     startingAtIndex:0]);
-    ancestors = [viewAncestors stringByAppendingString:componentAncestors];
+    ancestorDescription = [viewAncestorDescription stringByAppendingString:componentAncestorDescription];
   } else {
-    ancestors = ancestorDescriptionForView(view);
+    // Views including and above root view do not have an associated component
+    ancestorDescription = ancestorDescriptionForView(view);
   }
-  return ancestors;
+  return ancestorDescription;
 }
 
 static NSUInteger depthOfViewInViewHierarchy(UIView *view)

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -47,7 +47,7 @@ static NSString *const indentString = @"| ";
   }
 }
 
-NSString *ancestorComponentHierarchyDescriptionForView(UIView *view)
+static NSString *ancestorComponentHierarchyDescriptionForView(UIView *view)
 {
   NSString *ancestors;
   if (view.ck_component) {
@@ -64,7 +64,7 @@ NSString *ancestorComponentHierarchyDescriptionForView(UIView *view)
   return ancestors;
 }
 
-NSUInteger depthOfViewInViewHierarchy(UIView *view)
+static NSUInteger depthOfViewInViewHierarchy(UIView *view)
 {
   NSUInteger depth = 0;
   while (view) {
@@ -74,7 +74,7 @@ NSUInteger depthOfViewInViewHierarchy(UIView *view)
   return depth;
 }
 
-NSString *ancestorDescriptionForView(UIView *view)
+static NSString *ancestorDescriptionForView(UIView *view)
 {
   NSMutableArray *ancestors = [NSMutableArray array];
   while (view) {
@@ -94,7 +94,7 @@ NSString *ancestorDescriptionForView(UIView *view)
   return description;
 }
 
-NSString *componentAncestorDescriptionForView(UIView *view, CKComponentRootView *rootView, NSString *prefix)
+static NSString *componentAncestorDescriptionForView(UIView *view, CKComponentRootView *rootView, NSString *prefix)
 {
   const CKComponentLayout &rootLayout = layoutForRootView(rootView);
   CKComponent *component = view.ck_component;
@@ -109,7 +109,7 @@ NSString *componentAncestorDescriptionForView(UIView *view, CKComponentRootView 
   return description;
 }
 
-BOOL buildComponentAncestors(const CKComponentLayout &layout, CKComponent *component, CGPoint position, std::deque<CKComponentDescriptionInformation> &ancestors)
+static BOOL buildComponentAncestors(const CKComponentLayout &layout, CKComponent *component, CGPoint position, std::deque<CKComponentDescriptionInformation> &ancestors)
 {
   CKComponent *layoutComponent = layout.component;
   UIView *view = layoutComponent.viewContext.view;
@@ -132,7 +132,7 @@ BOOL buildComponentAncestors(const CKComponentLayout &layout, CKComponent *compo
   return YES;
 }
 
-NSString *componentHierarchyDescriptionForView(UIView *view)
+static NSString *componentHierarchyDescriptionForView(UIView *view)
 {
   NSString *description;
   if (view.ck_component) {
@@ -147,25 +147,25 @@ NSString *componentHierarchyDescriptionForView(UIView *view)
   return description;
 }
 
-NSMutableString *computeDescription(CKComponent *component, UIView *view, CGSize size, CGPoint position, NSString *prefix)
+static NSMutableString *computeDescription(CKComponent *component, UIView *view, CGSize size, CGPoint position, NSString *prefix)
 {
   NSMutableString *nodeDescription = [NSMutableString string];
   if (component) {
     NSString *componentDescription = [NSString stringWithFormat:@"%@%@, Position: %@, Size: %@\n", prefix, component, NSStringFromCGPoint(position), NSStringFromCGSize(size)];
     [nodeDescription appendString:componentDescription];
-    // we do not add a viewDescription for the component if this condition is not satisfied
+    // We do not add a viewDescription for the component if this condition is not satisfied
     if (component == view.ck_component) { // @"^-> " is used for component's associated view
       NSString *viewDescription = [NSString stringWithFormat:@"%@^-> %@\n", prefix, view];
       [nodeDescription appendString:viewDescription];
     }
-  } else { // isolated view
+  } else { // Isolated view
     NSString *viewDescription = [NSString stringWithFormat:@"%@%@\n", prefix, view];
     [nodeDescription appendString:viewDescription];
   }
   return nodeDescription;
 }
 
-NSMutableString *recursiveDescriptionForView(UIView *view, NSString *prefix)
+static NSMutableString *recursiveDescriptionForView(UIView *view, NSString *prefix)
 {
   NSMutableString *description = [NSMutableString string];
   if ([view isKindOfClass:[CKComponentRootView class]]) {
@@ -184,7 +184,7 @@ NSMutableString *recursiveDescriptionForView(UIView *view, NSString *prefix)
   return description;
 }
 
-CKComponentRootView *rootViewForView(UIView *view)
+static CKComponentRootView *rootViewForView(UIView *view)
 {
   while (view && ![view isKindOfClass:[CKComponentRootView class]]) {
     view = view.superview;
@@ -192,12 +192,12 @@ CKComponentRootView *rootViewForView(UIView *view)
   return (CKComponentRootView *)view;
 }
 
-const CKComponentLayout &layoutForRootView(CKComponentRootView *rootView)
+static const CKComponentLayout &layoutForRootView(CKComponentRootView *rootView)
 {
   return rootView.ck_componentLifecycleManager.state.layout;
 }
 
-const CKComponentLayout *findLayoutForComponent(CKComponent *component, const CKComponentLayout &layout)
+static const CKComponentLayout *findLayoutForComponent(CKComponent *component, const CKComponentLayout &layout)
 {
   const CKComponentLayout *componentLayout = nil;
   if (layout.component == component) {
@@ -215,7 +215,7 @@ const CKComponentLayout *findLayoutForComponent(CKComponent *component, const CK
   return componentLayout;
 }
 
-NSMutableString *recursiveDescriptionForLayout(const CKComponentLayout &layout, CGPoint position, NSString *prefix)
+static NSMutableString *recursiveDescriptionForLayout(const CKComponentLayout &layout, CGPoint position, NSString *prefix)
 {
   CKComponent *component = layout.component;
   UIView *view = component.viewContext.view;

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -17,69 +17,216 @@
 #import "CKComponentLifecycleManager.h"
 #import "CKComponentLifecycleManagerInternal.h"
 #import "CKComponentViewInterface.h"
+#import "CKComponentLayout.h"
+#import "CKComponentRootView.h"
+
+#include <deque>
+
+struct CKComponentDescriptionInformation {
+  const CKComponentLayout &layout;
+  UIView *view;
+  CGPoint position;
+};
+
+static NSString *const indentString = @"| ";
 
 @implementation CKComponentHierarchyDebugHelper
 
 + (NSString *)componentHierarchyDescription
 {
   UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-  return [[self class] componentHierarchyDescriptionForView:window searchUpwards:NO];
+  return [self componentHierarchyDescriptionForView:window searchUpwards:NO];
 }
 
 + (NSString *)componentHierarchyDescriptionForView:(UIView *)view searchUpwards:(BOOL)upwards
 {
   if (upwards) {
-    while (view && !view.ck_componentLifecycleManager) {
-      view = view.superview;
-    }
-
-    if (!view) {
-      return @"Didn't find any components";
-    }
+    return ancestorComponentHierarchyDescriptionForView(view);
+  } else {
+    return componentHierarchyDescriptionForView(view);
   }
-  return (CKRecursiveComponentHierarchyDescription(view) ?: @"Didn't find any components");
 }
 
-static NSString *CKRecursiveComponentHierarchyDescription(UIView *view)
+NSString *ancestorComponentHierarchyDescriptionForView(UIView *view)
 {
-  if (view.ck_componentLifecycleManager) {
-    return [NSString stringWithFormat:@"For View: %@\n%@", view, CKComponentHierarchyDescription(view)];
+  NSString *ancestors;
+  if (view.ck_component) {
+    // Views including and above root view are isolated
+    CKComponentRootView *rootView = rootViewForView(view);
+    NSString *viewAncestors = ancestorDescriptionForView(rootView);
+    NSString *componentAncestors = componentAncestorDescriptionForView(view, rootView, [@"" stringByPaddingToLength:depthOfViewInViewHierarchy(rootView) * indentString.length
+                                                                                                         withString:indentString
+                                                                                                    startingAtIndex:0]);
+    ancestors = [viewAncestors stringByAppendingString:componentAncestors];
   } else {
-    NSMutableArray *array = [NSMutableArray array];
-    for (UIView *subview in view.subviews) {
-      NSString *subviewDescription = CKRecursiveComponentHierarchyDescription(subview);
-      if (subviewDescription) {
-        [array addObject:subviewDescription];
+    ancestors = ancestorDescriptionForView(view);
+  }
+  return ancestors;
+}
+
+NSUInteger depthOfViewInViewHierarchy(UIView *view)
+{
+  NSUInteger depth = 0;
+  while (view) {
+    depth++;
+    view = view.superview;
+  }
+  return depth;
+}
+
+NSString *ancestorDescriptionForView(UIView *view)
+{
+  NSMutableArray *ancestors = [NSMutableArray array];
+  while (view) {
+    [ancestors addObject:view];
+    view = view.superview;
+  }
+  
+  NSMutableString *prefix = [NSMutableString string];
+  NSMutableString *description = [NSMutableString string];
+  // reverse
+  NSArray *orderedAncestors = [[ancestors reverseObjectEnumerator] allObjects];
+  
+  for (UIView *ancestor in orderedAncestors) {
+    [description appendString:computeDescription(nil, ancestor, {0, 0}, {0, 0}, prefix)];
+    [prefix appendString:indentString];
+  }
+  return description;
+}
+
+NSString *componentAncestorDescriptionForView(UIView *view, CKComponentRootView *rootView, NSString *prefix)
+{
+  const CKComponentLayout &rootLayout = layoutForRootView(rootView);
+  CKComponent *component = view.ck_component;
+  std::deque<CKComponentDescriptionInformation> ancestors;
+  buildComponentAncestors(rootLayout, component, {0, 0}, ancestors);
+  NSMutableString *description = [NSMutableString string];
+  NSMutableString *currentPrefix = [prefix mutableCopy];
+  for (auto &descriptionInformation : ancestors) {
+    [description appendString:computeDescription(descriptionInformation.layout.component, descriptionInformation.view, descriptionInformation.layout.size, descriptionInformation.position, currentPrefix)];
+    [currentPrefix appendString:indentString];
+  }
+  return description;
+}
+
+BOOL buildComponentAncestors(const CKComponentLayout &layout, CKComponent *component, CGPoint position, std::deque<CKComponentDescriptionInformation> &ancestors)
+{
+  CKComponent *layoutComponent = layout.component;
+  UIView *view = layoutComponent.viewContext.view;
+  CKComponentDescriptionInformation descriptionInformation = {layout, view, position};
+  ancestors.push_back(descriptionInformation);
+  
+  if (component != layoutComponent) {
+    if (layout.children) {
+      for (const auto &child : *layout.children) {
+        BOOL childResult = buildComponentAncestors(child.layout, component, child.position, ancestors);
+        
+        if (childResult) {
+          return YES;
+        }
       }
     }
-    return array.count ? [array componentsJoinedByString:@"\n\n"] : nil;
+    ancestors.pop_back();
+    return NO;
   }
+  return YES;
 }
 
-static NSString *CKComponentHierarchyDescription(UIView *view)
+NSString *componentHierarchyDescriptionForView(UIView *view)
 {
-  CKComponentLayout layout = [view.ck_componentLifecycleManager state].layout;
-  NSMutableArray *description = [[NSMutableArray alloc] init];
-  CKBuildComponentHierarchyDescription(description, layout, {0, 0}, @"");
-  return [description componentsJoinedByString:@"\n"];
+  NSString *description;
+  if (view.ck_component) {
+    CKComponentRootView *rootView = rootViewForView(view);
+    CKComponent *component = view.ck_component;
+    const CKComponentLayout &rootLayout = layoutForRootView(rootView);
+    const CKComponentLayout &layout = *findLayoutForComponent(component, rootLayout);
+    description = recursiveDescriptionForLayout(layout, {0, 0}, @"");
+  } else {
+    description = recursiveDescriptionForView(view, @"");
+  }
+  return description;
 }
 
-static void CKBuildComponentHierarchyDescription(NSMutableArray *result, const CKComponentLayout &layout, CGPoint position, NSString *prefix)
+NSMutableString *computeDescription(CKComponent *component, UIView *view, CGSize size, CGPoint position, NSString *prefix)
 {
-  [result addObject:[NSString stringWithFormat:@"%@%@, Position: %@, Size: %@",
-                     prefix,
-                     layout.component,
-                     NSStringFromCGPoint(position),
-                     NSStringFromCGSize(layout.size)]];
+  NSMutableString *nodeDescription = [NSMutableString string];
+  if (component) {
+    NSString *componentDescription = [NSString stringWithFormat:@"%@%@, Position: %@, Size: %@\n", prefix, component, NSStringFromCGPoint(position), NSStringFromCGSize(size)];
+    [nodeDescription appendString:componentDescription];
+    // we do not add a viewDescription for the component if this condition is not satisfied
+    if (component == view.ck_component) { // @"^-> " is used for component's associated view
+      NSString *viewDescription = [NSString stringWithFormat:@"%@^-> %@\n", prefix, view];
+      [nodeDescription appendString:viewDescription];
+    }
+  } else { // isolated view
+    NSString *viewDescription = [NSString stringWithFormat:@"%@%@\n", prefix, view];
+    [nodeDescription appendString:viewDescription];
+  }
+  return nodeDescription;
+}
 
+NSMutableString *recursiveDescriptionForView(UIView *view, NSString *prefix)
+{
+  NSMutableString *description = [NSMutableString string];
+  if ([view isKindOfClass:[CKComponentRootView class]]) {
+    CKComponentRootView *rootView = (CKComponentRootView *)view;
+    const CKComponentLayout &rootLayout = layoutForRootView(rootView);
+    [description appendString:computeDescription(nil, rootView, {0, 0}, {0, 0}, prefix)];
+    [description appendString:recursiveDescriptionForLayout(rootLayout, {0, 0}, [prefix stringByAppendingString:indentString])];
+  } else {
+    description = computeDescription(nil, view, {0, 0}, {0, 0}, prefix);
+    if (view.subviews) {
+      for (UIView *subview in view.subviews) {
+        [description appendString:recursiveDescriptionForView(subview, [prefix stringByAppendingString:indentString])];
+      }
+    }
+  }
+  return description;
+}
+
+CKComponentRootView *rootViewForView(UIView *view)
+{
+  while (view && ![view isKindOfClass:[CKComponentRootView class]]) {
+    view = view.superview;
+  }
+  return (CKComponentRootView *)view;
+}
+
+const CKComponentLayout &layoutForRootView(CKComponentRootView *rootView)
+{
+  return rootView.ck_componentLifecycleManager.state.layout;
+}
+
+const CKComponentLayout *findLayoutForComponent(CKComponent *component, const CKComponentLayout &layout)
+{
+  const CKComponentLayout *componentLayout = nil;
+  if (layout.component == component) {
+    componentLayout = &layout;
+  } else {
+    for (const auto &child : *(layout.children)) {
+      const CKComponentLayout *childLayout = findLayoutForComponent(component, child.layout);
+      
+      if (childLayout) {
+        componentLayout = childLayout;
+        break;
+      }
+    }
+  }
+  return componentLayout;
+}
+
+NSMutableString *recursiveDescriptionForLayout(const CKComponentLayout &layout, CGPoint position, NSString *prefix)
+{
+  CKComponent *component = layout.component;
+  UIView *view = component.viewContext.view;
+  NSMutableString *description = computeDescription(component, view, layout.size, position, prefix);
+  
   if (layout.children) {
     for (const auto &child : *layout.children) {
-      CKBuildComponentHierarchyDescription(result,
-                                           child.layout,
-                                           child.position,
-                                           [NSString stringWithFormat:@"| %@", prefix]);
+      [description appendString:recursiveDescriptionForLayout(child.layout, child.position, [prefix stringByAppendingString:indentString])];
     }
-  } 
+  }
+  return description;
 }
 
 @end


### PR DESCRIPTION
* This set of commits couples view and component hierarchies
* This makes it very easy to match up a view with its component
* A view with an associated component is displayed on the following line with "^->" to indicate the association
* Each level of the hierarchy is further indented by "| "
* The searchUpwards parameter shows the component and view ancestors for a given view
* Tested using example app, WildeGuess
  * Checked output both upwards and downwards, for views above, at, and below the CKComponentRootView
* Also works with CKComponentHostingView (which is not used in WildeGuess)
* Much of the code is fragile as it depends getting the root layout from either the CKComponentRootView or CKComponentHostingView