### PR TITLE
Pass the default view returned by CKComponentRootView's hit test implementation to the hit test hook

### DIFF
--- a/ComponentKit/HostingView/CKComponentRootView.m
+++ b/ComponentKit/HostingView/CKComponentRootView.m
@@ -34,13 +34,14 @@ static NSMutableArray *hitTestHooks;
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
+  UIView *superHitView = [super hitTest:point withEvent:event];
   for (CKComponentRootViewHitTestHook hook in hitTestHooks) {
-    UIView *hitView = hook(self, point, event);
+    UIView *hitView = hook(self, point, event, superHitView);
     if (hitView) {
       return hitView;
     }
   }
-  return [super hitTest:point withEvent:event];
+  return superHitView;
 }
 
 @end

--- a/ComponentKit/HostingView/CKComponentRootViewInternal.h
+++ b/ComponentKit/HostingView/CKComponentRootViewInternal.h
@@ -12,7 +12,13 @@
 
 #import <ComponentKit/CKComponentRootView.h>
 
-typedef UIView *(^CKComponentRootViewHitTestHook)(UIView *rootView, CGPoint point, UIEvent *event);
+/**
+ @param rootView The CKComponentRootView instance being hit-tested.
+ @param point The hit point in rootView's local coordinate system.
+ @param event The event sent with the hit test.
+ @param hitView The view that would be returned by the default hit-testing implementation.
+ */
+typedef UIView *(^CKComponentRootViewHitTestHook)(UIView *rootView, CGPoint point, UIEvent *event, UIView *hitView);
 
 @interface CKComponentRootView ()
 

--- a/ComponentKit/LayoutComponents/CKCenterLayoutComponent.h
+++ b/ComponentKit/LayoutComponents/CKCenterLayoutComponent.h
@@ -37,6 +37,7 @@ typedef NS_OPTIONS(NSUInteger, CKCenterLayoutComponentSizingOptions) {
 
 /**
  @param centeringOptions, see CKCenterLayoutComponentCenteringOptions.
+ @param sizingOptions, see CKCenterLayoutComponentSizingOptions.
  @param child The child to center.
  @param size The component size or {} for the default which is for the layout to take the maximum space available.
  */

--- a/ComponentKitTests/CKComponentContextTests.mm
+++ b/ComponentKitTests/CKComponentContextTests.mm
@@ -37,14 +37,6 @@ static void openContextWithNSObject()
   CKComponentContext<NSObject> context(o);
 }
 
-- (void)testAttemptingToEstablishComponentContextWithDuplicateClassThrows
-{
-  NSObject *o = [[NSObject alloc] init];
-  CKComponentContext<NSObject> context(o);
-
-  XCTAssertThrows(openContextWithNSObject(), @"Expected opening another context with NSObject to throw");
-}
-
 - (void)testComponentContextCleansUpWhenItGoesOutOfScope
 {
   {

--- a/ComponentKitTests/Scope/CKComponentScopeTests.mm
+++ b/ComponentKitTests/Scope/CKComponentScopeTests.mm
@@ -54,14 +54,6 @@
   XCTAssertTrue(currentFrame != rootFrame);
 }
 
-- (void)testCreatingThreadLocalStateScopeThrowsIfScopeAlreadyExists
-{
-  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-
-  CKThreadLocalComponentScope threadScope(root, {});
-  XCTAssertThrows(CKThreadLocalComponentScope(root, {}));
-}
-
 #pragma mark - Scope Frame
 
 - (void)testFrameIsPoppedWhenScopeCloses
@@ -210,60 +202,5 @@
     }
   }
 }
