### PR TITLE
Fix potential crash in CKTextKitTailTruncater with extremely constrained bounds

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitTailTruncater.mm
+++ b/ComponentTextKit/TextKit/CKTextKitTailTruncater.mm
@@ -51,6 +51,11 @@
   NSRange visibleGlyphRange = [layoutManager glyphRangeForBoundingRect:constrainedRect
                                                        inTextContainer:textContainer];
   NSInteger lastVisibleGlyphIndex = (NSMaxRange(visibleGlyphRange) - 1);
+
+  if (lastVisibleGlyphIndex < 0) {
+    return NSNotFound;
+  }
+
   CGRect lastLineRect = [layoutManager lineFragmentRectForGlyphAtIndex:lastVisibleGlyphIndex
                                                         effectiveRange:NULL];
   CGRect lastLineUsedRect = [layoutManager lineFragmentUsedRectForGlyphAtIndex:lastVisibleGlyphIndex

--- a/ComponentTextKitApplicationTests/CKTextKitTruncationTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextKitTruncationTests.mm
@@ -125,4 +125,19 @@
   XCTAssertEqualObjects(expectedString, drawnString);
 }
 
+- (void)testHandleZeroHeightConstrainedSize
+{
+  CGSize constrainedSize = CGSizeMake(50, 0);
+  NSAttributedString *attributedString = [self _sentenceAttributedString];
+  CKTextKitContext *context = [[CKTextKitContext alloc] initWithAttributedString:attributedString
+                                                                   lineBreakMode:NSLineBreakByCharWrapping
+                                                            maximumNumberOfLines:0
+                                                                 constrainedSize:constrainedSize
+                                                            layoutManagerFactory:nil];
+  XCTAssertNoThrow([[CKTextKitTailTruncater alloc] initWithContext:context
+                                        truncationAttributedString:[self _simpleTruncationAttributedString]
+                                            avoidTailTruncationSet:[NSCharacterSet characterSetWithCharactersInString:@"."]
+                                                   constrainedSize:constrainedSize]);
+}
+
 @end


### PR DESCRIPTION
Hi guys,

Have seen this kind of crash in our logs:

