### PR TITLE
[TDS] compute final index paths for updates

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -63,7 +63,7 @@ CKTransactionalComponentDataSourceListener
 
 static void applyChangesToCollectionView(CKTransactionalComponentDataSourceAppliedChanges *changes, UICollectionView *collectionView)
 {
-  [collectionView reloadItemsAtIndexPaths:[changes.updatedIndexPaths allObjects]];
+  [collectionView reloadItemsAtIndexPaths:[changes.updatedIndexPaths allKeys]];
   [collectionView deleteItemsAtIndexPaths:[changes.removedIndexPaths allObjects]];
   [collectionView deleteSections:changes.removedSections];
   for (NSIndexPath *from in changes.movedIndexPaths) {

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.h
@@ -12,7 +12,7 @@
 
 @interface CKTransactionalComponentDataSourceAppliedChanges : NSObject
 
-@property (nonatomic, copy, readonly) NSSet *updatedIndexPaths;
+@property (nonatomic, copy, readonly) NSDictionary *updatedIndexPaths;
 @property (nonatomic, copy, readonly) NSSet *removedIndexPaths;
 @property (nonatomic, copy, readonly) NSIndexSet *removedSections;
 @property (nonatomic, copy, readonly) NSDictionary *movedIndexPaths;

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.mm
@@ -17,7 +17,7 @@
 
 @implementation CKTransactionalComponentDataSourceAppliedChanges
 
-- (instancetype)initWithUpdatedIndexPaths:(NSSet *)updatedIndexPaths
+- (instancetype)initWithUpdatedIndexPaths:(NSDictionary *)updatedIndexPaths
                         removedIndexPaths:(NSSet *)removedIndexPaths
                           removedSections:(NSIndexSet *)removedSections
                           movedIndexPaths:(NSDictionary *)movedIndexPaths
@@ -26,7 +26,7 @@
                                  userInfo:(NSDictionary *)userInfo
 {
   if (self = [super init]) {
-    _updatedIndexPaths = [updatedIndexPaths copy] ?: [NSSet set];
+    _updatedIndexPaths = [updatedIndexPaths copy] ?: @{};
     _removedIndexPaths = [removedIndexPaths copy] ?: [NSSet set];
     _removedSections = [removedSections copy] ?: [NSIndexSet indexSet];
     _movedIndexPaths = [movedIndexPaths copy] ?: @{};

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChangesInternal.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChangesInternal.h
@@ -14,7 +14,7 @@
 @interface CKTransactionalComponentDataSourceAppliedChanges ()
 
 /** Any of the parameters may be nil, in which case a default value will be substituted instead. */
-- (instancetype)initWithUpdatedIndexPaths:(NSSet *)updatedIndexPaths
+- (instancetype)initWithUpdatedIndexPaths:(NSDictionary *)updatedIndexPaths
                         removedIndexPaths:(NSSet *)removedIndexPaths
                           removedSections:(NSIndexSet *)removedSections
                           movedIndexPaths:(NSDictionary *)movedIndexPaths

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -42,11 +42,12 @@
   const CKSizeRange sizeRange = [configuration sizeRange];
 
   NSMutableArray *newSections = [NSMutableArray array];
-  NSMutableSet *updatedIndexPaths = [NSMutableSet set];
+  NSMutableDictionary *updatedIndexPaths = [NSMutableDictionary dictionary];
   [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     NSMutableArray *newItems = [NSMutableArray array];
     [items enumerateObjectsUsingBlock:^(CKTransactionalComponentDataSourceItem *item, NSUInteger itemIdx, BOOL *itemStop) {
-      [updatedIndexPaths addObject:[NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx]];
+      NSIndexPath *updateIndexPath = [NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx];
+      updatedIndexPaths[updateIndexPath] = updateIndexPath;
       const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
         return [componentProvider componentForModel:[item model] context:context];
       });

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -48,11 +48,12 @@
   && [_configuration componentProvider] == [[oldState configuration] componentProvider];
 
   NSMutableArray *newSections = [NSMutableArray array];
-  NSMutableSet *updatedIndexPaths = [NSMutableSet set];
+  NSMutableDictionary *updatedIndexPaths = [NSMutableDictionary dictionary];
   [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     NSMutableArray *newItems = [NSMutableArray array];
     [items enumerateObjectsUsingBlock:^(CKTransactionalComponentDataSourceItem *item, NSUInteger itemIdx, BOOL *itemStop) {
-      [updatedIndexPaths addObject:[NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx]];
+      NSIndexPath *updateIndexPath = [NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx];
+      updatedIndexPaths[updateIndexPath] = updateIndexPath;
 
       CKTransactionalComponentDataSourceItem *newItem;
       if (onlySizeRangeChanged) {

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -42,7 +42,7 @@
   const CKSizeRange sizeRange = [configuration sizeRange];
 
   NSMutableArray *newSections = [NSMutableArray array];
-  NSMutableSet *updatedIndexPaths = [NSMutableSet set];
+  NSMutableDictionary *updatedIndexPaths = [NSMutableDictionary dictionary];
   [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     NSMutableArray *newItems = [NSMutableArray array];
     [items enumerateObjectsUsingBlock:^(CKTransactionalComponentDataSourceItem *item, NSUInteger itemIdx, BOOL *itemStop) {
@@ -50,7 +50,8 @@
       if (stateUpdatesForItem == _stateUpdates.end()) {
         [newItems addObject:item];
       } else {
-        [updatedIndexPaths addObject:[NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx]];
+        NSIndexPath *updateIndexPath = [NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx];
+        updatedIndexPaths[updateIndexPath] = updateIndexPath;
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], stateUpdatesForItem->second, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetModificationTests.mm
@@ -199,5 +199,146 @@
   XCTAssertEqualObjects(c.model, @0);
 }
 
+- (void)testChangesetWithInsertWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 3, 3);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @1, [NSIndexPath indexPathForItem:1 inSection:0]: @2}]
+    withInsertedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @2}]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
+                                              [NSIndexPath indexPathForItem:1 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:0],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
+
+- (void)testChangesetWithRemovalWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 3, 3);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @1, [NSIndexPath indexPathForItem:2 inSection:0]: @2}]
+    withRemovedItems:[NSSet setWithObject:[NSIndexPath indexPathForItem:1 inSection:0]]]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
+                                              [NSIndexPath indexPathForItem:2 inSection:0]: [NSIndexPath indexPathForItem:1 inSection:0],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
+
+- (void)testChangesetWithInsertionAndRemovalWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 3, 3);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @1, [NSIndexPath indexPathForItem:2 inSection:0]: @2}]
+    withRemovedItems:[NSSet setWithObject:[NSIndexPath indexPathForItem:1 inSection:0]]]
+   withInsertedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @7}]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
+                                              [NSIndexPath indexPathForItem:2 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:0],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
+
+- (void)testChangesetWithMoveWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 1, 4);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @1, [NSIndexPath indexPathForItem:2 inSection:0]: @2}]
+    withMovedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:1 inSection:0]}]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:1 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
+                                              [NSIndexPath indexPathForItem:2 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:0],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
+
+- (void)testChangesetWithSectionInsertWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 3, 3);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @1, [NSIndexPath indexPathForItem:1 inSection:0]: @2}]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:1],
+                                              [NSIndexPath indexPathForItem:1 inSection:0]: [NSIndexPath indexPathForItem:1 inSection:1],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
+
+- (void)testChangesetWithSectionRemovalWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 3, 3);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:1]: @1, [NSIndexPath indexPathForItem:1 inSection:1]: @2}]
+    withRemovedSections:[NSIndexSet indexSetWithIndex:0]]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:0 inSection:1]: [NSIndexPath indexPathForItem:0 inSection:0],
+                                              [NSIndexPath indexPathForItem:1 inSection:1]: [NSIndexPath indexPathForItem:1 inSection:0],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
+
+- (void)testChangesetWithSectionInsertionAndSectionRemovalWillCorrectlyComputeIndexPathsForUpdates
+{
+  CKTransactionalComponentDataSourceState *originalState = CKTransactionalComponentDataSourceTestState([self class], nil, 3, 3);
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+      withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:1]: @1, [NSIndexPath indexPathForItem:2 inSection:1]: @2}]
+     withRemovedSections:[NSIndexSet indexSetWithIndex:0]]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+   build];
+  CKTransactionalComponentDataSourceChangesetModification *changesetModification =
+  [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset
+                                                                       stateListener:nil
+                                                                            userInfo:nil];
+  CKTransactionalComponentDataSourceChange *change = [changesetModification changeFromState:originalState];
+  NSDictionary *expectedUpdatedIndexPaths = @{
+                                              [NSIndexPath indexPathForItem:0 inSection:1]: [NSIndexPath indexPathForItem:0 inSection:1],
+                                              [NSIndexPath indexPathForItem:2 inSection:1]: [NSIndexPath indexPathForItem:2 inSection:1],
+                                              };
+  XCTAssertEqualObjects([[change appliedChanges] updatedIndexPaths], expectedUpdatedIndexPaths);
+}
 
 @end

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.h
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.h
@@ -23,4 +23,4 @@ CKTransactionalComponentDataSourceState *CKTransactionalComponentDataSourceTestS
 /** Returns a data source with one item and one section. */
 CKTransactionalComponentDataSource *CKTransactionalComponentTestDataSource(Class<CKComponentProvider> provider);
 
