### PR TITLE
pcomponents now outputs coupled component and view descriptions

### DIFF
--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -210,7 +210,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
 
 #pragma mark - Debug
 
-- (CKComponentLifecycleManagerState)state
+- (const CKComponentLifecycleManagerState &)state
 {
   return _state;
 }

--- a/ComponentKit/Core/CKComponentLifecycleManagerInternal.h
+++ b/ComponentKit/Core/CKComponentLifecycleManagerInternal.h
@@ -16,6 +16,6 @@
  */
 @interface CKComponentLifecycleManager () <CKComponentStateListener>
 
-- (CKComponentLifecycleManagerState)state;
+- (const CKComponentLifecycleManagerState &)state;
 
 @end

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -17,69 +17,236 @@
 #import "CKComponentLifecycleManager.h"
 #import "CKComponentLifecycleManagerInternal.h"
 #import "CKComponentViewInterface.h"
+#import "CKComponentLayout.h"
+#import "CKComponentRootView.h"
+#import "CKComponentHostingView.h"
+#import "CKComponentHostingViewInternal.h"
+
+#include <deque>
+
+struct CKComponentDescriptionInformation {
+  const CKComponentLayout &layout;
+  UIView *view;
+  CGPoint position;
+};
+
+static NSString *const indentString = @"| ";
 
 @implementation CKComponentHierarchyDebugHelper
 
 + (NSString *)componentHierarchyDescription
 {
   UIWindow *window = [[UIApplication sharedApplication] keyWindow];
-  return [[self class] componentHierarchyDescriptionForView:window searchUpwards:NO];
+  return [self componentHierarchyDescriptionForView:window searchUpwards:NO];
 }
 
 + (NSString *)componentHierarchyDescriptionForView:(UIView *)view searchUpwards:(BOOL)upwards
 {
   if (upwards) {
-    while (view && !view.ck_componentLifecycleManager) {
-      view = view.superview;
-    }
-
-    if (!view) {
-      return @"Didn't find any components";
-    }
+    return ancestorComponentHierarchyDescriptionForView(view);
+  } else {
+    return componentHierarchyDescriptionForView(view);
   }
-  return (CKRecursiveComponentHierarchyDescription(view) ?: @"Didn't find any components");
 }
 
