### PR TITLE
Fix assert inside block

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRenderer+Positioning.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRenderer+Positioning.mm
@@ -358,7 +358,7 @@ static const CGFloat CKTextKitRendererTextCapHeightPadding = 1.3;
   [self.context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
     // Bail on invalid range.
     if (NSMaxRange(textRange) > [textStorage length]) {
-      CKFailAssert(@"Invalid range");
+      CKCFailAssert(@"Invalid range");
       return;
     }
 


### PR DESCRIPTION
This assert is inside a block, so we should use the `CKCFailAssert` instead of plain `CKFailAssert`.