### PR TITLE
Add CKComponentBoundsAnimation to CKCollectionViewTransactionalDataSource

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -3404,10 +3404,6 @@
 		B342DC471AC23E8200ACAC53 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = "ComponentKitTests/ComponentKitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3418,10 +3414,6 @@
 		B342DC481AC23E8200ACAC53 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = "ComponentKitTests/ComponentKitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3432,10 +3424,6 @@
 		B342DC921AC23EC300ACAC53 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = "ComponentKitApplicationTests/ComponentKitApplicationTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3447,10 +3435,6 @@
 		B342DC931AC23EC300ACAC53 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = "ComponentKitApplicationTests/ComponentKitApplicationTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -19,6 +19,7 @@
 #import "CKComponentRootView.h"
 #import "CKComponentLayout.h"
 #import "CKComponentDataSourceAttachController.h"
+#import "CKComponentBoundsAnimation+UICollectionView.h"
 
 @interface CKCollectionViewTransactionalDataSource () <
 UICollectionViewDataSource,
@@ -69,12 +70,13 @@ CKTransactionalComponentDataSourceListener
 
 static void applyChangesToCollectionView(UICollectionView *collectionView,
                                          CKComponentDataSourceAttachController *attachController,
+                                         NSMapTable<UICollectionViewCell *, CKTransactionalComponentDataSourceItem *> *cellToItemMap,
                                          CKTransactionalComponentDataSourceState *currentState,
                                          CKTransactionalComponentDataSourceAppliedChanges *changes)
 {
   [changes.updatedIndexPaths enumerateObjectsUsingBlock:^(NSIndexPath *indexPath, BOOL *stop) {
     if (CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *) [collectionView cellForItemAtIndexPath:indexPath]) {
-      attachToCell(cell, [currentState objectAtIndexPath:indexPath], attachController);
+      attachToCell(cell, [currentState objectAtIndexPath:indexPath], attachController, cellToItemMap);
     }
   }];
   [collectionView deleteItemsAtIndexPaths:[changes.removedIndexPaths allObjects]];
@@ -93,14 +95,65 @@ static void applyChangesToCollectionView(UICollectionView *collectionView,
                   didModifyPreviousState:(CKTransactionalComponentDataSourceState *)previousState
                        byApplyingChanges:(CKTransactionalComponentDataSourceAppliedChanges *)changes
 {
-  [_collectionView performBatchUpdates:^{
-    applyChangesToCollectionView(_collectionView, _attachController, [_componentDataSource state], changes);
-    // Detach all the component layouts for items being deleted
-    [self _detachComponentLayoutForRemovedItemsAtIndexPaths:[changes removedIndexPaths]
-                                                    inState:previousState];
-    // Update current state
-    _currentState = [_componentDataSource state];
-  } completion:NULL];
+  const BOOL changesIncludeNonUpdates = (changes.removedIndexPaths.count ||
+                                         changes.insertedIndexPaths.count ||
+                                         changes.movedIndexPaths.count ||
+                                         changes.insertedSections.count ||
+                                         changes.removedSections.count);
+  const BOOL changesIncludeOnlyUpdates = (changes.updatedIndexPaths.count && !changesIncludeNonUpdates);
+  
+  CKTransactionalComponentDataSourceState *state = [_componentDataSource state];
+  
+  if (changesIncludeOnlyUpdates) {
+    // We are not able to animate the updates individually, so we pick the
+    // first bounds animation with a non-zero duration.
+    CKComponentBoundsAnimation boundsAnimation = {};
+    for (NSIndexPath *indexPath in changes.updatedIndexPaths) {
+      boundsAnimation = [[state objectAtIndexPath:indexPath] boundsAnimation];
+      if (boundsAnimation.duration)
+        break;
+    }
+    
+    void (^applyUpdatedState)(CKTransactionalComponentDataSourceState *) = ^(CKTransactionalComponentDataSourceState *updatedState) {
+      [_collectionView performBatchUpdates:^{
+        _currentState = updatedState;
+      } completion:^(BOOL finished) {}];
+    };
+
+    // We only apply the bounds animation if we found one with a duration.
+    // Animating the collection view is an expensive operation and should be
+    // avoided when possible.
+    if (boundsAnimation.duration) {
+      id boundsAnimationContext = CKComponentBoundsAnimationPrepareForCollectionViewBatchUpdates(_collectionView);
+      [UIView performWithoutAnimation:^{
+        applyUpdatedState(state);
+      }];
+      CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(boundsAnimationContext, boundsAnimation);
+    } else {
+      applyUpdatedState(state);
+    }
+    
+    // Within an animation block we directly attach the updated items to
+    // their respective cells if visible.
+    CKComponentBoundsAnimationApply(boundsAnimation, ^{
+      for (NSIndexPath *indexPath in changes.updatedIndexPaths) {
+        CKTransactionalComponentDataSourceItem *item = [state objectAtIndexPath:indexPath];
+        CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *)[_collectionView cellForItemAtIndexPath:indexPath];
+        if (cell) {
+          attachToCell(cell, item, _attachController, _cellToItemMap);
+        }
+      }
+    }, nil);
+  } else if (changesIncludeNonUpdates) {
+    [_collectionView performBatchUpdates:^{
+      applyChangesToCollectionView(_collectionView, _attachController, _cellToItemMap, state, changes);
+      // Detach all the component layouts for items being deleted
+      [self _detachComponentLayoutForRemovedItemsAtIndexPaths:[changes removedIndexPaths]
+                                                      inState:previousState];
+      // Update current state
+      _currentState = state;
+    } completion:NULL];
+  }
 }
 
 - (void)_detachComponentLayoutForRemovedItemsAtIndexPaths:(NSSet *)removedIndexPaths
