### PR TITLE
Make FBSnapshotTestCase tolerance property accessible

### DIFF
--- a/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h
+++ b/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h
@@ -87,6 +87,11 @@ XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); 
 @interface CKComponentSnapshotTestCase : FBSnapshotTestCase
 
 /**
+ The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ */
+@property (readwrite, nonatomic, assign) CGFloat tolerance;
+
+/**
  Performs the comparison or records a snapshot of the view if recordMode is YES.
  @param component The component to snapshot
  @param referenceImagesDirectory The directory in which reference images are stored.

--- a/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.mm
+++ b/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.mm
@@ -39,7 +39,7 @@ static CKComponent *_leakyComponent;
   return [self compareSnapshotOfView:v
             referenceImagesDirectory:referenceImagesDirectory
                           identifier:identifier
-                           tolerance:0
+                           tolerance:self.tolerance
                                error:errorPtr];
 }
 


### PR DESCRIPTION
Hi all,

Just a simple one here - `FBSnapshotTestCase` has had the `tolerance` feature available since baae047998f6c3f5ace0d38daad5653bc3aee385. However, it's not easily accessibly from `CKComponentSnapshotTestCase`. We certainly do a lot of re-recording of reference images for things like major OS updates (we had loads for 8 -> 9) where inconsequential minor pixel changes happen, so it would be great to make use of this.

Seems fine to just have it as a property of the test case since it would seem to me that one would set this to a value that's a "policy" of sorts across the board.

Anyway, let me know!