### PR TITLE
Remount transactional data source

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		2DF899011CDD4064003C3507 /* ReferenceImages_IOS9 in Resources */ = {isa = PBXBuildFile; fileRef = 2DF899001CDD4064003C3507 /* ReferenceImages_IOS9 */; };
 		39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */; };
 		497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */; };
+		49FA174E1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49FA174D1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm */; };
 		991DE3411B3B308900AA05B2 /* CKComponentMemoizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */; };
 		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
 		A2100E0D1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */; };
@@ -822,6 +823,7 @@
 		2DF899001CDD4064003C3507 /* ReferenceImages_IOS9 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS9; sourceTree = "<group>"; };
 		39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDataSourceAttachControllerTests.mm; sourceTree = "<group>"; };
 		497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceTests.mm; sourceTree = "<group>"; };
+		49FA174D1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceIntegrationTests.mm; sourceTree = "<group>"; };
 		991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentMemoizerTests.mm; sourceTree = "<group>"; };
 		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
 		A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm; sourceTree = "<group>"; };
@@ -1294,6 +1296,7 @@
 				A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */,
 				A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */,
 				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */,
+				49FA174D1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm */,
 				B761C8AA1CB36AAE00CDD03F /* CKTransactionalComponentDataSourceConfigurationTests.mm */,
 				B761C8AD1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm */,
 				B761C8B01CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm */,
@@ -2851,6 +2854,7 @@
 				B342DC701AC23EA900ACAC53 /* CKComponentDataSourceTestDelegate.mm in Sources */,
 				B342DC831AC23EA900ACAC53 /* CKTestRunLoopRunning.mm in Sources */,
 				B342DC731AC23EA900ACAC53 /* CKComponentGestureActionsTests.mm in Sources */,
+				49FA174E1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm in Sources */,
 				18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */,
 				B342DC821AC23EA900ACAC53 /* CKSectionedArrayControllerTests.mm in Sources */,
 				A27C72751AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm in Sources */,

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceIntegrationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceIntegrationTests.mm
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import "CKComponent.h"
+#import "CKComponentProvider.h"
+#import "CKComponentScope.h"
+#import "CKCompositeComponent.h"
+#import "CKComponentController.h"
+#import "CKCollectionViewTransactionalDataSource.h"
+#import "CKTransactionalComponentDataSourceConfiguration.h"
+#import "CKTransactionalComponentDataSourceChangeset.h"
+
+static NSNotificationCenter *_notificationCenter = nil;
+
+@interface CKTransactionalComponentDataSourceIntegrationTestComponent : CKCompositeComponent
+@end
+
+@implementation CKTransactionalComponentDataSourceIntegrationTestComponent
++ (instancetype)newWithIdentifier:(id)identifier {
+  CKComponentScope scope(self, identifier);
+  return [self newWithComponent:[CKComponent new]];
+}
+@end
+
+@interface CKTransactionalComponentDataSourceIntegrationTestComponentController : CKComponentController
+@end
+
+@implementation CKTransactionalComponentDataSourceIntegrationTestComponentController
+- (void)didUpdateComponent {
+  [super didUpdateComponent];
+  [_notificationCenter postNotificationName:NSStringFromSelector(_cmd) object:self];
+}
+- (void)willRemount {
+  [super willRemount];
+  [_notificationCenter postNotificationName:NSStringFromSelector(_cmd) object:self];
+}
+- (void)didRemount {
+  [super didRemount];
+  [_notificationCenter postNotificationName:NSStringFromSelector(_cmd) object:self];
+}
+@end
+
+@interface CKTransactionalComponentDataSourceIntegrationTests : XCTestCase <CKComponentProvider>
+@property (strong) UICollectionViewController *collectionViewController;
+@property (strong) CKCollectionViewTransactionalDataSource *dataSource;
+@property (strong) CKComponentController *componentController;
+@property (strong) id observerMock;
+@end
+
+@implementation CKTransactionalComponentDataSourceIntegrationTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.collectionViewController = [[UICollectionViewController alloc]
+                                   initWithCollectionViewLayout:[UICollectionViewFlowLayout new]];
+
+  CKTransactionalComponentDataSourceConfiguration *config = [[CKTransactionalComponentDataSourceConfiguration alloc]
+                                                             initWithComponentProvider:self.class
+                                                             context:nil
+                                                             sizeRange:CKSizeRange({50, 50}, {50, 50})];
+
+  self.dataSource = [[CKCollectionViewTransactionalDataSource alloc]
+                     initWithCollectionView:self.collectionViewController.collectionView
+                     supplementaryViewDataSource:nil
+                     configuration:config];
+
+  _notificationCenter = [[NSNotificationCenter alloc] init];
+
+  self.observerMock = [OCMockObject observerMock];
+  [_notificationCenter addMockObserver:self.observerMock name:nil object:nil];
+
+  [[self.observerMock expect] notificationWithName:NSStringFromSelector(@selector(didUpdateComponent))
+                                            object:[OCMArg checkWithBlock:^BOOL(CKComponentController *c)
+                                                    {
+                                                      self.componentController = c;
+                                                      return YES;
+                                                    }]];
+  
+  [self.dataSource applyChangeset:
+   [[[[CKTransactionalComponentDataSourceChangesetBuilder new]
+      withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+     withInsertedItems:@{ [NSIndexPath indexPathForItem:0 inSection:0] : @"" }]
+    build] mode:CKUpdateModeSynchronous userInfo:nil];
+}
+
+- (void)tearDown {
+  [self.observerMock verify];
+  [_notificationCenter removeObserver:self.observerMock];
+  _notificationCenter = nil;
+  [super tearDown];
+}
+
++ (CKComponent *)componentForModel:(NSString*)model context:(id<NSObject>)context {
+  return [CKTransactionalComponentDataSourceIntegrationTestComponent newWithIdentifier:@"TestComponent"];
+}
+
+- (void)testUpdateItemWithMatchingIdentifierShouldTriggerRemountInComponentController
+{
+  [[self.observerMock expect] notificationWithName:NSStringFromSelector(@selector(didUpdateComponent))
+                                            object:self.componentController];
+  [[self.observerMock expect] notificationWithName:NSStringFromSelector(@selector(willRemount))
+                                            object:self.componentController];
+  [[self.observerMock expect] notificationWithName:NSStringFromSelector(@selector(didRemount))
+                                            object:self.componentController];
+
+  [self.dataSource applyChangeset:
+   [[[CKTransactionalComponentDataSourceChangesetBuilder new]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0] : @""}]
+    build] mode:CKUpdateModeSynchronous userInfo:nil];
+}
+
+@end


### PR DESCRIPTION
Resolves https://github.com/facebook/componentkit/issues/342

As noted in the issue, I encountered the same remounting issue with the new data source as encountered in the original (https://github.com/facebook/componentkit/pull/256). The first part of the problem was to use the same technique of grabbing any existing cell for the index path and reusing it. Then an additional problem *seemed* to be that changes were applied to the collection view before updating the local state in `CKCollectionViewTransactionalDataSource`. Simply moving the `applyChangesToCollectionView()` call until after that fixed this.

So... this appears at quick inspection to fix the issue although I'm certainly not 100% confident about the ramifications. I also thought about migrating the example app to the new data source to illustrate the issue, but as far as I can remember it only uses `-updateState`, and not changeset modifications.

Anyway, looking forward to feedback :+1: 