@@ -158,9 +211,7 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
   CKCollectionViewDataSourceCell *cell = [_collectionView dequeueReusableCellWithReuseIdentifier:kReuseIdentifier forIndexPath:indexPath];
-  CKTransactionalComponentDataSourceItem *item = [_currentState objectAtIndexPath:indexPath];
-  attachToCell(cell, item, _attachController);
-  [_cellToItemMap setObject:item forKey:cell];
+  attachToCell(cell, [_currentState objectAtIndexPath:indexPath], _attachController, _cellToItemMap);
   return cell;
 }
 
@@ -181,9 +232,11 @@ static NSString *const kReuseIdentifier = @"com.component_kit.collection_view_da
 
 static void attachToCell(CKCollectionViewDataSourceCell *cell,
                          CKTransactionalComponentDataSourceItem *item,
-                         CKComponentDataSourceAttachController *attachController)
+                         CKComponentDataSourceAttachController *attachController,
+                         NSMapTable<UICollectionViewCell *, CKTransactionalComponentDataSourceItem *> *cellToItemMap)
 {
-  [attachController attachComponentLayout:item.layout withScopeIdentifier:item.scopeRoot.globalIdentifier toView:cell.rootView];
+  [attachController attachComponentLayout:item.layout withScopeIdentifier:item.scopeRoot.globalIdentifier withBoundsAnimation:item.boundsAnimation toView:cell.rootView];
+  [cellToItemMap setObject:item forKey:cell];
 }
 
 @end

--- a/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
+++ b/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
@@ -104,6 +104,10 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
   if (animation.duration == 0) {
     return;
   }
