### PR TITLE
Add CKComponentAnimation on layer at key path

### DIFF
--- a/ComponentKit/Core/CKComponentAnimation.h
+++ b/ComponentKit/Core/CKComponentAnimation.h
@@ -18,15 +18,27 @@
 struct CKComponentAnimation {
 
   /**
-   Creates a CKComponentAnimation that applies a CAAnimation to a CKComponent.
-
+   Creates a CKComponentAnimation that applies a CAAnimation to a CKComponent on the layer found at layerPath.
+   
    @note The CKComponent must create a UIView via its view configuration; or, it must be a CKCompositeComponent that
-   renders to a component that creates a view.
-
+   renders to a component that creates a view. The view must have a CALayer at the keypath that corresponds to 
+   layerPath.
+   
+   @example Suppose the component has a CAShapeLayer as the mask of the view's layer. The path of the mask could be animated
+   with: {myComponent, [CABasicAnimation animationWithKeypath:@"path"], "layer.mask"}
+   */
+  CKComponentAnimation(CKComponent* component, CAAnimation* animation, NSString* layerPath);
+  
+  /**
+   Creates a CKComponentAnimation that applies a CAAnimation to a CKComponent on the layer of the view.
+   
    @example {myComponent, [CABasicAnimation animationWithKeypath:@"position"]}
+   
+   @see CKComponentAnimation(CKComponent* component, CAAnimation* animation, NSString* layerPath)
    */
   CKComponentAnimation(CKComponent *component, CAAnimation *animation);
 
+  
   /** Creates a completely custom animation with arbitrary hooks. */
   CKComponentAnimation(const CKComponentAnimationHooks &hooks);
 

--- a/ComponentKit/Core/CKComponentAnimation.h
+++ b/ComponentKit/Core/CKComponentAnimation.h
@@ -18,26 +18,23 @@
 struct CKComponentAnimation {
 
   /**
-   Creates a CKComponentAnimation that applies a CAAnimation to a CKComponent on the layer found at layerPath.
+   Creates a CKComponentAnimation that applies a CAAnimation to a CKComponent, on the layer found at layerPath. The
+   layer of the view is used when layerPath is nil.
    
    @note The CKComponent must create a UIView via its view configuration; or, it must be a CKCompositeComponent that
-   renders to a component that creates a view. The view must have a CALayer at the keypath that corresponds to 
-   layerPath.
-   
-   @example Suppose the component has a CAShapeLayer as the mask of the view's layer. The path of the mask could be animated
-   with: {myComponent, [CABasicAnimation animationWithKeypath:@"path"], "layer.mask"}
-   */
-  CKComponentAnimation(CKComponent* component, CAAnimation* animation, NSString* layerPath);
-  
-  /**
-   Creates a CKComponentAnimation that applies a CAAnimation to a CKComponent on the layer of the view.
-   
-   @example {myComponent, [CABasicAnimation animationWithKeypath:@"position"]}
-   
-   @see CKComponentAnimation(CKComponent* component, CAAnimation* animation, NSString* layerPath)
-   */
-  CKComponentAnimation(CKComponent *component, CAAnimation *animation);
+   renders to a component that creates a view. The view must have a CALayer at the keypath that corresponds to
+   layerPath; or, it must be nil.
 
+   @example Animate the position of a component: {myComponent, [CABasicAnimation animationWithKeypath:@"position"]}
+   
+   @example Suppose the component has a CAShapeLayer as the mask of the view's layer. The path of the mask could be
+   animated with: {myComponent, [CABasicAnimation animationWithKeypath:@"path"], "layer.mask"}
+   
+   @param component A CKComponent that will be animated.
+   @param animation A CAAnimation to apply on the component's layer.
+   @param layerPath A key path to a sublayer of the component's view. Defaults to nil.
+   */
+  CKComponentAnimation(CKComponent *component, CAAnimation *animation, NSString *layerPath = nil);
   
   /** Creates a completely custom animation with arbitrary hooks. */
   CKComponentAnimation(const CKComponentAnimationHooks &hooks);

--- a/ComponentKit/Core/CKComponentAnimation.mm
+++ b/ComponentKit/Core/CKComponentAnimation.mm
@@ -18,7 +18,7 @@
 @property (nonatomic, copy, readonly) NSString *key;
 @end
 
-static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation)
+static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation, NSString *layerPath = @"layer")
 {
   CKCAssertNotNil(component, @"Component being animated must be non-nil");
   CKCAssertNotNil(originalAnimation, @"Animation being added must be non-nil");
@@ -28,8 +28,8 @@ static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAA
   CAAnimation *copiedAnimation = [originalAnimation copy];
   return {
     .didRemount = ^(id context){
-      CALayer *layer = component.viewForAnimation.layer;
-      CKCAssertNotNil(layer, @"%@ has no mounted view, so it cannot be animated", [component class]);
+      CALayer *layer = [component.viewForAnimation valueForKeyPath:layerPath];
+      CKCAssertNotNil(layer, @"%@ has no mounted view or layer at key path %@, so it cannot be animated", [component class], layerPath);
       NSString *key = [[NSUUID UUID] UUIDString];
 
       // CAMediaTiming beginTime is specified in the time space of the superlayer. Since the component has no way to
@@ -48,7 +48,14 @@ static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAA
 }
 
 CKComponentAnimation::CKComponentAnimation(CKComponent *component, CAAnimation *animation)
-: hooks(hooksForCAAnimation(component, animation)) {}
+: hooks(hooksForCAAnimation(component, animation))
+{
+}
+
+CKComponentAnimation::CKComponentAnimation(CKComponent* component, CAAnimation* animation, NSString* layerPath)
+: hooks(hooksForCAAnimation(component, animation, layerPath))
+{
+}
 
 CKComponentAnimation::CKComponentAnimation(const CKComponentAnimationHooks &h) : hooks(h) {}
 

--- a/ComponentKit/Core/CKComponentAnimation.mm
+++ b/ComponentKit/Core/CKComponentAnimation.mm
@@ -18,7 +18,7 @@
 @property (nonatomic, copy, readonly) NSString *key;
 @end
 
-static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation, NSString *layerPath = @"layer")
+static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation, NSString *layerPath)
 {
   CKCAssertNotNil(component, @"Component being animated must be non-nil");
   CKCAssertNotNil(originalAnimation, @"Animation being added must be non-nil");
@@ -28,8 +28,8 @@ static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAA
   CAAnimation *copiedAnimation = [originalAnimation copy];
   return {
     .didRemount = ^(id context){
-      CALayer *layer = [component.viewForAnimation valueForKeyPath:layerPath];
-      CKCAssertNotNil(layer, @"%@ has no mounted view or layer at key path %@, so it cannot be animated", [component class], layerPath);
+      CALayer *layer = layerPath ? [component.viewForAnimation valueForKeyPath:layerPath] : component.viewForAnimation.layer;
+      CKCAssertNotNil(layer, @"%@ has no mounted layer at key path %@, so it cannot be animated", [component class], layerPath);
       NSString *key = [[NSUUID UUID] UUIDString];
 
       // CAMediaTiming beginTime is specified in the time space of the superlayer. Since the component has no way to
@@ -47,15 +47,8 @@ static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAA
   };
 }
 
-CKComponentAnimation::CKComponentAnimation(CKComponent *component, CAAnimation *animation)
-: hooks(hooksForCAAnimation(component, animation))
-{
-}
-
-CKComponentAnimation::CKComponentAnimation(CKComponent* component, CAAnimation* animation, NSString* layerPath)
-: hooks(hooksForCAAnimation(component, animation, layerPath))
-{
-}
+CKComponentAnimation::CKComponentAnimation(CKComponent *component, CAAnimation *animation, NSString *layerPath)
+: hooks(hooksForCAAnimation(component, animation, layerPath)) {}
 
 CKComponentAnimation::CKComponentAnimation(const CKComponentAnimationHooks &h) : hooks(h) {}
 


### PR DESCRIPTION
Add convenience `CKComponentAnimation` initialization method for animating the `CALayer` at a specific key path.

Right now, animations are performed on the component's view's layer. Often I use a `UIView` subclass when design requires a view with multiple layers. Animating these layers requires dropping down to a custom `CKComponentAnimationHooks`. This PR abstracts `hooksForCAAnimation` for flexibility. 

Example: A view's layer has a CAShapeLayer as the mask. The path of the mask needs be animated on initial mount. We can now achieve this with:
```Objective-C++
- (std::vector<CKComponentAnimation>)animationsOnInitialMount
{
    return { {self, [CABasicAnimation animationWithKeypath:@"path"], "layer.mask"} };
}
```
