### PR TITLE
[text] Fix crash when highlighted range exceeds truncation range

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRenderer+Positioning.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRenderer+Positioning.mm
@@ -27,9 +27,8 @@ static const CGFloat CKTextKitRendererTextCapHeightPadding = 1.3;
 {
   __block NSArray *textRects = @[];
   [self.context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
-    BOOL textRangeIsValid = (NSMaxRange(textRange) <= [textStorage length]);
-    CKCAssertTrue(textRangeIsValid);
-    if (!textRangeIsValid) {
+    NSRange clampedRange = NSIntersectionRange(textRange, NSMakeRange(0, [textStorage length]));
+    if (clampedRange.location == NSNotFound || clampedRange.length == 0) {
       return;
     }
 
@@ -41,7 +40,7 @@ static const CGFloat CKTextKitRendererTextCapHeightPadding = 1.3;
 
     NSString *string = textStorage.string;
 
-    NSRange totalGlyphRange = [layoutManager glyphRangeForCharacterRange:textRange actualCharacterRange:NULL];
+    NSRange totalGlyphRange = [layoutManager glyphRangeForCharacterRange:clampedRange actualCharacterRange:NULL];
 
     [layoutManager enumerateLineFragmentsForGlyphRange:totalGlyphRange usingBlock:^(CGRect rect,
                                                                                     CGRect usedRect,

--- a/ComponentTextKitApplicationTests/CKTextKitTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextKitTests.mm
@@ -13,8 +13,10 @@
 
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
+#import "CKTextKitEntityAttribute.h"
 #import "CKTextKitAttributes.h"
 #import "CKTextKitRenderer.h"
+#import "CKTextKitRenderer+Positioning.h"
 
 @interface CKTextKitTests : XCTestCase
 
@@ -133,6 +135,24 @@ static BOOL checkAttributes(const CKTextKitAttributes &attributes, const CGSize 
     .attributedString = attrStr
   };
   XCTAssert(checkAttributes(attributes, { 100, 100 }));
+}
+
+- (void)testRectsForRangeBeyondTruncationSizeReturnsNonZeroNumberOfRects
+{
+  NSAttributedString *attributedString =
+  [[NSAttributedString alloc]
+   initWithString:@"90's cray photo booth tote bag bespoke Carles. Plaid wayfarers Odd Future master cleanse tattooed four dollar toast small batch kale chips leggings meh photo booth occupy irony.  " attributes:@{CKTextKitEntityAttributeName : [[CKTextKitEntityAttribute alloc] initWithEntity:@"entity"]}];
+
+  CKTextKitRenderer *renderer =
+  [[CKTextKitRenderer alloc]
+   initWithTextKitAttributes:{
+     .attributedString = attributedString,
+     .maximumNumberOfLines = 1,
+     .truncationAttributedString = [[NSAttributedString alloc] initWithString:@"... Continue Reading"]
+   }
+   constrainedSize:{ 100, 100 }];
+
+  XCTAssert([renderer rectsForTextRange:NSMakeRange(0, attributedString.length) measureOption:CKTextKitRendererMeasureOptionBlock].count > 0);
 }
 
 @end


### PR DESCRIPTION
This was a needless assert. Remove it and just clamp the range to the string range. Add a test to confirm this works.

Resolves https://github.com/facebook/componentkit/issues/428