-NSSet *CKTestIndexPaths(NSUInteger numberOfSections, NSUInteger numberOfItemsPerSection);
+NSDictionary *CKTestIndexPaths(NSUInteger numberOfSections, NSUInteger numberOfItemsPerSection);

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
@@ -69,12 +69,12 @@ CKTransactionalComponentDataSource *CKTransactionalComponentTestDataSource(Class
   return ds;
 }
 
-NSSet *CKTestIndexPaths(NSUInteger numberOfSections, NSUInteger numberOfItemsPerSection)
+NSDictionary *CKTestIndexPaths(NSUInteger numberOfSections, NSUInteger numberOfItemsPerSection)
 {
-  NSMutableSet *ips = [NSMutableSet set];
+  NSMutableDictionary *ips = [NSMutableDictionary dictionary];
   for (NSUInteger i = 0; i < numberOfSections; i++) {
     for (NSUInteger j = 0; j < numberOfItemsPerSection; j++) {
-      [ips addObject:[NSIndexPath indexPathForItem:j inSection:i]];
+      ips[[NSIndexPath indexPathForItem:j inSection:i]] = [NSIndexPath indexPathForItem:j inSection:i];
     }
   }
   return ips;

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceTests.mm
@@ -127,7 +127,7 @@ struct CKDataSourceAnnouncedUpdate {
                  userInfo:nil];
 
   CKTransactionalComponentDataSourceAppliedChanges *expectedAppliedChanges =
-  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]
+  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:@{[NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0]}
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
@@ -146,7 +146,7 @@ struct CKDataSourceAnnouncedUpdate {
   [ds reloadWithMode:CKUpdateModeSynchronous userInfo:nil];
 
   CKTransactionalComponentDataSourceAppliedChanges *expectedAppliedChanges =
-  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]
+  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:@{[NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0]}
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
@@ -169,7 +169,7 @@ struct CKDataSourceAnnouncedUpdate {
   [ds reloadWithMode:CKUpdateModeAsynchronous userInfo:@{@"id": @3}];
 
   CKTransactionalComponentDataSourceAppliedChanges *expectedAppliedChangesForSyncReload =
-  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]
+  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:@{[NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0]}
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
@@ -177,7 +177,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                    insertedIndexPaths:nil
                                                                              userInfo:@{@"id": @2}];
   CKTransactionalComponentDataSourceAppliedChanges *expectedAppliedChangesForSecondAsyncReload =