+  // Don't animate the collection view if it is not being displayed.
+  if (!_collectionView.window) {
+    return;
+  }
   // The documentation states that you must not use these functions with inserts or deletes. Let's be safe:
   if ([_collectionView numberOfSections] != _numberOfSections) {
     return;

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.h
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.h
@@ -41,6 +41,7 @@
  */
 - (void)attachComponentLayout:(CKComponentLayout)layout
           withScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier
+          withBoundsAnimation:(CKComponentBoundsAnimation)boundsAnimation
                        toView:(UIView *)view;
 /**
  Detaching a component tree will cause it to be unmounted from the view it is currently attached to and will mark the view as available to be

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
@@ -52,6 +52,7 @@
 
 - (void)attachComponentLayout:(CKComponentLayout)layout
           withScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier
+          withBoundsAnimation:(CKComponentBoundsAnimation)boundsAnimation
                        toView:(UIView *)view
 {
   CKAssertMainThread();
@@ -67,7 +68,7 @@
   }
   
   // Mount the component tree on the view
-  CKComponentDataSourceAttachState *attachState = _mountComponentLayoutInView(layout, view, scopeIdentifier);
+  CKComponentDataSourceAttachState *attachState = _mountComponentLayoutInView(layout, view, scopeIdentifier, boundsAnimation);
   // Mark the view as attached and associates it to the right attach state
   _scopeIdentifierToAttachedViewMap[@(scopeIdentifier)] = view;
   view.ck_attachState = attachState;
@@ -101,11 +102,15 @@
 
 static CKComponentDataSourceAttachState *_mountComponentLayoutInView(CKComponentLayout layout,
                                                                      UIView *view,
-                                                                     CKComponentScopeRootIdentifier scopeIdentifier)
+                                                                     CKComponentScopeRootIdentifier scopeIdentifier,
+                                                                     CKComponentBoundsAnimation boundsAnimation)
 {
   CKCAssertNotNil(view, @"Impossible to mount a component layout on a nil view");
   NSSet *currentlyMountedComponents = view.ck_attachState.mountedComponents;
-  NSSet *newMountedComponents = CKMountComponentLayout(layout, view, currentlyMountedComponents, nil);
+  __block NSSet *newMountedComponents = nil;
+  CKComponentBoundsAnimationApply(boundsAnimation, ^{
+    newMountedComponents = CKMountComponentLayout(layout, view, currentlyMountedComponents, nil);
+  }, nil);
   return [[CKComponentDataSourceAttachState alloc] initWithScopeIdentifier:scopeIdentifier mountedComponents:newMountedComponents layout:layout];
 }
 

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.h
@@ -9,6 +9,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <ComponentKit/CKComponentBoundsAnimation.h>
 
 class CKComponentLayout;
 @class CKComponentScopeRoot;
@@ -22,5 +23,8 @@ class CKComponentLayout;
 
 /** The scope root for this item, which holds references to component controllers and state */
 @property (nonatomic, strong, readonly) CKComponentScopeRoot *scopeRoot;
+
+/** The bounds animation with which to apply the layout */
+@property (nonatomic, readonly) CKComponentBoundsAnimation boundsAnimation;
 
 @end

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.mm
@@ -23,11 +23,13 @@
 - (instancetype)initWithLayout:(const CKComponentLayout &)layout
                          model:(id)model
                      scopeRoot:(CKComponentScopeRoot *)scopeRoot
+               boundsAnimation:(CKComponentBoundsAnimation)boundsAnimation
 {
   if (self = [super init]) {
     _layout = layout;
     _model = model;
     _scopeRoot = scopeRoot;
+    _boundsAnimation = boundsAnimation;
   }
   return self;
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItemInternal.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItemInternal.h
@@ -15,6 +15,7 @@
 
 - (instancetype)initWithLayout:(const CKComponentLayout &)layout
                          model:(id)model
-                     scopeRoot:(CKComponentScopeRoot *)scopeRoot;
+                     scopeRoot:(CKComponentScopeRoot *)scopeRoot
+               boundsAnimation:(CKComponentBoundsAnimation)boundsAnimation;
 
 @end

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -64,7 +64,7 @@
     const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
 
     [section replaceObjectAtIndex:indexPath.item withObject:
-     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot]];
+     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot boundsAnimation:result.boundsAnimation]];
   }];
 
   __block std::unordered_map<NSUInteger, std::map<NSUInteger, CKTransactionalComponentDataSourceItem *>> insertedItemsBySection;
@@ -109,7 +109,7 @@
     });
     const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
     insertedItemsBySection[indexPath.section][indexPath.item] =
-    [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
+    [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot boundsAnimation:result.boundsAnimation];
   }];
 
   for (const auto &sectionIt : insertedItemsBySection) {

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -52,7 +52,8 @@
       const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
       [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                    model:[item model]
-                                                                               scopeRoot:result.scopeRoot]];
+                                                                               scopeRoot:result.scopeRoot
+                                                                         boundsAnimation:result.boundsAnimation]];
     }];
     [newSections addObject:newItems];
   }];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -58,7 +58,8 @@
         const CKComponentLayout layout = CKComputeRootComponentLayout(item.layout.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
-                                                                       scopeRoot:[item scopeRoot]];
+                                                                       scopeRoot:[item scopeRoot]
+                                                                 boundsAnimation:[item boundsAnimation]];
       } else {
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
           return [componentProvider componentForModel:[item model] context:context];
@@ -66,7 +67,8 @@
         const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
-                                                                       scopeRoot:result.scopeRoot];
+                                                                       scopeRoot:result.scopeRoot
+                                                                 boundsAnimation:result.boundsAnimation];
       }
 
       [newItems addObject:newItem];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -56,7 +56,8 @@
         const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
         [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                      model:[item model]
-                                                                                 scopeRoot:result.scopeRoot]];
+                                                                                 scopeRoot:result.scopeRoot
+                                                                           boundsAnimation:result.boundsAnimation]];
       }
     }];
     [newSections addObject:newItems];

