### PR TITLE
Add animation options to CKComponentBoundsAnimation

### DIFF
--- a/ComponentKit/Core/CKComponentBoundsAnimation.h
+++ b/ComponentKit/Core/CKComponentBoundsAnimation.h
@@ -39,6 +39,7 @@ struct CKComponentBoundsAnimation {
   NSTimeInterval duration;
   NSTimeInterval delay;
   CKComponentBoundsAnimationMode mode;
+  UIViewAnimationOptions options;
 
   /** Ignored unless mode is Spring, in which case it specifies the damping ratio passed to UIKit. */
   CGFloat springDampingRatio;

--- a/ComponentKit/Core/CKComponentBoundsAnimation.mm
+++ b/ComponentKit/Core/CKComponentBoundsAnimation.mm
@@ -24,13 +24,13 @@ void CKComponentBoundsAnimationApply(const CKComponentBoundsAnimation &animation
                           delay:animation.delay
          usingSpringWithDamping:animation.springDampingRatio
           initialSpringVelocity:animation.springInitialVelocity
-                        options:0
+                        options:animation.options
                      animations:animations
                      completion:completion];
   } else {
     [UIView animateWithDuration:animation.duration
                           delay:animation.delay
-                        options:0
+                        options:animation.options
                      animations:animations
                      completion:completion];
   }


### PR DESCRIPTION
Add UIViewAnimationOptions options field to the CKComponentBoundsAnimation struct to enable components to apply specific UIViewAnimationOptions to the animation.