### PR TITLE
Add moved sections support to CKTransactionalComponentDataSourceChangeset

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -70,6 +70,10 @@ static void applyChangesToCollectionView(CKTransactionalComponentDataSourceAppli
     NSIndexPath *to = changes.movedIndexPaths[from];
     [collectionView moveItemAtIndexPath:from toIndexPath:to];
   }
+  for (NSNumber *from in changes.movedSections) {
+    NSNumber *to = changes.movedSections[from];
+    [collectionView moveSection:from.unsignedIntegerValue toSection:to.unsignedIntegerValue];
+  }
   [collectionView insertSections:changes.insertedSections];
   [collectionView insertItemsAtIndexPaths:[changes.insertedIndexPaths allObjects]];
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.h
@@ -16,6 +16,7 @@
 @property (nonatomic, copy, readonly) NSSet *removedIndexPaths;
 @property (nonatomic, copy, readonly) NSIndexSet *removedSections;
 @property (nonatomic, copy, readonly) NSDictionary *movedIndexPaths;
+@property (nonatomic, copy, readonly) NSDictionary *movedSections;
 @property (nonatomic, copy, readonly) NSIndexSet *insertedSections;
 @property (nonatomic, copy, readonly) NSSet *insertedIndexPaths;
 

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.mm
@@ -21,6 +21,7 @@
                         removedIndexPaths:(NSSet *)removedIndexPaths
                           removedSections:(NSIndexSet *)removedSections
                           movedIndexPaths:(NSDictionary *)movedIndexPaths
+                            movedSections:(NSDictionary *)movedSections
                          insertedSections:(NSIndexSet *)insertedSections
                        insertedIndexPaths:(NSSet *)insertedIndexPaths
                                  userInfo:(NSDictionary *)userInfo
@@ -30,6 +31,7 @@
     _removedIndexPaths = [removedIndexPaths copy] ?: [NSSet set];
     _removedSections = [removedSections copy] ?: [NSIndexSet indexSet];
     _movedIndexPaths = [movedIndexPaths copy] ?: @{};
+    _movedSections = [movedSections copy] ?: @{};
     _insertedSections = [insertedSections copy] ?: [NSIndexSet indexSet];
     _insertedIndexPaths = [insertedIndexPaths copy] ?: [NSSet set];
     _userInfo = [userInfo copy];
@@ -44,6 +46,7 @@
     && CKObjectIsEqual(a.removedIndexPaths, b.removedIndexPaths)
     && CKObjectIsEqual(a.removedSections, b.removedSections)
     && CKObjectIsEqual(a.movedIndexPaths, b.movedIndexPaths)
+    && CKObjectIsEqual(a.movedSections, b.movedSections)
     && CKObjectIsEqual(a.insertedSections, b.insertedSections)
     && CKObjectIsEqual(a.insertedIndexPaths, b.insertedIndexPaths)
     && CKObjectIsEqual(a.userInfo, b.userInfo);
@@ -57,6 +60,7 @@
     [_removedIndexPaths hash],
     [_removedSections hash],
     [_movedIndexPaths hash],
+    [_movedSections hash],
     [_insertedSections hash],
     [_insertedIndexPaths hash],
     [_userInfo hash],

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChangesInternal.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChangesInternal.h
@@ -18,6 +18,7 @@
                         removedIndexPaths:(NSSet *)removedIndexPaths
                           removedSections:(NSIndexSet *)removedSections
                           movedIndexPaths:(NSDictionary *)movedIndexPaths
+                            movedSections:(NSDictionary *)movedSections
                          insertedSections:(NSIndexSet *)insertedSections
                        insertedIndexPaths:(NSSet *)insertedIndexPaths
                                  userInfo:(NSDictionary *)userInfo;

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangeset.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangeset.h
@@ -25,6 +25,7 @@
                         removedItems:(NSSet *)removedItems
                      removedSections:(NSIndexSet *)removedSections
                           movedItems:(NSDictionary *)movedItems
+                       movedSections:(NSDictionary *)movedSections
                     insertedSections:(NSIndexSet *)insertedSections
                        insertedItems:(NSDictionary *)insertedItems;
 
@@ -38,6 +39,7 @@
 - (instancetype)withRemovedItems:(NSSet *)removedItems;
 - (instancetype)withRemovedSections:(NSIndexSet *)removedSections;
 - (instancetype)withMovedItems:(NSDictionary *)movedItems;
+- (instancetype)withMovedSections:(NSDictionary *)movedSections;
 - (instancetype)withInsertedSections:(NSIndexSet *)insertedSections;
 - (instancetype)withInsertedItems:(NSDictionary *)insertedItems;
 - (CKTransactionalComponentDataSourceChangeset *)build;

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangeset.m
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangeset.m
@@ -17,6 +17,7 @@
                         removedItems:(NSSet *)removedItems
                      removedSections:(NSIndexSet *)removedSections
                           movedItems:(NSDictionary *)movedItems