--- a/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
@@ -36,7 +36,7 @@
   CKComponent *component = [CKComponent new];
   CKComponentScopeRootIdentifier scopeIdentifier = 0x5C09E;
 
-  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier toView:view];
+  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier withBoundsAnimation:{} toView:view];
   CKComponentDataSourceAttachState *attachState = [_attachController attachStateForScopeIdentifier:scopeIdentifier];
   XCTAssertEqualObjects(attachState.mountedComponents, [NSSet setWithObject:component]);
   XCTAssertEqual(attachState.scopeIdentifier, scopeIdentifier);
@@ -51,11 +51,11 @@
   UIView *view = [UIView new];
   CKComponent *component = [CKComponent new];
   CKComponentScopeRootIdentifier scopeIdentifier = 0x5C09E;
-  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier toView:view];
+  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier withBoundsAnimation:{} toView:view];
 
   CKComponent *component2 = [CKComponent new];
   CKComponentScopeRootIdentifier scopeIdentifier2 = 0x5C09E2;
-  [_attachController attachComponentLayout:{component2, {0, 0}} withScopeIdentifier:scopeIdentifier2 toView:view];
+  [_attachController attachComponentLayout:{component2, {0, 0}} withScopeIdentifier:scopeIdentifier2 withBoundsAnimation:{} toView:view];
 
   // the first component is now detached
   CKComponentDataSourceAttachState *attachState = [_attachController attachStateForScopeIdentifier:scopeIdentifier];

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
@@ -997,7 +997,8 @@ static CKTransactionalComponentDataSourceItem *itemWithModel(id model)
 {
   return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout()
                                                                   model:model
-                                                              scopeRoot:nil];
+                                                              scopeRoot:nil
+                                                        boundsAnimation:{}];
 }
 
 @end

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
@@ -27,7 +27,7 @@ static CKTransactionalComponentDataSourceItem *item(CKTransactionalComponentData
     return [configuration.componentProvider componentForModel:model context:configuration.context];
   });
   const CKComponentLayout layout = [result.component layoutThatFits:configuration.sizeRange parentSize:configuration.sizeRange.max];
-  return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
+  return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot boundsAnimation:result.boundsAnimation];
 }
 
 CKTransactionalComponentDataSourceState *CKTransactionalComponentDataSourceTestState(Class<CKComponentProvider> provider,

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
@@ -90,14 +90,14 @@
 
 - (void)testStateEquality
 {
-  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
+  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil boundsAnimation:{}];
   CKTransactionalComponentDataSourceConfiguration *firstConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"
                                                                            sizeRange:CKSizeRange()];
   CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[firstItem]]];
 
-  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
+  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil boundsAnimation:{}];
   CKTransactionalComponentDataSourceConfiguration *secondConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"
@@ -109,14 +109,14 @@
 
 - (void)testNonEqualStates
 {
-  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
+  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil boundsAnimation:{}];
   CKTransactionalComponentDataSourceConfiguration *firstConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"
                                                                            sizeRange:CKSizeRange()];
   CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[firstItem]]];
 
-  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model2" scopeRoot:nil];
+  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model2" scopeRoot:nil boundsAnimation:{}];
   CKTransactionalComponentDataSourceConfiguration *secondConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"


### PR DESCRIPTION
In `CKCollectionViewDataSource`, synchronous cell updates do not trigger a collection view reload and instead mount the new component layout in place and animate any size changes. I made this the default behavior for both asynchronous and synchronous updates to `CKCollectionViewTransactionalDataSource`, where the content of the changeset is only cell updates.

Calling `-[UICollectionView reloadItemsAtIndexPaths:]` causes the component to be unmounted and remounted. This is fine in some cases, but it has adverse side effects. It causes the cell to flash to its new state without animation and it also disrupts the first responder.
