### PR TITLE
Add "remove all" support

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -13,7 +13,8 @@
 		18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */; };
 		31EBF255C3C6127E5A3619D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */; };
-		497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */; settings = {ASSET_TAGS = (); }; };
+		491B4D931C4FD78000842FDD /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 491B4D921C4FD78000842FDD /* CKCollectionViewTransactionalDataSourceTests.mm */; };
+		497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm */; };
 		83EBF589FB5C5611BC1A2D13 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8D95429A0D918C06B66E5F /* libPods.a */; };
 		991DE3411B3B308900AA05B2 /* CKComponentMemoizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */; };
 		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
@@ -99,7 +100,8 @@
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
 		39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDataSourceAttachControllerTests.mm; sourceTree = "<group>"; };
-		497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceTests.mm; sourceTree = "<group>"; };
+		491B4D921C4FD78000842FDD /* CKCollectionViewTransactionalDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceTests.mm; sourceTree = "<group>"; };
+		497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm; sourceTree = "<group>"; };
 		71F5A01FFD736AB56CFCFD58 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentMemoizerTests.mm; sourceTree = "<group>"; };
 		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
@@ -270,7 +272,8 @@
 				A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */,
 				A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */,
 				A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */,
-				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */,
+				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm */,
+				491B4D921C4FD78000842FDD /* CKCollectionViewTransactionalDataSourceTests.mm */,
 			);
 			path = TransactionalDataSource;
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 				A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */,
 				B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */,
 				B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */,
+				491B4D931C4FD78000842FDD /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */,
 				B342DC6F1AC23EA900ACAC53 /* CKComponentControllerTests.mm in Sources */,
 				B342DC851AC23EA900ACAC53 /* CKComponentScopeTests.mm in Sources */,
 				A2CD66321AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm in Sources */,
@@ -710,7 +714,7 @@
 				39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */,
 				B342DC741AC23EA900ACAC53 /* CKComponentHostingViewTestModel.mm in Sources */,
 				B342DC761AC23EA900ACAC53 /* CKComponentLifecycleManagerTests.mm in Sources */,
-				497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */,
+				497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm in Sources */,
 				A22FE3061AF2CF0C00EC30B8 /* CKStateExposingComponent.mm in Sources */,
 				B342DC721AC23EA900ACAC53 /* CKComponentFlexibleSizeRangeProviderTests.mm in Sources */,
 				B342DC7B1AC23EA900ACAC53 /* CKComponentSizeTests.mm in Sources */,

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
@@ -66,6 +66,14 @@
                        mode:(CKUpdateMode)mode
                    userInfo:(NSDictionary *)userInfo;
 
+/**
+ Enqueues a change set with the specified mode and userInfo that will remove all items
+ and sections, according to the current state of the component date source. This returns
+ the collection view to an "empty" state.
+ */
+- (void)removeAllWithMode:(CKUpdateMode)mode
+                 userInfo:(NSDictionary *)userInfo;
+
 @property (readonly, nonatomic, strong) UICollectionView *collectionView;
 
 @end

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -16,6 +16,7 @@
 #import "CKTransactionalComponentDataSourceItem.h"
 #import "CKTransactionalComponentDataSourceState.h"
 #import "CKTransactionalComponentDataSourceAppliedChanges.h"
+#import "CKTransactionalComponentDataSourceChangeset.h"
 #import "CKComponentRootView.h"
 #import "CKComponentLayout.h"
 #import "CKComponentDataSourceAttachController.h"
@@ -127,6 +128,28 @@ static void applyChangesToCollectionView(CKTransactionalComponentDataSourceAppli
                    userInfo:(NSDictionary *)userInfo
 {
   [_componentDataSource updateConfiguration:configuration mode:mode userInfo:userInfo];
+}
+
+#pragma mark - Remove All
+
+- (void)removeAllWithMode:(CKUpdateMode)mode
+                 userInfo:(NSDictionary *)userInfo
+{
+  NSMutableSet *indexPaths = [NSMutableSet set];
+  NSMutableIndexSet *sections = [NSMutableIndexSet indexSet];
+	[_currentState enumerateObjectsUsingBlock:^(CKTransactionalComponentDataSourceItem *_, NSIndexPath *indexPath, BOOL *stop) {
+    [indexPaths addObject:indexPath];
+    [sections addIndex:indexPath.section];
+  }];
+  CKTransactionalComponentDataSourceChangeset *changeSet =
+  [[CKTransactionalComponentDataSourceChangeset alloc]
+   initWithUpdatedItems:nil
+   removedItems:indexPaths
+   removedSections:sections
+   movedItems:nil
+   insertedSections:nil
+   insertedItems:nil];
+  [self applyChangeset:changeSet mode:mode userInfo:userInfo];
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceSupplementaryViewTests.mm
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import <UIKit/UIKit.h>
+
+#import "CKCollectionViewTransactionalDataSource.h"
+#import "CKTransactionalComponentDataSourceConfiguration.h"
+#import "CKSupplementaryViewDataSource.h"
+#import "CKSizeRange.h"
+
+@interface CKCollectionViewTransactionalDataSource () <UICollectionViewDataSource>
+@end
+
+@interface CKCollectionViewTransactionalDataSourceSupplementaryViewTests : XCTestCase
+@property (strong) CKCollectionViewTransactionalDataSource *dataSource;
+@property (strong) id mockCollectionView;
+@property (strong) id mockSupplementaryViewDataSource;
+@end
+
+@implementation CKCollectionViewTransactionalDataSourceSupplementaryViewTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.mockSupplementaryViewDataSource = [OCMockObject mockForProtocol:@protocol(CKSupplementaryViewDataSource)];
+  self.mockCollectionView = [OCMockObject niceMockForClass:[UICollectionView class]];
+
+  CKTransactionalComponentDataSourceConfiguration *config = [[CKTransactionalComponentDataSourceConfiguration alloc]
+                                                             initWithComponentProvider:nil
+                                                             context:nil
+                                                             sizeRange:CKSizeRange()];
+
+  self.dataSource = [[CKCollectionViewTransactionalDataSource alloc]
+                     initWithCollectionView:self.mockCollectionView
+                     supplementaryViewDataSource:self.mockSupplementaryViewDataSource
+                     configuration:config];
+}
+
+- (void)testSupplementaryViewDataSource
+{
+  NSIndexPath *indexPath = [NSIndexPath indexPathForItem:3 inSection:4];
+  NSString *viewKind = @"foo";
+  
+  [[self.mockSupplementaryViewDataSource expect] collectionView:self.mockCollectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+  [self.dataSource collectionView:self.mockCollectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+}
+
+@end


### PR DESCRIPTION
Hi all,

Here's one I should have thought to submit a while ago. Basically, CK is very good at inserting items, and removing individual items, but lacks any support for a one-shot *reset* or *clear all* feature. We actually need this to support a kind of "reset and refresh" functionality, and it requires a bit of external overhead in order to support this otherwise - we need access to a reliable set of already inserted item indexPaths and section indexes. Since `CKTransactionalComponentDataSourceState` already has all of this info internally, it's trivial to add.

I would perhaps have added this in a category, but it's necessary to add in the main implementation since `CKTransactionalComponentDataSourceState` is a direct ivar usage. Also unsure of threading considerations here. In any case, basically implemented with a simple test. Happy to hear feedback, of course.

Thanks!