### PR TITLE
Add -modelForItemAtIndexPath to CKCollectionViewTransactionalDataSource

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
@@ -39,6 +39,15 @@
               userInfo:(NSDictionary *)userInfo;
 
 /**
+ @return The model associated with a certain index path in the collectionView.
+
+ As stated above components are generated asynchronously and on a backgorund thread. This means that a changeset is enqueued
+ and applied asynchronously when the corresponding component tree is generated. For this reason always use this method when you
+ want to retrieve the model associated to a certain index path in the table view (e.g in didSelectRowAtIndexPath: )
+ */
+- (id<NSObject>)modelForItemAtIndexPath:(NSIndexPath *)indexPath;
+
+/**
  @return The layout size of the component tree at a certain indexPath. Use this to access the component sizes for instance in a
  `UICollectionViewLayout(s)` or in a `UICollectionViewDelegateFlowLayout`.
  */

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -101,6 +101,11 @@ static void applyChangesToCollectionView(CKTransactionalComponentDataSourceAppli
 
 #pragma mark - State
 
+- (id<NSObject>)modelForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+  return [_currentState objectAtIndexPath:indexPath].model;
+}
+
 - (CGSize)sizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   return [_currentState objectAtIndexPath:indexPath].layout.size;


### PR DESCRIPTION
Hi all,

I noticed that `CKCollectionViewTransactionalDataSource` lacks an equivalent to `CKCollectionViewDataSource`'s `-modelForItemAtIndexPath:` method. Seems like an accidental omission to me, since the implementation is trivial, and it would certainly be a necessity for us to migrate to the new class. So... here it is here.