### PR TITLE
Allow primitive values in view attribute maps

### DIFF
--- a/ComponentKit/Core/CKComponentViewAttribute.h
+++ b/ComponentKit/Core/CKComponentViewAttribute.h
@@ -81,8 +81,44 @@ struct CKComponentViewAttribute {
   bool operator==(const CKComponentViewAttribute &attr) const { return identifier == attr.identifier; };
 };
 
+struct CKBoxedValue {
+  CKBoxedValue() : __actual(nil) {};
 
-typedef std::unordered_map<CKComponentViewAttribute, id> CKViewComponentAttributeValueMap;
+  // Could replace this with !CK::is_objc_class<T>
+  CKBoxedValue(bool v) : __actual(@(v)) {};
+  CKBoxedValue(int8_t v) : __actual(@(v)) {};
+  CKBoxedValue(uint8_t v) : __actual(@(v)) {};
+  CKBoxedValue(int16_t v) : __actual(@(v)) {};
+  CKBoxedValue(uint16_t v) : __actual(@(v)) {};
+  CKBoxedValue(int32_t v) : __actual(@(v)) {};
+  CKBoxedValue(uint32_t v) : __actual(@(v)) {};
+  CKBoxedValue(int64_t v) : __actual(@(v)) {};
+  CKBoxedValue(uint64_t v) : __actual(@(v)) {};
+  CKBoxedValue(long v) : __actual(@(v)) {};
+  CKBoxedValue(unsigned long v) : __actual(@(v)) {};
+  CKBoxedValue(float v) : __actual(@(v)) {};
+  CKBoxedValue(double v) : __actual(@(v)) {};
+  CKBoxedValue(SEL v) : __actual([NSValue valueWithPointer:v]) {};
+  CKBoxedValue(std::nullptr_t v) : __actual(nil) {};
+  
+  // Any objects go here
+  CKBoxedValue(id obj) : __actual(obj) {};
+
+  // Define conversions for common Apple types
+  CKBoxedValue(CGRect v) : __actual([NSValue valueWithCGRect:v]) {};
+  CKBoxedValue(CGPoint v) : __actual([NSValue valueWithCGPoint:v]) {};
+  CKBoxedValue(UIEdgeInsets v) : __actual([NSValue valueWithBytes:&v objCType:@encode(decltype(v))]) {};
+  
+  operator id () const {
+    return __actual;
+  };
+
+private:
+  id __actual;
+
+};
+
+typedef std::unordered_map<CKComponentViewAttribute, CKBoxedValue> CKViewComponentAttributeValueMap;
 
 namespace std {
 

--- a/ComponentKitTests/CKComponentViewAttributeTests.mm
+++ b/ComponentKitTests/CKComponentViewAttributeTests.mm
@@ -74,6 +74,37 @@
   XCTAssertTrue(c.layer.opacity == 0.5, @"Expected opacity to be applied to view's layer");
 }
 
+- (void)testThatMountingViewWithPrimitiveAttributeActuallyAppliesAttributeToView
+{
+  CKComponent *testComponent = [CKComponent newWithView:{[CKNSNumberView class], {
+    {@selector(setSelected:), YES},
+    {CKComponentViewAttribute::LayerAttribute(@selector(setOpacity:)), @0.5},
+    {@selector(setTag:), 2},
+    {@selector(setPrimitiveChar:), 'D'},
+    {@selector(setPrimitiveShort:), short(1)},
+    {@selector(setPrimitiveInt:), 14},
+    {@selector(setPrimitiveInt32:), 9L},
+    {@selector(setPrimitiveInt64:), 5LL},
+    {@selector(setPrimitiveUChar:), (unsigned char)('L')},
+    {@selector(setPrimitiveUShort:), (ushort)(23)},
+    {@selector(setPrimitiveUInt32:), 15UL},
+    {@selector(setPrimitiveUInt64:), 18ULL},
+    {@selector(setPrimitiveDouble:), 11.3},
+    {@selector(setPrimitiveFloat:), 21.1F},
+  }} size:{}];
+  CKComponentLifecycleManager *m = [[CKComponentLifecycleManager alloc] init];
+  [m updateWithState:{
+    .layout = [testComponent layoutThatFits:{{0, 0}, {10, 10}} parentSize:kCKComponentParentSizeUndefined]
+  }];
+  
+  UIView *container = [[UIView alloc] init];
+  [m attachToView:container];
+  CKNSNumberView *c = [[container subviews] firstObject];
+  XCTAssertTrue([c isSelected], @"Expected selected to be applied to view");
+  XCTAssertTrue(c.layer.opacity == 0.5, @"Expected opacity to be applied to view's layer");
+}
+
+
 - (void)testThatRecyclingViewWithSameAttributeValueDoesNotReApplyAttributeToView
 {
   CKComponent *testComponent1 = [CKComponent newWithView:{[CKSetterCounterView class], {


### PR DESCRIPTION
Instead of forcing people to manually box values for setters, we can use c++ to deduce the right way to box it for them. Still backwards compatible with manual boxing.

Shouldn't cause additional overhead, but we should test just in case.