### PR TITLE
Add configurable watchdog timer

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentPreparationQueue.mm
+++ b/ComponentKit/DataSources/Common/CKComponentPreparationQueue.mm
@@ -17,6 +17,7 @@
 #import "CKMutex.h"
 #import "CKComponentLifecycleManager.h"
 #import "CKComponentPreparationQueueListenerAnnouncer.h"
+#import "CKWatchdogTimer.h"
 
 @implementation CKComponentPreparationInputItem
 {
@@ -199,6 +200,8 @@
 
 - (void)_processJob:(CKComponentPreparationQueueJob *)job
 {
+  CKWatchdogTimer watchdog;
+
   // All announcments are scheduled on the main thread
   dispatch_async(dispatch_get_main_queue(), ^{
     [_announcer componentPreparationQueue:self

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -20,6 +20,7 @@
 #import "CKComponentScopeRoot.h"
 #import "CKComponentSizeRangeProviding.h"
 #import "CKComponentSubclass.h"
+#import "CKWatchdogTimer.h"
 
 struct CKComponentHostingViewInputs {
   CKComponentScopeRoot *scopeRoot;
@@ -187,6 +188,7 @@ struct CKComponentHostingViewInputs {
 
   const auto inputs = std::make_shared<const CKComponentHostingViewInputs>(_pendingInputs);
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    CKWatchdogTimer watchdog;
     const auto result = std::make_shared<const CKBuildComponentResult>(CKBuildComponent(
       inputs->scopeRoot,
       inputs->stateUpdates,

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -22,6 +22,7 @@
 #import "CKTransactionalComponentDataSourceStateModifying.h"
 #import "CKTransactionalComponentDataSourceUpdateConfigurationModification.h"
 #import "CKTransactionalComponentDataSourceUpdateStateModification.h"
+#import "CKWatchdogTimer.h"
 
 @interface CKTransactionalComponentDataSource () <CKComponentStateListener>
 {
@@ -164,6 +165,7 @@
   id<CKTransactionalComponentDataSourceStateModifying> modification = _pendingAsynchronousModifications[0];
   CKTransactionalComponentDataSourceState *baseState = _state;
   dispatch_async(_workQueue, ^{
+    CKWatchdogTimer watchdog;
     CKTransactionalComponentDataSourceChange *change = [modification changeFromState:baseState];
     dispatch_async(dispatch_get_main_queue(), ^{
       // If the first object in _pendingAsynchronousModifications is not still the modification,

--- a/ComponentKit/Utilities/CKWatchdogTimer.h
+++ b/ComponentKit/Utilities/CKWatchdogTimer.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+/** Fires a global handler function if the object stays alive for longer than a global timeout value. */
+class CKWatchdogTimer {
+public:
+  CKWatchdogTimer();
+  ~CKWatchdogTimer();
+
+  /** Configures the duration to wait and the action to take upon firing. Default is to do nothing. */
+  static void configure(const int64_t timeoutNanoseconds, void (*handler)(void));
+private:
+  CKWatchdogTimer(const CKWatchdogTimer&) = delete;
+  CKWatchdogTimer &operator=(const CKWatchdogTimer&) = delete;
+  dispatch_source_t _timer;
+};

--- a/ComponentKit/Utilities/CKWatchdogTimer.mm
+++ b/ComponentKit/Utilities/CKWatchdogTimer.mm
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKWatchdogTimer.h"
+
+#import <UIKit/UIKit.h>
+#include <mach/mach_time.h>
+
+#import "CKMutex.h"
+
+/** Protects timeoutNanoseconds and handler */
+static CK::StaticMutex mutex = CK_MUTEX_INITIALIZER;
+static uint64_t timeoutNanoseconds = 0;
+static void (*handler)(void) = nullptr;
+
+static dispatch_source_t newTimer()
+{
+  uint64_t localTimeoutNanoseconds;
+  {
+    CK::StaticMutexLocker l(mutex);
+    localTimeoutNanoseconds = timeoutNanoseconds;
+  }
+  if (localTimeoutNanoseconds == 0) {
+    return nil; // Avoid cost of creating the timer altogether.
+  }
+
+  // Main thread only; as measured by mach_absolute_time
+  static uint64_t lastBackgroundingTimestamp = 0;
+  static id backgroundObserver;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    lastBackgroundingTimestamp = mach_absolute_time();
+    backgroundObserver =
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *note) {
+                                                    lastBackgroundingTimestamp = mach_absolute_time();
+                                                  }];
+  });
+
+  const uint64_t timerCreationTimestamp = mach_absolute_time();
+  dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+  dispatch_source_set_event_handler(timer, ^{
+    CKCAssertMainThread();
+    // Don't fire the handler if the app backgrounded after scheduling the timer since that suspends app's CPU
+    if (lastBackgroundingTimestamp < timerCreationTimestamp) {
+      void (*localHandler)(void);
+      {
+        CK::StaticMutexLocker l(mutex);
+        localHandler = handler;
+      }
+      if (localHandler) {
+        localHandler();
+      }
+    }
+    // Prevent further invocations of the timer.
+    dispatch_source_cancel(timer);
+  });
+  dispatch_source_set_timer(timer,
+                            // Fire after the timeout has expired.
+                            dispatch_time(DISPATCH_TIME_NOW, localTimeoutNanoseconds),
+                            // Repeat at some high interval; in practice it's canceled when it fires the first time.
+                            NSEC_PER_SEC * 1000,
+                            // High leeway for efficiency as we don't need to be exact.
+                            NSEC_PER_SEC);
+  dispatch_resume(timer);
+  return timer;
+}
+
+CKWatchdogTimer::CKWatchdogTimer()
+: _timer(newTimer()) {}
+
+CKWatchdogTimer::~CKWatchdogTimer()
+{
+  if (_timer) {
+    dispatch_source_cancel(_timer);
+  }
+}
+
+void CKWatchdogTimer::configure(const int64_t newTimeoutNanoseconds, void (*newHandler)(void))
+{
+  CK::StaticMutexLocker l(mutex);
+  timeoutNanoseconds = newTimeoutNanoseconds;
+  handler = newHandler;
+}


### PR DESCRIPTION
The process of building a component may deadlock. Add a class that will detect this case and fire a configurable C function pointer when it occurs.