### PR TITLE
Add CKSupplementaryViewDataSource support to transactional data source

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */; };
 		31EBF255C3C6127E5A3619D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */; };
+		497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */; settings = {ASSET_TAGS = (); }; };
 		83EBF589FB5C5611BC1A2D13 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		991DE3411B3B308900AA05B2 /* CKComponentMemoizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */; };
 		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
@@ -98,6 +99,7 @@
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
 		39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDataSourceAttachControllerTests.mm; sourceTree = "<group>"; };
+		497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceTests.mm; sourceTree = "<group>"; };
 		71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentMemoizerTests.mm; sourceTree = "<group>"; };
 		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */,
 				A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */,
 				A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */,
+				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */,
 			);
 			path = TransactionalDataSource;
 			sourceTree = "<group>";
@@ -707,6 +710,7 @@
 				39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */,
 				B342DC741AC23EA900ACAC53 /* CKComponentHostingViewTestModel.mm in Sources */,
 				B342DC761AC23EA900ACAC53 /* CKComponentLifecycleManagerTests.mm in Sources */,
+				497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */,
 				A22FE3061AF2CF0C00EC30B8 /* CKStateExposingComponent.mm in Sources */,
 				B342DC721AC23EA900ACAC53 /* CKComponentFlexibleSizeRangeProviderTests.mm in Sources */,
 				B342DC7B1AC23EA900ACAC53 /* CKComponentSizeTests.mm in Sources */,

--- a/ComponentKit/DataSources/CKCollectionViewDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.h
@@ -11,6 +11,7 @@
 #import <UIKit/UIKit.h>
 
 #import <ComponentKit/CKArrayControllerChangeset.h>
+#import <ComponentKit/CKSupplementaryViewDataSource.h>
 
 #import <ComponentKit/CKMacros.h>
 #import <ComponentKit/CKDimension.h>
