### PR TITLE
Snapshot test case updates

### DIFF
--- a/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.mm
+++ b/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.mm
@@ -39,6 +39,7 @@ static CKComponent *_leakyComponent;
   return [self compareSnapshotOfView:v
             referenceImagesDirectory:referenceImagesDirectory
                           identifier:identifier
+                           tolerance:0
                                error:errorPtr];
 }
 

--- a/ComponentSnapshotTestCase/ComponentSnapshotTestCase.podspec
+++ b/ComponentSnapshotTestCase/ComponentSnapshotTestCase.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '7.0'
   s.requires_arc = true
   s.source_files = '**/*.h', '**/*.m', '**/*.mm'
-  s.dependency 'FBSnapshotTestCase'
+  s.dependency 'FBSnapshotTestCase/Core'
   s.frameworks = 'UIKit', 'XCTest'
 end

--- a/ComponentTextKitApplicationTests/CKTextKitTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextKitTests.mm
@@ -75,7 +75,7 @@ static BOOL checkAttributes(const CKTextKitAttributes &attributes, const CGSize 
   FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] init];
   UIImage *labelImage = UITextViewImageWithAttributes(attributes, constrainedSize);
   UIImage *textKitImage = CKTextKitImageWithAttributes(attributes, constrainedSize);
-  return [controller compareReferenceImage:labelImage toImage:textKitImage error:nil];
+  return [controller compareReferenceImage:labelImage toImage:textKitImage tolerance:0 error:nil];
 }
 
 @implementation CKTextKitTests

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - ComponentKit (0.12)
   - ComponentKitTestLib (0.12)
   - ComponentSnapshotTestCase (0.12):
-    - FBSnapshotTestCase
-  - FBSnapshotTestCase (1.8.1)
+    - FBSnapshotTestCase/Core
+  - FBSnapshotTestCase/Core (2.0.3)
   - OCMock (2.2.4)
 
 DEPENDENCIES:
@@ -14,17 +14,17 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   ComponentKit:
-    :path: .
+    :path: "."
   ComponentKitTestLib:
-    :path: ./ComponentKitTestLib
+    :path: "./ComponentKitTestLib"
   ComponentSnapshotTestCase:
-    :path: ./ComponentSnapshotTestCase
+    :path: "./ComponentSnapshotTestCase"
 
 SPEC CHECKSUMS:
   ComponentKit: 4bf3ce82a9e28f2ec26ba112102a2120ef312aa6
   ComponentKitTestLib: 4c28d18b6f2f0f25fec043bb17113781f019c095
-  ComponentSnapshotTestCase: ce43fe9c9645718594e976e229dcbf1dcc49afd1
-  FBSnapshotTestCase: 3dc3899168747a0319c5278f5b3445c13a6532dd
+  ComponentSnapshotTestCase: eb054752d912bd14666c6db6614c1a55e59a3164
+  FBSnapshotTestCase: d0eeca6bf87958e088b254396ae66873f971cfb1
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
 
 COCOAPODS: 0.37.2


### PR DESCRIPTION
Hi all,

Some minor updates to the podpsecs that currently cause pain on `master` (which we're using...). The podfile doesn't limit the version of `FBSnapshotTestCase`, so some minor changes required.