-static NSString *CKRecursiveComponentHierarchyDescription(UIView *view)
+static NSString *ancestorComponentHierarchyDescriptionForView(UIView *view)
 {
-  if (view.ck_componentLifecycleManager) {
-    return [NSString stringWithFormat:@"For View: %@\n%@", view, CKComponentHierarchyDescription(view)];
+  NSString *ancestorDescription;
+  if (view.ck_component) {
+    CKComponentRootView *rootView = rootViewForView(view);
+    const CKComponentLayout &rootLayout = *rootLayoutFromRootView(rootView);
+    NSString *viewAncestorDescription = ancestorDescriptionForView(rootView);
+    NSString *componentAncestorDescription = componentAncestorDescriptionForView(view, rootLayout, [@"" stringByPaddingToLength:depthOfViewInViewHierarchy(rootView) * indentString.length
+                                                                                                         withString:indentString
+                                                                                                    startingAtIndex:0]);
+    ancestorDescription = [viewAncestorDescription stringByAppendingString:componentAncestorDescription];
   } else {
-    NSMutableArray *array = [NSMutableArray array];
-    for (UIView *subview in view.subviews) {
-      NSString *subviewDescription = CKRecursiveComponentHierarchyDescription(subview);
-      if (subviewDescription) {
-        [array addObject:subviewDescription];
+    // Views including and above root view do not have an associated component
+    ancestorDescription = ancestorDescriptionForView(view);
+  }
+  return ancestorDescription;
+}
+
+static NSUInteger depthOfViewInViewHierarchy(UIView *view)
+{
+  NSUInteger depth = 0;
+  while (view) {
+    depth++;
+    view = view.superview;
+  }
+  return depth;
+}
+
+static NSString *ancestorDescriptionForView(UIView *view)
+{
+  NSMutableArray *ancestors = [NSMutableArray array];
+  while (view) {
+    [ancestors addObject:view];
+    view = view.superview;
+  }
+
+  NSMutableString *prefix = [NSMutableString string];
+  NSMutableString *description = [NSMutableString string];
+  // reverse
+  NSArray *orderedAncestors = [[ancestors reverseObjectEnumerator] allObjects];
+
+  for (UIView *ancestor in orderedAncestors) {
+    [description appendString:computeDescription(nil, ancestor, {0, 0}, {0, 0}, prefix)];
+    [prefix appendString:indentString];
+  }
+  return description;
+}
+
+static NSString *componentAncestorDescriptionForView(UIView *view, const CKComponentLayout &rootLayout, NSString *prefix)
+{
+  CKComponent *component = view.ck_component;
+  std::deque<CKComponentDescriptionInformation> ancestors;
+  buildComponentAncestors(rootLayout, component, {0, 0}, ancestors);
+  NSMutableString *description = [NSMutableString string];
+  NSMutableString *currentPrefix = [prefix mutableCopy];
+  for (auto &descriptionInformation : ancestors) {
+    [description appendString:computeDescription(descriptionInformation.layout.component, descriptionInformation.view, descriptionInformation.layout.size, descriptionInformation.position, currentPrefix)];
+    [currentPrefix appendString:indentString];
+  }
+  return description;
+}
+
+static BOOL buildComponentAncestors(const CKComponentLayout &layout, CKComponent *component, CGPoint position, std::deque<CKComponentDescriptionInformation> &ancestors)
+{
+  CKComponent *layoutComponent = layout.component;
+  UIView *view = layoutComponent.viewContext.view;
+  CKComponentDescriptionInformation descriptionInformation = {layout, view, position};
+  ancestors.push_back(descriptionInformation);
+
+  if (component != layoutComponent) {
+    if (layout.children) {
+      for (const auto &child : *layout.children) {
+        BOOL childResult = buildComponentAncestors(child.layout, component, child.position, ancestors);
+
+        if (childResult) {
+          return YES;
+        }
       }
     }
-    return array.count ? [array componentsJoinedByString:@"\n\n"] : nil;
+    ancestors.pop_back();
+    return NO;
   }
+  return YES;
 }
 
-static NSString *CKComponentHierarchyDescription(UIView *view)
+static NSString *componentHierarchyDescriptionForView(UIView *view)
 {
-  CKComponentLayout layout = [view.ck_componentLifecycleManager state].layout;
-  NSMutableArray *description = [[NSMutableArray alloc] init];
-  CKBuildComponentHierarchyDescription(description, layout, {0, 0}, @"");
-  return [description componentsJoinedByString:@"\n"];
+  NSString *description;
+  if (view.ck_component) {
+    CKComponentRootView *rootView = rootViewForView(view);
+    CKComponent *component = view.ck_component;
+    const CKComponentLayout &rootLayout = *rootLayoutFromRootView(rootView);
+    const CKComponentLayout &layout = *findLayoutForComponent(component, rootLayout);
+    description = recursiveDescriptionForLayout(layout, {0, 0}, @"");
+  } else {
+    description = recursiveDescriptionForView(view, @"");
+  }
+  return description;
 }
 
-static void CKBuildComponentHierarchyDescription(NSMutableArray *result, const CKComponentLayout &layout, CGPoint position, NSString *prefix)
+static NSMutableString *computeDescription(CKComponent *component, UIView *view, CGSize size, CGPoint position, NSString *prefix)
 {
-  [result addObject:[NSString stringWithFormat:@"%@%@, Position: %@, Size: %@",
-                     prefix,
-                     layout.component,
-                     NSStringFromCGPoint(position),
-                     NSStringFromCGSize(layout.size)]];
+  NSMutableString *nodeDescription = [NSMutableString string];
+  if (component) {
+    NSString *componentDescription = [NSString stringWithFormat:@"%@%@, Position: %@, Size: %@\n", prefix, component, NSStringFromCGPoint(position), NSStringFromCGSize(size)];
+    [nodeDescription appendString:componentDescription];
+    // We do not add a viewDescription for the component if this condition is not satisfied
+    if (component == view.ck_component) { // @"^-> " is used for component's associated view
+      NSString *viewDescription = [NSString stringWithFormat:@"%@^-> %@\n", prefix, view];
+      [nodeDescription appendString:viewDescription];
+    }
+  } else { // Isolated view
+    NSString *viewDescription = [NSString stringWithFormat:@"%@%@\n", prefix, view];
+    [nodeDescription appendString:viewDescription];
+  }
+  return nodeDescription;
+}
+
+static NSMutableString *recursiveDescriptionForView(UIView *view, NSString *prefix)
+{
+  NSMutableString *description = [NSMutableString string];
+  if ([view isKindOfClass:[CKComponentRootView class]]) {
+    CKComponentRootView *rootView = (CKComponentRootView *)view;
+    const CKComponentLayout *rootLayout = rootLayoutFromRootView(rootView);
+
+    if (rootLayout) {
+      [description appendString:computeDescription(nil, rootView, {0, 0}, {0, 0}, prefix)];
+      [description appendString:recursiveDescriptionForLayout(*rootLayout, {0, 0}, [prefix stringByAppendingString:indentString])];
+      return description;
+    }
+  }
+
+  description = computeDescription(nil, view, {0, 0}, {0, 0}, prefix);
+
+  if (view.subviews) {
+    for (UIView *subview in view.subviews) {
+      [description appendString:recursiveDescriptionForView(subview, [prefix stringByAppendingString:indentString])];
+    }
+  }
+  return description;
+}
+
+static CKComponentRootView *rootViewForView(UIView *view)
+{
+  while (view && ![view isKindOfClass:[CKComponentRootView class]]) {
+    view = view.superview;
+  }
+  return (CKComponentRootView *)view;
+}
+
+/* Note: This is fragile code that is being used because ComponentKit is
+ * currently in the process of transitioning away holding the root layout in
+ * CKComponentRootView
+ */
+static const CKComponentLayout *rootLayoutFromRootView(CKComponentRootView *rootView)
+{
+  const CKComponentLayout *rootLayout;
+  if (rootView.ck_componentLifecycleManager) {
+    rootLayout = &rootView.ck_componentLifecycleManager.state.layout;
+  } else if ([rootView.superview isKindOfClass:[CKComponentHostingView class]]) {
+    CKComponentHostingView *hostingView = (CKComponentHostingView *)rootView.superview;
+    rootLayout = &hostingView.mountedLayout;
+  } else {
+    rootLayout = nil;
+  }
+  return rootLayout;
+}
+
+static const CKComponentLayout *findLayoutForComponent(CKComponent *component, const CKComponentLayout &layout)
+{
+  const CKComponentLayout *componentLayout = nil;
+  if (layout.component == component) {
+    componentLayout = &layout;
+  } else {
+    for (const auto &child : *(layout.children)) {
+      const CKComponentLayout *childLayout = findLayoutForComponent(component, child.layout);
+
+      if (childLayout) {
+        componentLayout = childLayout;
+        break;
+      }
+    }
+  }
+  return componentLayout;
+}
+
+static NSMutableString *recursiveDescriptionForLayout(const CKComponentLayout &layout, CGPoint position, NSString *prefix)
+{
+  CKComponent *component = layout.component;
+  UIView *view = component.viewContext.view;
+  NSMutableString *description = computeDescription(component, view, layout.size, position, prefix);
 
   if (layout.children) {
     for (const auto &child : *layout.children) {
-      CKBuildComponentHierarchyDescription(result,
-                                           child.layout,
-                                           child.position,
-                                           [NSString stringWithFormat:@"| %@", prefix]);
+      [description appendString:recursiveDescriptionForLayout(child.layout, child.position, [prefix stringByAppendingString:indentString])];
     }
-  } 
+  }
+  return description;
 }
 
 @end


### PR DESCRIPTION
* This commit couples view and component hierarchies
* This makes it very easy to match up a view with its component
* A view with an associated component is displayed on the following line with "^->" to indicate the association
* Each level of the hierarchy is further indented by "| "
* The searchUpwards parameter shows the component and view ancestors for a given view
* Tested using example app, WildeGuess
    * Checked output both upwards and downwards, for views above, at, and below the CKComponentRootView
* Also works with CKComponentHostingView (which is not used in WildeGuess)
* Much of the code is fragile as it depends getting the root layout from either the CKComponentRootView or CKComponentHostingView