### PR TITLE
Fix hostingview initial size issue.

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -71,7 +71,7 @@ struct CKComponentHostingViewInputs {
     _containerView = [[CKComponentRootView alloc] initWithFrame:CGRectZero];
     [self addSubview:_containerView];
 
-    _componentNeedsUpdate = YES;
+    _componentNeedsUpdate = NO;
     _requestedUpdateMode = CKUpdateModeSynchronous;
   }
   return self;


### PR DESCRIPTION
The issue is if update model in first time the method componentHostingViewDidInvalidateSize is not called. So there's no chance to adjust the hostingview's size.
Simply change the update initial value for flag variable.