### PR TITLE
Add size attribute to CKLabelComponent and CKTextComponent constructors

### DIFF
--- a/ComponentTextKit/CKLabelComponent.h
+++ b/ComponentTextKit/CKLabelComponent.h
@@ -69,4 +69,8 @@ struct CKLabelAttributes
 + (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
                         viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes;
 
++ (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
+                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
+                                  size:(const CKComponentSize &)size;
+
 @end

--- a/ComponentTextKit/CKLabelComponent.h
+++ b/ComponentTextKit/CKLabelComponent.h
@@ -67,9 +67,6 @@ struct CKLabelAttributes
 @interface CKLabelComponent : CKCompositeComponent
 
 + (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
-                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes;
-
-+ (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
                         viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
                                   size:(const CKComponentSize &)size;
 

--- a/ComponentTextKit/CKLabelComponent.mm
+++ b/ComponentTextKit/CKLabelComponent.mm
@@ -17,12 +17,22 @@
 + (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
                         viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
 {
+  return [self newWithLabelAttributes:attributes
+                       viewAttributes:viewAttributes
+                                 size:{}];
+}
+
++ (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
+                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
+                                  size:(const CKComponentSize &)size
+{
   CKViewComponentAttributeValueMap copiedMap = viewAttributes;
   return [super newWithComponent:
           [CKTextComponent
            newWithTextAttributes:textKitAttributes(attributes)
            viewAttributes:std::move(copiedMap)
-           accessibilityContext:{.isAccessibilityElement = @(YES)}]];
+           accessibilityContext:{.isAccessibilityElement = @(YES)}
+           size:size]];
 }
 
 static const CKTextKitAttributes textKitAttributes(const CKLabelAttributes &labelAttributes)

--- a/ComponentTextKit/CKLabelComponent.mm
+++ b/ComponentTextKit/CKLabelComponent.mm
@@ -16,14 +16,6 @@
 
 + (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
                         viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
-{
-  return [self newWithLabelAttributes:attributes
-                       viewAttributes:viewAttributes
-                                 size:{}];
-}
-
-+ (instancetype)newWithLabelAttributes:(const CKLabelAttributes &)attributes
-                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
                                   size:(const CKComponentSize &)size
 {
   CKViewComponentAttributeValueMap copiedMap = viewAttributes;

--- a/ComponentTextKit/CKTextComponent.h
+++ b/ComponentTextKit/CKTextComponent.h
@@ -27,10 +27,6 @@ struct CKTextComponentAccessibilityContext
 
 + (instancetype)newWithTextAttributes:(const CKTextKitAttributes &)attributes
                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
-                 accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext;
-
-+ (instancetype)newWithTextAttributes:(const CKTextKitAttributes &)attributes
-                       viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
                  accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext
                                  size:(const CKComponentSize &)size;
 

--- a/ComponentTextKit/CKTextComponent.h
+++ b/ComponentTextKit/CKTextComponent.h
@@ -29,4 +29,9 @@ struct CKTextComponentAccessibilityContext
                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
                  accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext;
 
++ (instancetype)newWithTextAttributes:(const CKTextKitAttributes &)attributes
+                       viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
+                 accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext
+                                 size:(const CKComponentSize &)size;
+
 @end

--- a/ComponentTextKit/CKTextComponent.mm
+++ b/ComponentTextKit/CKTextComponent.mm
@@ -64,16 +64,6 @@ static CKTextKitRenderer *rendererForAttributes(CKTextKitAttributes &attributes,
 + (instancetype)newWithTextAttributes:(const CKTextKitAttributes &)attributes
                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
                  accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext
-{
-  return [self newWithTextAttributes:attributes
-                      viewAttributes:viewAttributes
-                accessibilityContext:accessibilityContext
-                                size:{}];
-}
-
-+ (instancetype)newWithTextAttributes:(const CKTextKitAttributes &)attributes
-                       viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
-                 accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext
                                  size:(const CKComponentSize &)size
 {
   CKTextKitAttributes copyAttributes = attributes.copy();

--- a/ComponentTextKit/CKTextComponent.mm
+++ b/ComponentTextKit/CKTextComponent.mm
@@ -65,6 +65,17 @@ static CKTextKitRenderer *rendererForAttributes(CKTextKitAttributes &attributes,
                        viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
                  accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext
 {
+  return [self newWithTextAttributes:attributes
+                      viewAttributes:viewAttributes
+                accessibilityContext:accessibilityContext
+                                size:{}];
+}
+
++ (instancetype)newWithTextAttributes:(const CKTextKitAttributes &)attributes
+                       viewAttributes:(const CKViewComponentAttributeValueMap &)viewAttributes
+                 accessibilityContext:(const CKTextComponentAccessibilityContext &)accessibilityContext
+                                 size:(const CKComponentSize &)size
+{
   CKTextKitAttributes copyAttributes = attributes.copy();
   CKViewComponentAttributeValueMap copiedMap = viewAttributes;
   CKTextComponent *c = [super newWithView:{
@@ -76,7 +87,7 @@ static CKTextKitRenderer *rendererForAttributes(CKTextKitAttributes &attributes,
       .accessibilityLabel = accessibilityContext.accessibilityLabel.hasText()
       ? accessibilityContext.accessibilityLabel : ^{ return copyAttributes.attributedString.string; }
     }
-  } size:{}];
+  } size:size];
   if (c) {
     c->_attributes = copyAttributes;
     c->_accessibilityContext = accessibilityContext;

--- a/ComponentTextKitApplicationTests/CKLabelComponentTests.mm
+++ b/ComponentTextKitApplicationTests/CKLabelComponentTests.mm
@@ -41,7 +41,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -54,7 +55,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kUnrestrictedSize, @"");
 }
 
@@ -68,7 +70,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kStrictSize, @"");
 }
 
@@ -82,7 +85,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kStrictSize, @"");
 }
 
@@ -96,7 +100,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -110,7 +115,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -124,7 +130,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -138,7 +145,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -155,7 +163,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -172,7 +181,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -189,7 +199,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -203,7 +214,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -219,7 +231,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -233,7 +246,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -248,7 +262,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -262,7 +277,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -276,7 +292,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -290,7 +307,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -304,7 +322,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -318,7 +337,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -333,7 +353,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -347,7 +368,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -361,7 +383,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -375,7 +398,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -389,7 +413,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 
@@ -405,7 +430,8 @@ static const CKSizeRange kUnrestrictedSize = {};
    }
    viewAttributes:{
      {@selector(setBackgroundColor:),[UIColor clearColor]}
-   }];
+   }
+   size:{ }];
   CKSnapshotVerifyComponent(labelComponent, kFlexibleSize, @"");
 }
 

