### PR TITLE
Added inline doc size parameter, closes #471

### DIFF
--- a/ComponentTextKit/CKLabelComponent.h
+++ b/ComponentTextKit/CKLabelComponent.h
@@ -63,6 +63,7 @@ struct CKLabelAttributes
  
  @param attributes The content and styling information for the text component.
  @param viewAttributes These are passed directly to CKTextComponent and its backing view.
+ @param size The component size or {} for the default which is for the layout to take the maximum space available.
  */
 @interface CKLabelComponent : CKCompositeComponent
 


### PR DESCRIPTION
Adds the size parameter description to to inline documentation of CKLabelComponent