### PR TITLE
weak for component provider, and supplementary view data source

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -26,7 +26,7 @@ CKTransactionalComponentDataSourceListener
 >
 {
   CKTransactionalComponentDataSource *_componentDataSource;
-  id<CKSupplementaryViewDataSource> _supplementaryViewDataSource;
+  __weak id<CKSupplementaryViewDataSource> _supplementaryViewDataSource;
   CKTransactionalComponentDataSourceState *_currentState;
   CKComponentDataSourceAttachController *_attachController;
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceConfiguration.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceConfiguration.h
@@ -27,7 +27,7 @@
                                   context:(id<NSObject>)context
                                 sizeRange:(const CKSizeRange &)sizeRange;
 
-@property (nonatomic, strong, readonly) Class<CKComponentProvider> componentProvider;
+@property (nonatomic, weak, readonly) Class<CKComponentProvider> componentProvider;
 @property (nonatomic, strong, readonly) id<NSObject> context;
 - (const CKSizeRange &)sizeRange;
 


### PR DESCRIPTION
Hi all :smiley: 

Looks like some retain cycles fixed here. The first is my bad: I prefer `@property` over direct ivar access, so forgot to make the supplementary view data source `__weak` in https://github.com/facebook/componentkit/pull/395. Fixed here. However, pretty sure that the `componentProvider` also needs to be weak since we have the following basic ownership:

![untitled diagram](https://cloud.githubusercontent.com/assets/557391/10642471/1f9bb954-781e-11e5-8510-6d33d91c45c8.png)

Therefore the obvious place to break the cycle is to have a `weak` `componentProvider`. Doesn't seem to be any danger here, and fixes the cycles in our case.

Let me know what you think!