--- a/ComponentTextKitApplicationTests/CKTextComponentTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextComponentTests.mm
@@ -72,7 +72,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -89,7 +90,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -110,7 +112,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -126,7 +129,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -143,7 +147,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -161,7 +166,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -183,7 +189,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -206,7 +213,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -229,7 +237,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -257,7 +266,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -277,7 +287,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -295,7 +306,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -315,7 +327,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -335,7 +348,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kStrictSize, @"");
 }
 
@@ -354,7 +368,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -379,7 +394,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kFlexibleSize, @"");
 }
 
@@ -399,7 +415,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kUnrestrictedSize, @"");
 }
 
@@ -422,7 +439,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kUnrestrictedSize, @"");
 }
 
@@ -448,7 +466,8 @@ static NSLayoutManager *testLayoutManagerFactory(void) {
    viewAttributes:{
      {{@selector(setBackgroundColor:), [UIColor clearColor]}}
    }
-   accessibilityContext:{ }];
+   accessibilityContext:{ }
+   size:{ }];
   CKSnapshotVerifyComponent(c, kUnrestrictedSize, @"");
 }
 

--- a/Examples/WildeGuess/WildeGuess/Components/FrostedQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/FrostedQuoteComponent.mm
@@ -40,7 +40,8 @@
                   viewAttributes:{
                     {@selector(setBackgroundColor:), [UIColor clearColor]},
                     {@selector(setUserInteractionEnabled:), @NO},
-                  }],
+                  }
+                  size:{ }],
                  .alignSelf = CKStackLayoutAlignSelfCenter
                },
                {
@@ -57,7 +58,8 @@
                    viewAttributes:{
                      {@selector(setBackgroundColor:), [UIColor clearColor]},
                      {@selector(setUserInteractionEnabled:), @NO},
-                   }]],
+                   }
+                   size:{ }]],
                  .alignSelf = CKStackLayoutAlignSelfEnd, // Right aligned
                }
              }]]]];

--- a/Examples/WildeGuess/WildeGuess/Components/MonochromeQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/MonochromeQuoteComponent.mm
@@ -31,7 +31,8 @@
     viewAttributes:{
       {@selector(setBackgroundColor:), [UIColor clearColor]},
       {@selector(setUserInteractionEnabled:), @NO},
-    }]];
+    }
+    size:{ }]];
 
   CKComponent *quoteTextWithBookmarkComponent =
   [CKStackLayoutComponent

--- a/Examples/WildeGuess/WildeGuess/Components/SombreQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/SombreQuoteComponent.mm
@@ -40,7 +40,8 @@
                  viewAttributes:{
                    {@selector(setBackgroundColor:), [UIColor clearColor]},
                    {@selector(setUserInteractionEnabled:), @NO},
-                 }]},
+                 }
+                 size:{ }]},
                {lineComponent()},
              }]]]];;
 }

--- a/Examples/WildeGuess/WildeGuess/Components/SuccessIndicatorComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/SuccessIndicatorComponent.mm
@@ -54,7 +54,8 @@
                     viewAttributes:{
                       {@selector(setBackgroundColor:), [UIColor clearColor]},
                       {@selector(setUserInteractionEnabled:), @NO},
-                    }]
+                    }
+                    size:{ }]
                  },
                  {[CKLabelComponent
                    newWithLabelAttributes:{
@@ -66,7 +67,8 @@
                    viewAttributes:{
                      {@selector(setBackgroundColor:), [UIColor clearColor]},
                      {@selector(setUserInteractionEnabled:), @NO},
-                   }],
+                   }
+                   size:{ }],
                    .spacingBefore = 20
                  }
                }]]

--- a/Examples/WildeGuess/WildeGuess/Components/WarmQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/WarmQuoteComponent.mm
@@ -38,7 +38,8 @@
               viewAttributes:{
                 {@selector(setBackgroundColor:), [UIColor clearColor]},
                 {@selector(setUserInteractionEnabled:), @NO},
-              }]]]]];
+              }
+              size:{ }]]]]];
 
 }
 


### PR DESCRIPTION
In response to #444, I added new constructors instead of replacing the old ones for backward compatibility. Please take a look @ocrickard 