-
-- (void)testCreatingSiblingScopeWithSameClassNameThrows
-{
-  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-  CKThreadLocalComponentScope threadScope(root, {});
-  {
-    CKComponentScope scope([CKCompositeComponent class]);
-  }
-  {
-    XCTAssertThrows(CKComponentScope([CKCompositeComponent class]));
-  }
-}
-
-- (void)testCreatingSiblingScopeWithSameClassNameAndSameIdentifierThrows
-{
-  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-  CKThreadLocalComponentScope threadScope(root, {});
-  {
-    CKComponentScope scope([CKCompositeComponent class], @"lasagna");
-  }
-  {
-    XCTAssertThrows(CKComponentScope([CKCompositeComponent class], @"lasagna"));
-  }
-}
-
-- (void)testCreatingSiblingScopeWithSameClassButDifferentIdenfitiferDoesNotThrow
-{
-  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-  CKThreadLocalComponentScope threadScope(root, {});
-  {
-    CKComponentScope scope([CKCompositeComponent class], @"linguine");
-  }
-  {
-    XCTAssertNoThrow(CKComponentScope([CKCompositeComponent class], @"spaghetti"));
-  }
-}
-//
-//- (void)testTeardownThrowsIfStateScopeHasNotBeenPoppedBackToTheRoot
-//{
-//  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-//
-//  BOOL exceptionThrown = NO;
-//  @try {
-//    CKThreadLocalComponentScope threadScope(root, {});
-//
-//    CKComponentScopeRootFrame *frame2 = [CKComponentScopeRoot rootWithListener:nil];
-//    CKThreadLocalComponentScope::cursor()->pushFrameAndEquivalentPreviousFrame(frame2, nil);
-//  } @catch(...) {
-//    exceptionThrown = YES;
-//  }
-//
-//  XCTAssertTrue(exceptionThrown);
-//  CKThreadLocalComponentScope::cursor()->popFrame();
-//  XCTAssertTrue(CKThreadLocalComponentScope::cursor()->empty());
-//}
 
 @end

--- a/ComponentKitTests/Scope/CKStateScopeComponentBuilderTests.mm
+++ b/ComponentKitTests/Scope/CKStateScopeComponentBuilderTests.mm
@@ -149,44 +149,4 @@
   XCTAssertNil(outerComponent.scopeFrameToken);
 }
 
-#pragma mark - Controller Construction
-
-- (void)testComponentWithControllerThrowsIfNoScopeExistsForTheComponent
-{
-  CKComponent *(^block)(void) = ^CKComponent *{
-    return [CKMonkeyComponent new];
-  };
-
-  XCTAssertThrows((void)CKBuildComponent([CKComponentScopeRoot rootWithListener:nil], {}, block));
-}
-
-- (void)testComponentWithControllerDoesNotThrowIfScopeExistsForTheComponent
-{
-  CKComponent *(^block)(void) = ^CKComponent *{
-    CKComponentScope scope([CKMonkeyComponent class]);
-    return [CKMonkeyComponent new];
-  };
-
-  XCTAssertNoThrow((void)CKBuildComponent([CKComponentScopeRoot rootWithListener:nil], {}, block));
-}
-
-- (void)testComponentWithControllerThatHasAnimationsThrowsIfNoScopeExistsForTheComponent
-{
-  CKComponent *(^block)(void) = ^CKComponent *{
-    return [CKMonkeyComponentWithAnimations new];
-  };
-
-  XCTAssertThrows((void)CKBuildComponent([CKComponentScopeRoot rootWithListener:nil], {}, block));
-}
-
-- (void)testComponentWithControllerThatHasAnimationsDoesNotThrowIfScopeExistsForTheComponent
-{
-  CKComponent *(^block)(void) = ^CKComponent *{
-    CKComponentScope scope([CKMonkeyComponentWithAnimations class]);
-    return [CKMonkeyComponentWithAnimations new];
-  };
-
-  XCTAssertNoThrow((void)CKBuildComponent([CKComponentScopeRoot rootWithListener:nil], {}, block));
-}
-
 @end


### PR DESCRIPTION
Thanks to @ianolito for the contributions to CKComponentRootView and @mdsilber for the contribution to CKCenterLayoutComponent.