### PR TITLE
Use new method of reference image lookup in FBSnapshotTestCase

### DIFF
--- a/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h
+++ b/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h
@@ -47,7 +47,7 @@ CK_64 ? [suffix stringByAppendingString:@"_64"] : suffix; \
 #define CKSnapshotVerifyComponent(component__, sizeRange__, identifier__) \
 { \
 NSError *error__ = nil; \
-NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s%@", FB_REFERENCE_IMAGE_DIR, CKSnapshotReferenceDirectorySuffix()]; \
+NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%@%@", [self getReferenceImageDirectoryWithDefault:(@ FB_REFERENCE_IMAGE_DIR)], CKSnapshotReferenceDirectorySuffix()]; \
 BOOL comparisonSuccess__ = [self compareSnapshotOfComponent:(component__) sizeRange:(sizeRange__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
 XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
 }
@@ -77,7 +77,7 @@ CKSnapshotVerifyComponent([CKInsetComponent newWithInsets:insets__ component:com
 #define CKSnapshotVerifyComponentBlockWithState(componentBlock__, updateStateBlock__, sizeRange__, identifier__) \
 { \
 NSError *error__ = nil; \
-NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s%@", FB_REFERENCE_IMAGE_DIR, CKSnapshotReferenceDirectorySuffix()]; \
+NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%@%@", [self getReferenceImageDirectoryWithDefault:(@ FB_REFERENCE_IMAGE_DIR)], CKSnapshotReferenceDirectorySuffix()]; \
 BOOL comparisonSuccess__ = [self compareSnapshotOfComponentBlock:(componentBlock__) updateStateBlock:(updateStateBlock__) sizeRange:(sizeRange__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
 XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
 }

--- a/ComponentSnapshotTestCase/ComponentSnapshotTestCase.podspec
+++ b/ComponentSnapshotTestCase/ComponentSnapshotTestCase.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '7.0'
   s.requires_arc = true
   s.source_files = '**/*.h', '**/*.m', '**/*.mm'
-  s.dependency 'FBSnapshotTestCase/Core'
+  s.dependency 'FBSnapshotTestCase/Core', '~> 2.0.4'
   s.frameworks = 'UIKit', 'XCTest'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - ComponentKit (0.13)
   - ComponentKitTestLib (0.13)
   - ComponentSnapshotTestCase (0.13):
-    - FBSnapshotTestCase/Core
-  - FBSnapshotTestCase/Core (2.0.3)
+    - FBSnapshotTestCase/Core (~> 2.0.4)
+  - FBSnapshotTestCase/Core (2.0.4)
   - OCMock (2.2.4)
 
 DEPENDENCIES:
@@ -23,8 +23,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   ComponentKit: b79a11f258ef71c44e3be976e4929c6eb4144c58
   ComponentKitTestLib: df0db542b6605ba88e18cba63dd59d9ccc5966fd
-  ComponentSnapshotTestCase: cc50eb3c5418e77387dba6202a7e58760468d785
-  FBSnapshotTestCase: d0eeca6bf87958e088b254396ae66873f971cfb1
+  ComponentSnapshotTestCase: cce245e91f4cf10369c18ae8438927ff6ca0d146
+  FBSnapshotTestCase: d94cf34841c9e77390e29009e8e2713479d48753
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
 
 COCOAPODS: 0.38.2


### PR DESCRIPTION
Use new method of looking up reference images introduced in version 2.0.4. This will cause images to be looked up in bundle if FB_REFERENCE_IMAGE_DIR is empty string.