### PR TITLE
debugQuickLookObject categories

### DIFF
--- a/ComponentKit/Debug/ComponentKit+QuickLook.mm
+++ b/ComponentKit/Debug/ComponentKit+QuickLook.mm
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentController.h>
+
+@implementation CKComponent (QuickLook)
+
+- (id)debugQuickLookObject
+{
+  return self.viewContext.view;
+}
+
+@end
+
+@implementation CKComponentController (QuickLook)
+
+- (id)debugQuickLookObject
+{
+  return self.component.debugQuickLookObject;
+}
+
+@end


### PR DESCRIPTION
Hi all,

Just a quick simple debugging aid for Xcode users here. Very trivial addition, but looks potentially very helpful. Up until this point I've been using Chisel for this myself, but direct Quicklook access via LLDB seems much more user friendly:

![screen shot 2015-10-28 at 10 44 36](https://cloud.githubusercontent.com/assets/557391/10784956/37040040-7d61-11e5-8215-8341d6e9e643.png)

Let me know what you think.

Thanks!