### PR TITLE
Create willDealloc CKComponentController lifecycle method

### DIFF
--- a/ComponentKit/Core/CKComponentController.h
+++ b/ComponentKit/Core/CKComponentController.h
@@ -39,6 +39,9 @@
 /** The controller's component was previously mounted, but now it no longer is. */
 - (void)didUnmount NS_REQUIRES_SUPER;
 
+/** The controller is about to reach the end of it's lifecycle. */
+- (void)willDealloc NS_REQUIRES_SUPER;
+
 /** If the controller's component is changing, invoked immediately before the updated component is mounted. */
 - (void)willUpdateComponent NS_REQUIRES_SUPER;
 

--- a/ComponentKit/Core/CKComponentController.mm
+++ b/ComponentKit/Core/CKComponentController.mm
@@ -82,6 +82,7 @@ static void eraseAnimation(CKAppliedComponentAnimationMap &map, CKComponentAnima
 - (void)didRemount {}
 - (void)willUnmount {}
 - (void)didUnmount {}
+- (void)willDealloc {}
 - (void)willUpdateComponent {}
 - (void)didUpdateComponent {}
 - (void)componentWillRelinquishView {}

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -77,6 +77,17 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
       dispatch_async(dispatch_get_main_queue(), unmountBlock);
     }
   }
+  
+  // Send the willDealloc event to all controllers that implement the lifecycle's root scope
+  if (_previousRoot) {
+    CKComponentScopeRoot *scope = _previousRoot;
+    dispatch_block_t willDeallocBlock = ^{ [scope announceEventToControllers:CKComponentAnnouncedEventControllerWillDealloc]; };
+    if ([NSThread isMainThread]) {
+      willDeallocBlock();
+    } else {
+      dispatch_async(dispatch_get_main_queue(), willDeallocBlock);
+    }
+  }
 }
 
 #pragma mark - Updates

--- a/ComponentKit/Core/Scope/CKComponentScopeRoot.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeRoot.h
@@ -21,6 +21,7 @@
 typedef NS_ENUM(NSUInteger, CKComponentAnnouncedEvent) {
   CKComponentAnnouncedEventTreeWillAppear,
   CKComponentAnnouncedEventTreeDidDisappear,
+  CKComponentAnnouncedEventControllerWillDealloc
 };
 
 @protocol CKComponentStateListener <NSObject>

--- a/ComponentKit/Core/Scope/CKComponentScopeRoot.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeRoot.mm
@@ -27,6 +27,7 @@ static const CKAnounceableEventMap &announceableEvents()
   static const CKAnounceableEventMap *announceableEvents = new CKAnounceableEventMap({
     {CKComponentAnnouncedEventTreeWillAppear, @selector(componentTreeWillAppear)},
     {CKComponentAnnouncedEventTreeDidDisappear, @selector(componentTreeDidDisappear)},
+    {CKComponentAnnouncedEventControllerWillDealloc, @selector(willDealloc)},
   });
   return *announceableEvents;
 }


### PR DESCRIPTION
Similar to #429, I have a case where a component's controller is managing a timer. 

This PR, introduces a new api, willDealloc, on `CKComponentController`. 

The `CKComponentScopeRoot` implementation lead me to believe that a component's controller's lifecycle ends when the scope root is release. Therefore, my approach was to trigger `willDealloc`, on the main thread,  just before the `CKComponentLifecycleManager` destroys the root scope.

TODO: Document willDealloc in API and Getting Started guide (should this PR get merged)