### PR TITLE
Fix pcomponents for CKTransactionalComponentDataSource

### DIFF
--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
@@ -14,12 +14,6 @@
 #import "CKComponentDataSourceAttachController.h"
 #import "CKComponentDataSourceAttachControllerInternal.h"
 
-@interface UIView(CKComponentDataSourceAttachController)
-
-@property (nonatomic, strong, setter=ck_setAttachState:) CKComponentDataSourceAttachState *ck_attachState;
-
-@end
-
 @implementation CKComponentDataSourceAttachController
 {
   /**
@@ -112,7 +106,7 @@ static CKComponentDataSourceAttachState *_mountComponentLayoutInView(CKComponent
   CKCAssertNotNil(view, @"Impossible to mount a component layout on a nil view");
   NSSet *currentlyMountedComponents = view.ck_attachState.mountedComponents;
   NSSet *newMountedComponents = CKMountComponentLayout(layout, view, currentlyMountedComponents, nil);
-  return [[CKComponentDataSourceAttachState alloc] initWithScopeIdentifier:scopeIdentifier mountedComponents:newMountedComponents];
+  return [[CKComponentDataSourceAttachState alloc] initWithScopeIdentifier:scopeIdentifier mountedComponents:newMountedComponents layout:layout];
 }
 
 static void _tearDownAttachStateFromViews(NSArray *views)
@@ -129,18 +123,27 @@ static void _tearDownAttachStateFromViews(NSArray *views)
 @end
 
 
-@implementation CKComponentDataSourceAttachState
+@implementation CKComponentDataSourceAttachState {
+  CKComponentLayout _layout;
+}
 
 - (instancetype)initWithScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier
                       mountedComponents:(NSSet *)mountedComponents
+                                 layout:(const CKComponentLayout &)layout
 {
   self = [super init];
   if (self) {
     CKAssertNotNil(mountedComponents, @"");
     _scopeIdentifier = scopeIdentifier;
     _mountedComponents = [mountedComponents copy];
+    _layout = layout;
   }
   return self;
+}
+
+- (const CKComponentLayout &)layout
+{
+  return _layout;
 }
 
 @end

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachControllerInternal.h
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachControllerInternal.h
@@ -17,11 +17,21 @@
 @property (nonatomic, readonly) CKComponentScopeRootIdentifier scopeIdentifier;
 
 - (instancetype)initWithScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier
-                      mountedComponents:(NSSet *)mountedComponents;
+                      mountedComponents:(NSSet *)mountedComponents
+                                 layout:(const CKComponentLayout &)layout;
+
+- (const CKComponentLayout &)layout;
+
 @end
 
 @interface CKComponentDataSourceAttachController ()
 
 - (CKComponentDataSourceAttachState *)attachStateForScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier;
+
+@end
+
+@interface UIView(CKComponentDataSourceAttachController)
+
+@property (nonatomic, strong, setter=ck_setAttachState:) CKComponentDataSourceAttachState *ck_attachState;
 
 @end

--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -14,6 +14,8 @@
 
 #import "CKComponent.h"
 #import "CKComponentInternal.h"
+#import "CKComponentDataSourceAttachController.h"
+#import "CKComponentDataSourceAttachControllerInternal.h"
 #import "CKComponentLifecycleManager.h"
 #import "CKComponentLifecycleManagerInternal.h"
 #import "CKComponentViewInterface.h"
@@ -244,16 +246,13 @@ static CKComponentRootView *rootViewForView(UIView *view)
   return (CKComponentRootView *)view;
 }
 
-/**
- Note: This is fragile code that is being used because ComponentKit is currently in the process of
- transitioning away from holding the root layout in CKComponentRootView. This code should be updated
- once the move away from a ck_componentLifecycleManager is done.
- */
 static const CKComponentLayout *rootLayoutFromRootView(CKComponentRootView *rootView)
 {
   const CKComponentLayout *rootLayout;
   if (rootView.ck_componentLifecycleManager) {
     rootLayout = &rootView.ck_componentLifecycleManager.state.layout;
+  } else if (rootView.ck_attachState) {
+    rootLayout = &[rootView.ck_attachState layout];
   } else if ([rootView.superview isKindOfClass:[CKComponentHostingView class]]) {
     CKComponentHostingView *hostingView = (CKComponentHostingView *)rootView.superview;
     rootLayout = &hostingView.mountedLayout;


### PR DESCRIPTION
`pcomponents` relies on being able to find the layout of the component
hierarchy from the root view. The mapping existed for the legacy data
source but doesn't exist for the transactional one.

This adds a mapping from root view to layout in the transactional data
source that can be accessed using an internal header. It also fixes up
`pcomponents` so that `pcomponents` uses this mapping.