### PR TITLE
[ComponentKit] Fix animation leaks

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -215,20 +215,26 @@ static void applyChangesetToCollectionView(const Output::Changeset &changeset, U
       case CKArrayControllerChangeTypeUpdate:
         [itemUpdateIndexPaths addObject:change.sourceIndexPath.toNSIndexPath()];
         break;
+      case CKArrayControllerChangeTypeMove:
+        [collectionView moveItemAtIndexPath:change.sourceIndexPath.toNSIndexPath() toIndexPath:change.destinationIndexPath.toNSIndexPath()];
+        break;
       default:
         CKCFailAssert(@"Unsupported change type for items: %d", type);
         break;
     }
   };
   
-  Sections::Enumerator sectionsEnumerator = ^(NSIndexSet *sectionIndexes, CKArrayControllerChangeType type, BOOL *stop) {
-    if (sectionIndexes.count > 0) {
+  Sections::Enumerator sectionsEnumerator = ^(NSIndexSet *sourceIndexes, NSIndexSet *destinationIndexes, CKArrayControllerChangeType type, BOOL *stop) {
+    if (sourceIndexes.count > 0 || destinationIndexes.count > 0) {
       switch (type) {
         case CKArrayControllerChangeTypeDelete:
-          [collectionView deleteSections:sectionIndexes];
+          [collectionView deleteSections:sourceIndexes];
           break;
         case CKArrayControllerChangeTypeInsert:
-          [collectionView insertSections:sectionIndexes];
+          [collectionView insertSections:destinationIndexes];
+          break;
+        case CKArrayControllerChangeTypeMove:
+          [collectionView moveSection:sourceIndexes.firstIndex toSection:destinationIndexes.firstIndex];
           break;
         default:
           CKCFailAssert(@"Unsuported change type for sections %d", type);

--- a/ComponentKit/DataSources/Common/CKComponentPreparationQueue.mm
+++ b/ComponentKit/DataSources/Common/CKComponentPreparationQueue.mm
@@ -248,7 +248,8 @@
   if (![inputItem isPassthrough]) {
     CKArrayControllerChangeType changeType = [inputItem changeType];
     if (changeType == CKArrayControllerChangeTypeInsert ||
-        changeType == CKArrayControllerChangeTypeUpdate) {
+        changeType == CKArrayControllerChangeTypeUpdate ||
+        changeType == CKArrayControllerChangeTypeMove) {
       
       // Grab the lifecycle manager and use it to generate an layout the component tree
       CKComponentLifecycleManager *lifecycleManager = [inputItem lifecycleManager];

--- a/ComponentKitTests/CKComponentDataSourceTestDelegate.mm
+++ b/ComponentKitTests/CKComponentDataSourceTestDelegate.mm
@@ -65,7 +65,7 @@ using namespace CK::ArrayController;
   const auto &changeset = changesetApplicator();
 
   Sections::Enumerator sectionsEnumerator =
-  ^(NSIndexSet *indexes, CKArrayControllerChangeType type, BOOL *stop) {};
+  ^(NSIndexSet *sourceIndexes, NSIndexSet *destinationIndexes, CKArrayControllerChangeType type, BOOL *stop) {};
 
   Output::Items::Enumerator itemsEnumerator =
   ^(const Output::Change &change, CKArrayControllerChangeType type, BOOL *stop) {

--- a/ComponentKitTests/CKSectionedArrayControllerTests.mm
+++ b/ComponentKitTests/CKSectionedArrayControllerTests.mm
@@ -420,6 +420,72 @@ using namespace CK::ArrayController;
 
 @end
 
+@interface CKSectionedArrayControllerMoveTests : XCTestCase
+@end
+
+@implementation CKSectionedArrayControllerMoveTests
+{
+  CKSectionedArrayController *_controller;
+}
+
+- (void)setUp
+{
+  [super setUp];
+  _controller = [[CKSectionedArrayController alloc] init];
+
+  Sections sections;
+  sections.insert(0);
+  sections.insert(1);
+
+  Input::Items items;
+  items.insert({0, 0}, @0);
+  items.insert({0, 1}, @1);
+
+  (void)[_controller applyChangeset:{sections, items}];
+}
+
+- (void)tearDown
+{
+  _controller = nil;
+  [super tearDown];
+}
+
+- (void)testMoveOfSection
+{
+  Sections sections;
+  sections.move(0, 1);
+
+  auto output = [_controller applyChangeset:{sections, {}}];
+
+  XCTAssertEqual([_controller numberOfObjectsInSection:0], 0, @"");
+  XCTAssertEqual([_controller numberOfObjectsInSection:1], 2, @"");
+
+  Sections expectedSections;
+  expectedSections.move(0, 1);
+  Output::Changeset expected = {expectedSections, {}};
+
+  XCTAssertTrue(output == expected, @"");
+}
+
+- (void)testMoveOfItem
+{
+  Input::Items items;
+  items.move({0, 0}, {0, 1});
+
+  auto output = [_controller applyChangeset:{{}, items}];
+
+  XCTAssertEqual([_controller numberOfObjectsInSection:0], 2, @"");
+  XCTAssertEqual([_controller objectAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:0]], @0, @"");
+
+  Output::Items expectedItems;
+  expectedItems.move({0, 0}, {0, 1}, @0);
+  Output::Changeset expected = {{}, expectedItems};
+
+  XCTAssertTrue(output == expected, @"");
+}
+
+@end
+
 @interface CKSectionedArrayControllerEnumerationTest : XCTestCase
 @end
 


### PR DESCRIPTION
Retaining animations on CKComponentController causes a reference cycle:
the component is retained by the animation, which is retained by the
controller, which is retained by the scope handle, which is retained by
the component.

The cycle gets broken when the component is unmounted, but that happens
too late in some cases. This change makes the cycle get broken when the
animation finishes.