### PR TITLE
Fixed dangling datasource pointer

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -73,6 +73,11 @@ CK_FINAL_CLASS([CKCollectionViewDataSource class]);
   CK_NOT_DESIGNATED_INITIALIZER();
 }
 
+- (void)dealloc
+{
+    _collectionView.dataSource = nil;
+}
+
 #pragma mark - Changesets
 
 - (void)enqueueChangeset:(const CKArrayControllerInputChangeset &)changeset constrainedSize:(const CKSizeRange &)constrainedSize


### PR DESCRIPTION
Prior iOS9 UIKit does not use ARC, we have to clear weak ref manually.