-  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]
+  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:@{[NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0]}
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
@@ -81,7 +81,7 @@
   CKTransactionalComponentDataSourceChange *change = [updateStateModification changeFromState:originalState];
 
   CKTransactionalComponentDataSourceAppliedChanges *expectedAppliedChanges =
-  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:[NSSet setWithObject:ip]
+  [[CKTransactionalComponentDataSourceAppliedChanges alloc] initWithUpdatedIndexPaths:@{ip: ip}
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil


### PR DESCRIPTION
So far updates in `CKTransactionalComponentDataSourceAppliedChanges` have contained only index paths in pre-changeset-application world. This makes sense, since that's what you use to tell tableview/collection view what to update.

It's useful to know where updated rows ended up after the whole changeset has been applied (for reasons we don't let CV do reloads but we perform them manually). The only way to do gain that information is basically by performing a simulation of what TDS does internally.
That is an duplication of work and another opportunity to introduce a bug. Therefore I created this diff which makes TDS compute these post-changeset-application index paths for updates as well.

How does it work? We just record initial index path for each updated item. Then once we apply the whole changeset we look at every item in the new state whether we have an initial position recorded for it.

Caveat: This means a backwards incompatible change in `CKTransactionalComponentDataSourceAppliedChanges`'s interface.

cc @benlodotcom 