### PR TITLE
Facilitate the inclusion of additional information during layout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: objective-c
 
 before_install:
   - gem install activesupport
-  - gem update cocoapods
-  - gem install slather
+  - gem install cocoapods -v 0.37.2
+  - gem install slather -v 1.8
 
 script: ./build.sh ci
 

--- a/ComponentKit/Core/CKComponentLayout.h
+++ b/ComponentKit/Core/CKComponentLayout.h
@@ -29,14 +29,15 @@ struct CKComponentLayout {
   CKComponent *component;
   CGSize size;
   std::shared_ptr<const std::vector<CKComponentLayoutChild>> children;
+  NSDictionary *extra;
 
-  CKComponentLayout(CKComponent *c, CGSize s, std::vector<CKComponentLayoutChild> ch = {})
-  : component(c), size(s), children(new std::vector<CKComponentLayoutChild>(std::move(ch)), CKOffMainThreadDeleter()) {
+  CKComponentLayout(CKComponent *c, CGSize s, std::vector<CKComponentLayoutChild> ch = {}, NSDictionary *e = nil)
+  : component(c), size(s), children(new std::vector<CKComponentLayoutChild>(std::move(ch)), CKOffMainThreadDeleter()), extra(e) {
     CKCAssertNotNil(c, @"Nil components are not allowed");
   };
 
   CKComponentLayout()
-  : component(nil), size({0, 0}), children(new std::vector<CKComponentLayoutChild>(), CKOffMainThreadDeleter()) {};
+  : component(nil), size({0, 0}), children(new std::vector<CKComponentLayoutChild>(), CKOffMainThreadDeleter()), extra(nil) {};
 };
 
 struct CKComponentLayoutChild {


### PR DESCRIPTION
Adds an optional `NSDictionary` field called `extra` to CKComponentLayout that can be used to contain additional information during layout.

This change also pins CocoaPods and Slather to specific versions. Previously Travis CI would install the latest versions which may not always work well together (for some reason or another). Using specific versions should lead to a more deterministic build.