@@ -113,15 +114,3 @@ typedef void(*CKCellConfigurationFunction)(UICollectionViewCell *cell, NSIndexPa
 
 @end
 
-/**
- The supplementaryViewDataSource can't just conform to @see UICollectionViewDataSource as this protocol includes required
- methods that are already implemented by this class. Hence we duplicate the part of the protocol related to supplementary views
- and wrap it in our internal one.
- */
-@protocol CKSupplementaryViewDataSource<NSObject>
-
-- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView
-           viewForSupplementaryElementOfKind:(NSString *)kind
-                                 atIndexPath:(NSIndexPath *)indexPath;
-
-@end

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
@@ -31,6 +31,8 @@
            supplementaryViewDataSource:(id<CKSupplementaryViewDataSource>)supplementaryViewDataSource
                          configuration:(CKTransactionalComponentDataSourceConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /** 
  Applies a changeset either synchronously or asynchronously to the collection view.
  If a synchronous changeset is applied while asynchronous changesets are still pending, then the pending changesets will be applied synchronously

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
@@ -11,6 +11,7 @@
 #import <UIKit/UIKit.h>
 
 #import "CKTransactionalComponentDataSource.h"
+#import "CKSupplementaryViewDataSource.h"
 
 /**
  This class is an implementation of a `UICollectionViewDataSource` that can be used along with components. For each set of changes (i.e insertion/deletion/update
@@ -27,6 +28,7 @@
  @param collectionView The collectionView is held strongly and its datasource property will be set to the receiver.
  */
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView
+           supplementaryViewDataSource:(id<CKSupplementaryViewDataSource>)supplementaryViewDataSource
                          configuration:(CKTransactionalComponentDataSourceConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /** 

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -26,6 +26,7 @@ CKTransactionalComponentDataSourceListener
 >
 {
   CKTransactionalComponentDataSource *_componentDataSource;
+  id<CKSupplementaryViewDataSource> _supplementaryViewDataSource;
   CKTransactionalComponentDataSourceState *_currentState;
   CKComponentDataSourceAttachController *_attachController;
 }
@@ -34,6 +35,7 @@ CKTransactionalComponentDataSourceListener
 @implementation CKCollectionViewTransactionalDataSource
 
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView
+           supplementaryViewDataSource:(id<CKSupplementaryViewDataSource>)supplementaryViewDataSource
                          configuration:(CKTransactionalComponentDataSourceConfiguration *)configuration
 {
   self = [super init];
@@ -46,6 +48,7 @@ CKTransactionalComponentDataSourceListener
     [_collectionView registerClass:[CKCollectionViewDataSourceCell class] forCellWithReuseIdentifier:kReuseIdentifier];
     
     _attachController = [[CKComponentDataSourceAttachController alloc] init];
+    _supplementaryViewDataSource = supplementaryViewDataSource;
   }
   return self;
 }
@@ -136,6 +139,11 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
   CKTransactionalComponentDataSourceItem *item = [_currentState objectAtIndexPath:indexPath];
   [_attachController attachComponentLayout:item.layout withScopeIdentifier:item.scopeRoot.globalIdentifier toView:cell.rootView];
   return cell;
+}
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+  return [_supplementaryViewDataSource collectionView:collectionView viewForSupplementaryElementOfKind:kind atIndexPath:indexPath];
 }
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView

--- a/ComponentKit/DataSources/CKSupplementaryViewDataSource.h
+++ b/ComponentKit/DataSources/CKSupplementaryViewDataSource.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@class UICollectionReusableView;
+@class UICollectionView;
+
+/**
+ The supplementaryViewDataSource can't just conform to @see UICollectionViewDataSource as this protocol includes required
+ methods that are already implemented by this class. Hence we duplicate the part of the protocol related to supplementary views
+ and wrap it in our internal one.
+ */
+@protocol CKSupplementaryViewDataSource<NSObject>
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView
+           viewForSupplementaryElementOfKind:(NSString *)kind
+                                 atIndexPath:(NSIndexPath *)indexPath;
+
+@end

--- a/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceTests.mm
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <UIKit/UIKit.h>
+
+#import "CKCollectionViewTransactionalDataSource.h"
+#import "CKTransactionalComponentDataSourceConfiguration.h"
+#import "CKSupplementaryViewDataSource.h"
+#import "CKSizeRange.h"
+
+@interface CKCollectionViewTransactionalDataSource () <UICollectionViewDataSource>
+@end
+
+@interface CKCollectionViewTransactionalDataSourceTests : XCTestCase
+@property (strong) CKCollectionViewTransactionalDataSource *dataSource;
+@property (strong) id mockCollectionView;
+@property (strong) id mockSupplementaryViewDataSource;
+@end
+
+@implementation CKCollectionViewTransactionalDataSourceTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.mockSupplementaryViewDataSource = [OCMockObject mockForProtocol:@protocol(CKSupplementaryViewDataSource)];
+  self.mockCollectionView = [OCMockObject niceMockForClass:[UICollectionView class]];
+
+  CKTransactionalComponentDataSourceConfiguration *config = [[CKTransactionalComponentDataSourceConfiguration alloc]
+                                                             initWithComponentProvider:nil
+                                                             context:nil
+                                                             sizeRange:CKSizeRange()];
+
+  self.dataSource = [[CKCollectionViewTransactionalDataSource alloc]
+                     initWithCollectionView:self.mockCollectionView
+                     supplementaryViewDataSource:self.mockSupplementaryViewDataSource
+                     configuration:config];
+}
+
+- (void)testSupplementaryViewDataSource
+{
+  NSIndexPath *indexPath = [NSIndexPath indexPathForItem:3 inSection:4];
+  NSString *viewKind = @"foo";
+  
+  [[self.mockSupplementaryViewDataSource expect] collectionView:self.mockCollectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+  [self.dataSource collectionView:self.mockCollectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+}
+
+@end


### PR DESCRIPTION
Resolves https://github.com/facebook/componentkit/issues/394.

Ok, we found that problem! `CKCollectionViewTransactionalDataSource` doesn't forward supplementary view methods à la `CKCollectionViewDataSource`. Since we use section headers implemented previously with `CKCollectionViewDataSource` we return non-zero sizes for the expected supplementary views. `CKCollectionViewTransactionalDataSource` doesn't implement the supplementary view method and hence the collectionView starts playing with `nil` views.

Problem solved and QED. Trivial to implement. Please let me know any suggested adjustments.