```
2015-08-07 16:04:57.985 <REDACTED>[19467:2606941] !!! _NSLayoutTreeLineFragmentRectForGlyphAtIndex invalid glyph index 18446744073709551615
2015-08-07 16:04:57.987 <REDACTED>[19467:2606941] !!! _NSLayoutTreeLineFragmentUsedRectForGlyphAtIndex invalid glyph index 18446744073709551615
2015-08-07 16:04:58.009 <REDACTED>[19467:2606941] *** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[NSConcreteTextStorage attributesAtIndex:effectiveRange:]: Range or index out of bounds'
...
  * frame #10: 0x0000000191cf805c UIFoundation`-[NSConcreteTextStorage attributesAtIndex:effectiveRange:] + 148
    frame #11: 0x0000000100800484 <REDACTED>`-[CKTextKitTailTruncater _calculateCharacterIndexBeforeTruncationMessage:textStorage:textContainer:](self=0x00000001742c0ee0, _cmd=0x0000000100c032b9, layoutManager=0x00000001703e4800, textStorage=0x000000013b050960, textContainer=0x000000017430e100) + 556 at CKTextKitTailTruncater.mm:58
    frame #12: 0x0000000100801464 <REDACTED>`__35-[CKTextKitTailTruncater _truncate]_block_invoke(.block_descriptor=<unavailable>, layoutManager=0x00000001703e4800, textStorage=0x000000013b050960, textContainer=0x000000017430e100) + 532 at CKTextKitTailTruncater.mm:165
    frame #13: 0x00000001007f7cb4 <REDACTED>`-[CKTextKitContext performBlockWithLockedTextKitComponents:](self=0x00000001702bd580, _cmd=0x0000000100c02c03, block=0x0000000107c28798) + 156 at CKTextKitContext.mm:55
    frame #14: 0x00000001008011ec <REDACTED>`-[CKTextKitTailTruncater _truncate](self=0x00000001742c0ee0, _cmd=0x0000000100c03133) + 164 at CKTextKitTailTruncater.mm:153
    frame #15: 0x0000000100800170 <REDACTED>`-[CKTextKitTailTruncater initWithContext:truncationAttributedString:avoidTailTruncationSet:constrainedSize:](self=0x00000001742c0ee0, _cmd=0x0000000100c02ef5, context=0x00000001702bd580, truncationAttributedString=0x0000000170c25ee0, avoidTailTruncationSet=0x000000017044e580, constrainedSize=(width = 0, height = +Inf)) + 320 at CKTextKitTailTruncater.mm:37
    frame #16: 0x00000001007fdb84 <REDACTED>`-[CKTextKitRenderer initWithTextKitAttributes:constrainedSize:](self=0x0000000170328980, _cmd=0x0000000100c0284c, attributes=0x00000001703e5888, constrainedSize=(width = 0, height = +Inf)) + 780 at CKTextKitRenderer.mm:60
    frame #17: 0x00000001007e6858 <REDACTED>`rendererForAttributes(attributes=0x00000001703e5888, constrainedSize=(width = 0, height = +Inf)) + 232 at CKTextComponent.mm:48
    frame #18: 0x00000001007e657c <REDACTED>`-[CKTextComponent computeLayoutThatFits:](self=0x00000001703e5800, _cmd=0x0000000100c00c9b, constrainedSize=(min = (width = 0, height = 0), max = (width = 0, height = +Inf))) + 88 at CKTextComponent.mm:89
    frame #19: 0x0000000100767480 <REDACTED>`-[CKComponent computeLayoutThatFits:restrictedToSize:relativeToParentSize:](self=0x00000001703e5800, _cmd=0x0000000100c00c37, constrainedSize=(min = (width = 0, height = 0), max = (width = 0, height = +Inf)), size=0x00000001703e5820, parentSize=(width = 0, height = NaN)) + 220 at CKComponent.mm:228
    frame #20: 0x0000000100766e84 <REDACTED>`-[CKComponent layoutThatFits:parentSize:](self=0x00000001703e5800, _cmd=0x0000000100c00c1c, constrainedSize=(min = (width = 0, height = 0), max = (width = 0, height = +Inf)), parentSize=(width = 0, height = NaN)) + 284 at CKComponent.mm:207
    frame #21: 0x00000001007c784c <REDACTED>`-[CKCompositeComponent computeLayoutThatFits:restrictedToSize:relativeToParentSize:](self=0x00000001743040b0, _cmd=0x0000000100c00c37, constrainedSize=(min = (width = 0, height = 0), max = (width = 0, height = +Inf)), size=0x00000001743040d0, parentSize=(width = 0, height = NaN)) + 676 at CKCompositeComponent.mm:76
    frame #22: 0x0000000100766e84 <REDACTED>`-[CKComponent layoutThatFits:parentSize:](self=0x00000001743040b0, _cmd=0x0000000100c00c1c, constrainedSize=(min = (width = 0, height = 0), max = (width = 0, height = +Inf)), parentSize=(width = 0, height = NaN)) + 284 at CKComponent.mm:207
    frame #23: 0x00000001007db1a4 <REDACTED>`crossChildLayout(child=0x00000001702d9280, style=<unavailable>, stackMin=0, stackMax=+Inf, crossMin=0, crossMax=0, size=(width = 0, height = NaN)) + 300 at CKStackUnpositionedLayout.mm:38
    frame #24: 0x00000001007de07c <REDACTED>`layoutChildrenAlongUnconstrainedStackDimension(this=0x0000000107c29a20, child=0x00000001702d9280)::$_6::operator()(CKStackLayoutComponentChild const&) const + 628 at CKStackUnpositionedLayout.mm:313
    frame #25: 0x00000001007ddd28
...
```

This is caused by having `{0, 0}` for `visibleGlyphRange` in `_calculateCharacterIndexBeforeTruncationMessage:...`. In our case, this is caused by a zero height component (which is another issue...), but put in a simple check here to bail early and at least not crash.

Thanks!