### PR TITLE
[text] Use the closest glyph to determine hit token

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRenderer+TextChecking.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRenderer+TextChecking.mm
@@ -72,11 +72,12 @@
 
   if (truncationTokenRange.location == NSNotFound) {
     // The truncation string didn't specify a substring which should be highlighted, so we just highlight it all
-    truncationTokenRange = { 0, self.attributes.truncationAttributedString.length };
+    truncationTokenRange = { 0, truncationAttributedString.length };
   }
 
   truncationTokenRange.location += NSMaxRange(visibleRange);
 
+  __block CGFloat minDistance = CGFLOAT_MAX;
   [self enumerateTextIndexesAtPosition:point usingBlock:^(NSUInteger index, CGRect glyphBoundingRect, BOOL *stop){
     if (index >= truncationTokenRange.location) {
       result = [[CKTextKitTextCheckingResult alloc] initWithType:CKTextKitTextCheckingTypeTruncation
@@ -86,14 +87,13 @@
       NSRange range;
       NSDictionary *attributes = [attributedString attributesAtIndex:index effectiveRange:&range];
       CKTextKitEntityAttribute *entityAttribute = attributes[CKTextKitEntityAttributeName];
-      if (entityAttribute) {
+      CGFloat distance = hypot(CGRectGetMidX(glyphBoundingRect) - point.x, CGRectGetMidY(glyphBoundingRect) - point.y);
+      if (entityAttribute && distance < minDistance) {
         result = [[CKTextKitTextCheckingResult alloc] initWithType:CKTextKitTextCheckingTypeEntity
                                                    entityAttribute:entityAttribute
                                                              range:range];
+        minDistance = distance;
       }
-    }
-    if (result != nil) {
-      *stop = YES;
     }
   }];
   return result;


### PR DESCRIPTION
Previously we were just taking the *first* glyph instead of the closest. This resulted in a weird edge case where if there was a link directly above your link, it was nearly impossibly to hit any glyphs in the link you were pressing on.  This diff just computes the distance of every candidate glyph in the enumeration, and then takes the minimum centroidal distance.

Result? When I put lots of links near eachother in a text component, it correctly highlights the right links every time...

Should resolve https://github.com/facebook/componentkit/issues/303 .