### PR TITLE
Fix CKNetworkImageComponent flash when defaultImage changes

### DIFF
--- a/ComponentKit/Components/CKNetworkImageComponent.mm
+++ b/ComponentKit/Components/CKNetworkImageComponent.mm
@@ -125,6 +125,12 @@
   if (CKObjectIsEqual(specifier, _specifier)) {
     return;
   }
+  
+  BOOL isShowingCurrentImageURL = self.image != _specifier.defaultImage && self.image != nil;
+  if (isShowingCurrentImageURL && CKObjectIsEqual(_specifier.url, specifier.url)) {
+    _specifier = specifier;
+    return;
+  }
 
   if (_download) {
     [_specifier.imageDownloader cancelImageDownload:_download];


### PR DESCRIPTION
If we already showed the image in CKNetworkImageComponent, if we download the same URL but the defaultImage is the same, the current code will assume it is a different image and set the defaultImage again and redownload the URL again.
There is no need to do that if the image is already downloaded. All we have to do is update the specifier to make sure if we need to show the defaultImage, we will use the new one when needed.

It is hard to snapshot test this since this is behavior inside CKNetworkComponentView. It will require creating a new 2nd component and make it use the same view. Happy to add a unit test if this is something possible.