### PR TITLE
Fix flash in CKNetworkImageComponent when defaultImage is different.

### DIFF
--- a/ComponentKit/Components/CKNetworkImageComponent.mm
+++ b/ComponentKit/Components/CKNetworkImageComponent.mm
@@ -125,6 +125,12 @@
   if (CKObjectIsEqual(specifier, _specifier)) {
     return;
   }
+  
+  BOOL isShowingCurrentImageURL = self.image != _specifier.defaultImage && self.image != nil;
+  if (isShowingCurrentImageURL && CKObjectIsEqual(_specifier.url, specifier.url)) {
+    _specifier = specifier;
+    return;
+  }
 
   if (_download) {
     [_specifier.imageDownloader cancelImageDownload:_download];

--- a/ComponentKit/Components/CKNetworkImageComponent.mm
+++ b/ComponentKit/Components/CKNetworkImageComponent.mm
@@ -127,24 +127,24 @@
     return;
   }
 
-  BOOL urlIsDifferent = !CKObjectIsEqual(_specifier.url, specifier.url);
-  BOOL cropRectIsDifferent = !CGRectEqualToRect(_specifier.cropRect, specifier.cropRect);
-
-  _specifier = specifier;
-
-  if (cropRectIsDifferent) {
+  if (!CGRectEqualToRect(_specifier.cropRect, specifier.cropRect)) {
     [self setNeedsLayout];
   }
 
-  if (urlIsDifferent || CKObjectIsEqual(self.image, _specifier.defaultImage)) {
-    self.image = _specifier.defaultImage;
+  BOOL urlIsDifferent = !CKObjectIsEqual(_specifier.url, specifier.url);
+  BOOL isShowingCurrentDefaultImage = CKObjectIsEqual(self.image, _specifier.defaultImage);
+  if (urlIsDifferent || isShowingCurrentDefaultImage) {
+    self.image = specifier.defaultImage;
   }
 
+  if (urlIsDifferent && _download != nil) {
+    [specifier.imageDownloader cancelImageDownload:_download];
+    _download = nil;
+  }
+
+  _specifier = specifier;
+
   if (urlIsDifferent) {
-    if (_download != nil) {
-      [_specifier.imageDownloader cancelImageDownload:_download];
-      _download = nil;
-    }
     [self _startDownloadIfNotInReusePool];
   }
 }


### PR DESCRIPTION
This is the 2nd attempt to fix this. This one is respecting cropRect and is only doing the necessary steps in setSpecifier based on what fields changed in the specifier. 