+                       movedSections:(NSDictionary *)movedSections
                     insertedSections:(NSIndexSet *)insertedSections
                        insertedItems:(NSDictionary *)insertedItems
 {
@@ -25,6 +26,7 @@
     _removedItems = [removedItems copy] ?: [NSSet set];
     _removedSections = [removedSections copy] ?: [NSIndexSet indexSet];
     _movedItems = [movedItems copy] ?: @{};
+    _movedSections = [movedSections copy] ?: @{};
     _insertedSections = [insertedSections copy] ?: [NSIndexSet indexSet];
     _insertedItems = [insertedItems copy] ?: @{};
   }
@@ -39,6 +41,7 @@
   NSSet *_removedItems;
   NSIndexSet *_removedSections;
   NSDictionary *_movedItems;
+  NSDictionary *_movedSections;
   NSIndexSet *_insertedSections;
   NSDictionary *_insertedItems;
 }
@@ -48,6 +51,7 @@
 - (instancetype)withRemovedItems:(NSSet *)removedItems { _removedItems = removedItems; return self; }
 - (instancetype)withRemovedSections:(NSIndexSet *)removedSections { _removedSections = removedSections; return self; }
 - (instancetype)withMovedItems:(NSDictionary *)movedItems { _movedItems = movedItems; return self; }
+- (instancetype)withMovedSections:(NSDictionary *)movedSections { _movedSections = movedSections; return self; }
 - (instancetype)withInsertedSections:(NSIndexSet *)insertedSections { _insertedSections = insertedSections; return self; }
 - (instancetype)withInsertedItems:(NSDictionary *)insertedItems { _insertedItems = insertedItems; return self; }
 
@@ -57,6 +61,7 @@
                                                                       removedItems:_removedItems
                                                                    removedSections:_removedSections
                                                                         movedItems:_movedItems
+                                                                     movedSections:_movedSections
                                                                   insertedSections:_insertedSections
                                                                      insertedItems:_insertedItems];
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangesetInternal.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceChangesetInternal.h
@@ -17,6 +17,7 @@
 @property (nonatomic, copy, readonly) NSSet *removedItems;
 @property (nonatomic, copy, readonly) NSIndexSet *removedSections;
 @property (nonatomic, copy, readonly) NSDictionary *movedItems;
+@property (nonatomic, copy, readonly) NSDictionary *movedSections;
 @property (nonatomic, copy, readonly) NSIndexSet *insertedSections;
 @property (nonatomic, copy, readonly) NSDictionary *insertedItems;
 @property (nonatomic, copy, readonly) NSDictionary *userInfo;

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -134,6 +134,7 @@
                                                                     removedIndexPaths:[_changeset removedItems]
                                                                       removedSections:[_changeset removedSections]
                                                                       movedIndexPaths:[_changeset movedItems]
+                                                                        movedSections:[_changeset movedSections]
                                                                      insertedSections:[_changeset insertedSections]
                                                                    insertedIndexPaths:[NSSet setWithArray:[[_changeset insertedItems] allKeys]]
                                                                              userInfo:_userInfo];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -67,6 +67,7 @@
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:_userInfo];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -84,6 +84,7 @@
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:_userInfo];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -72,6 +72,7 @@
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:nil];

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceReloadModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceReloadModificationTests.mm
@@ -64,6 +64,7 @@ static u_int32_t globalState = 0;
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:nil];

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceTests.mm
@@ -76,6 +76,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:[NSIndexSet indexSetWithIndex:0]
                                                                    insertedIndexPaths:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]
                                                                              userInfo:nil];
@@ -104,6 +105,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:[NSIndexSet indexSetWithIndex:0]
                                                                    insertedIndexPaths:[NSSet setWithObject:[NSIndexPath indexPathForItem:0 inSection:0]]
                                                                              userInfo:nil];
@@ -131,6 +133,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:nil];
@@ -150,6 +153,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:nil];
@@ -173,6 +177,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:@{@"id": @2}];
@@ -181,6 +186,7 @@ struct CKDataSourceAnnouncedUpdate {
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:@{@"id": @3}];

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm
@@ -94,6 +94,7 @@
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:nil];

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
@@ -85,6 +85,7 @@
                                                                     removedIndexPaths:nil
                                                                       removedSections:nil
                                                                       movedIndexPaths:nil
+                                                                        movedSections:nil
                                                                      insertedSections:nil
                                                                    insertedIndexPaths:nil
                                                                              userInfo:nil];


### PR DESCRIPTION
As discussed in https://github.com/facebook/componentkit/pull/391. I'll do the DSL builder as a separate project, but section moving support is definitely missing here, so added it.