### PR TITLE
Fixing UITableview's demo code

### DIFF
--- a/_docs/20-datasource-dive-deeper.md
+++ b/_docs/20-datasource-dive-deeper.md
@@ -193,7 +193,7 @@ static void applyChangesetToTableView(const CKArrayControllerOutputChangeset &ch
 
   CKArrayControllerOutputItems::Enumerator itemEnumerator =
   ^(const CKArrayControllerOutputChange &change, CKArrayControllerChangeType type, BOOL *stop) {
-    NSIndexPath *indexPath = change.indexPath.toNSIndexPath();
+    NSIndexPath *indexPath = change.destinationIndexPath.toNSIndexPath();
     if (type == CKArrayControllerChangeTypeDelete) {
       [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationFade];
     }


### PR DESCRIPTION
It seem like the CKArrayControllerOutputChange API has changed. The [UITableView's demo](http://componentkit.org/docs/datasource-dive-deeper.html) doesn't compile.
