### PR TITLE
Add appending to CKTransactionalComponentDataSourceChangesetBuilder

### DIFF
--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangeset.m
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangeset.m
@@ -35,21 +35,75 @@
 
 @implementation CKTransactionalComponentDataSourceChangesetBuilder
 {
-  NSDictionary *_updatedItems;
-  NSSet *_removedItems;
-  NSIndexSet *_removedSections;
-  NSDictionary *_movedItems;
-  NSIndexSet *_insertedSections;
-  NSDictionary *_insertedItems;
+  id _updatedItems;
+  id _removedItems;
+  id _removedSections;
+  id _movedItems;
+  id _insertedSections;
+  id _insertedItems;
 }
 
 + (instancetype)transactionalComponentDataSourceChangeset { return [[self alloc] init]; }
-- (instancetype)withUpdatedItems:(NSDictionary *)updatedItems { _updatedItems = updatedItems; return self;}
-- (instancetype)withRemovedItems:(NSSet *)removedItems { _removedItems = removedItems; return self; }
-- (instancetype)withRemovedSections:(NSIndexSet *)removedSections { _removedSections = removedSections; return self; }
-- (instancetype)withMovedItems:(NSDictionary *)movedItems { _movedItems = movedItems; return self; }
-- (instancetype)withInsertedSections:(NSIndexSet *)insertedSections { _insertedSections = insertedSections; return self; }
-- (instancetype)withInsertedItems:(NSDictionary *)insertedItems { _insertedItems = insertedItems; return self; }
+
+- (instancetype)withUpdatedItems:(NSDictionary *)updatedItems {
+  if (_updatedItems) {
+    _updatedItems = [_updatedItems mutableCopy];
+    [_updatedItems addEntriesFromDictionary:updatedItems];
+  } else {
+    _updatedItems = updatedItems;
+  }
+	return self;
+}
+
+- (instancetype)withRemovedItems:(NSSet *)removedItems {
+  if (_removedItems) {
+    _removedItems = [_removedItems mutableCopy];
+    [_removedItems addObjectsFromArray:removedItems.allObjects];
+  } else {
+    _removedItems = removedItems;
+  }
+  return self;
+}
+
+- (instancetype)withRemovedSections:(NSIndexSet *)removedSections {
+  if (_removedSections) {
+    _removedSections = [_removedSections mutableCopy];
+    [_removedSections addIndexes:removedSections];
+  } else {
+    _removedSections = removedSections;
+  }
+  return self;
+}
+
+- (instancetype)withMovedItems:(NSDictionary *)movedItems {
+  if (_movedItems) {
+    _movedItems = [_movedItems mutableCopy];
+    [_movedItems addEntriesFromDictionary:movedItems];
+  } else {
+    _movedItems = movedItems;
+  }
+  return self;
+}
+
+- (instancetype)withInsertedSections:(NSIndexSet *)insertedSections {
+  if (_insertedSections) {
+    _insertedSections = [_insertedSections mutableCopy];
+    [_insertedSections addIndexes:insertedSections];
+  } else {
+    _insertedSections = insertedSections;
+  }
+  return self;
+}
+
+- (instancetype)withInsertedItems:(NSDictionary *)insertedItems {
+  if (_insertedItems) {
+    _insertedItems = [_insertedItems mutableCopy];
+    [_insertedItems addEntriesFromDictionary:insertedItems];
+  } else {
+    _insertedItems = insertedItems;
+  }
+  return self;
+}
 
 - (CKTransactionalComponentDataSourceChangeset *)build
 {

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetModificationTests.mm
@@ -16,6 +16,7 @@
 #import "CKComponentLayout.h"
 #import "CKComponentProvider.h"
 #import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
+#import "CKTransactionalComponentDataSourceChangesetInternal.h"
 #import "CKTransactionalComponentDataSourceChange.h"
 #import "CKTransactionalComponentDataSourceChangeset.h"
 #import "CKTransactionalComponentDataSourceItem.h"
@@ -170,6 +171,74 @@
 
   c = (CKModelExposingComponent *)[[[change state] objectAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]] layout].component;
   XCTAssertEqualObjects(c.model, @0);
+}
+
+- (void)testAppendsUpdatedItems
+{
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @"updated0"}]
+   withUpdatedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @"updated1"}]
+  build];
+  XCTAssertEqualObjects(changeSet.updatedItems,
+                        (@{[NSIndexPath indexPathForItem:0 inSection:0]: @"updated0",
+                           [NSIndexPath indexPathForItem:1 inSection:0]: @"updated1"}));
+}
+
+- (void)testAppendsRemovedItems
+{
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withRemovedItems:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]]
+    withRemovedItems:[NSSet setWithObject:[NSIndexPath indexPathForItem:1 inSection:0]]]
+   build];
+  XCTAssertEqualObjects(changeSet.removedItems,
+                        ([NSSet setWithObjects:
+                          [NSIndexPath indexPathForItem:0 inSection:0],
+                          [NSIndexPath indexPathForItem:1 inSection:0],
+                          nil]));
+}
+
+- (void)testAppendsRemovedSections
+{
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withRemovedSections:[NSIndexSet indexSetWithIndex:0]]
+    withRemovedSections:[NSIndexSet indexSetWithIndex:1]] build];
+  XCTAssertEqualObjects(changeSet.removedSections, [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]);
+}
+
+- (void)testAppendsMovedItems
+{
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withMovedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @"updated0"}]
+    withMovedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @"updated1"}]
+   build];
+  XCTAssertEqualObjects(changeSet.movedItems,
+                        (@{[NSIndexPath indexPathForItem:0 inSection:0]: @"updated0",
+                           [NSIndexPath indexPathForItem:1 inSection:0]: @"updated1"}));
+}
+
+- (void)testAppendsInsertedSections
+{
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:1]] build];
+  XCTAssertEqualObjects(changeSet.insertedSections, [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]);
+}
+
+- (void)testAppendsInsertedItems
+{
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withInsertedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @"updated0"}]
+    withInsertedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @"updated1"}]
+   build];
+  XCTAssertEqualObjects(changeSet.insertedItems,
+                        (@{[NSIndexPath indexPathForItem:0 inSection:0]: @"updated0",
+                           [NSIndexPath indexPathForItem:1 inSection:0]: @"updated1"}));
 }
 
 


### PR DESCRIPTION
Hi all,

Have just been looking at the recently merged transactional data source changes, and from a third-party point of view, a few things popped out. I have a bit of time to propose some ideas, so please let me know what you think.

In the case of `CKTransactionalComponentDataSourceChangesetBuilder`, I noticed that whilst the implementation supports chaining, since all the properties are overwritten in the convenience methods it's not possible to append inserts/removals/moves, etc. This would mean that when looping over a collection of models one would have to create a mutable container themselves and then pass it to the builder, which rather detracts from the convenience it should provide. Also, if users assume that appends are possible they will do a lot of head-scratching wondering why their updates aren't applied.

I wanted to avoid unnecessary use of `-mutableCopy`, in case the user doesn't make any appends. This, means the methods being a little longer than they might be otherwise, and contain a lot of repeated boiler-plate. I considered using a macro to simplify this, but thought perhaps you would prefer them written out in full.

This also means that the properties could be either mutable or immutable, depending on whether an append has been performed. As such, I had to change the ivars to `id` in order to satisfy the compiler. Since the initialiser for `CKTransactionalComponentDataSourceChangeset` makes copies, I think this is the most efficient way to add the mutable functionality without doing any unnecessary copying.

In any case, please let me know what you think!

PS. No documentation regarding this feature added *as yet*, but could be if you think it necessary.