### PR TITLE
Replace the mapIndex method on CKArrayControllerSections

### DIFF
--- a/ComponentKit/Utilities/CKArrayControllerChangeset.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.h
@@ -93,6 +93,10 @@ namespace CK {
                                 CKArrayControllerChangeType type,
                                 BOOL *stop);
 
+      typedef NSInteger (^Mapper)(const NSInteger sectionIndex, CKArrayControllerChangeType type);
+
+      Sections mapIndex(Mapper mapper) const;
+
     private:
       std::set<NSInteger> _insertions;
       std::set<NSInteger> _removals;

--- a/ComponentKit/Utilities/CKArrayControllerChangeset.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangeset.mm
@@ -69,6 +69,24 @@ size_t Sections::size() const noexcept
   return _insertions.size() + _removals.size() + _moves.size();
 }
 
+Sections Sections::mapIndex(Sections::Mapper mapper) const
+{
+  __block Sections mappedSections = {};
+  void (^map)(std::set<NSInteger>, CKArrayControllerChangeType) = ^(std::set<NSInteger> indexes, CKArrayControllerChangeType type) {
+    for (auto index : indexes) {
+      NSInteger newIndex = mapper(index, type);
+      if (type == CKArrayControllerChangeTypeInsert) {
+        mappedSections.insert(newIndex);
+      } else if (type == CKArrayControllerChangeTypeDelete) {
+        mappedSections.remove(newIndex);
+      }
+    }
+  };
+  map(_insertions, CKArrayControllerChangeTypeInsert);
+  map(_removals, CKArrayControllerChangeTypeDelete);
+  return mappedSections;
+}
+
 /**
  Updates and removals operate in the same index path space, but insertions operate post-application of updates and
  removals. Therefore insertions index paths can alse appear in the commands for removals and updates and vice versa,


### PR DESCRIPTION
The `mapIndex` method is public and may still be used. Let's add it back for now.

I'm not quite familiar with the reasoning behind removing it in the first place. We should make sure that it isn't incompatible with the changes introduced in #414.