### PR TITLE
Clarify import source

### DIFF
--- a/ComponentKitApplicationTests/CKButtonComponentTests.mm
+++ b/ComponentKitApplicationTests/CKButtonComponentTests.mm
@@ -10,7 +10,7 @@
 
 #import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
-#import "CKButtonComponent.h"
+#import <ComponentKit/CKButtonComponent.h>
 
 @interface CKButtonComponentTests : CKComponentSnapshotTestCase
 @end

--- a/ComponentKitApplicationTests/CKCenterLayoutComponentsTests.mm
+++ b/ComponentKitApplicationTests/CKCenterLayoutComponentsTests.mm
@@ -12,9 +12,9 @@
 
 #import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
-#import "CKBackgroundLayoutComponent.h"
-#import "CKCenterLayoutComponent.h"
-#import "CKStackLayoutComponent.h"
+#import <ComponentKit/CKBackgroundLayoutComponent.h>
+#import <ComponentKit/CKCenterLayoutComponent.h>
+#import <ComponentKit/CKStackLayoutComponent.h>
 
 static const CKSizeRange kSize = {{100, 120}, {320, 160}};
 

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -13,11 +13,11 @@
 
 #import <ComponentKitTestHelpers/CKTestActionComponent.h>
 
-#import "CKComponentAction.h"
-#import "CKCompositeComponent.h"
-#import "CKComponentSubclass.h"
-#import "CKComponentInternal.h"
-#import "CKComponentLayout.h"
+#import <ComponentKit/CKComponentAction.h>
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentLayout.h>
 
 @interface CKComponentActionAttributeTests : XCTestCase
 @end

--- a/ComponentKitApplicationTests/CKComponentBoundsAnimationTests.mm
+++ b/ComponentKitApplicationTests/CKComponentBoundsAnimationTests.mm
@@ -10,12 +10,12 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponentInternal.h"
-#import "CKComponentScope.h"
-#import "CKComponentScopeFrame.h"
-#import "CKComponentScopeRoot.h"
-#import "CKComponentSubclass.h"
-#import "CKStackLayoutComponent.h"
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentScopeFrame.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKStackLayoutComponent.h>
 
 @interface CKComponentBoundsAnimationTests : XCTestCase
 @end

--- a/ComponentKitApplicationTests/CKInsetComponentTests.mm
+++ b/ComponentKitApplicationTests/CKInsetComponentTests.mm
@@ -10,10 +10,10 @@
 
 #import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
-#import "CKBackgroundLayoutComponent.h"
-#import "CKCompositeComponent.h"
-#import "CKInsetComponent.h"
-#import "CKStaticLayoutComponent.h"
+#import <ComponentKit/CKBackgroundLayoutComponent.h>
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKInsetComponent.h>
+#import <ComponentKit/CKStaticLayoutComponent.h>
 
 
 typedef NS_OPTIONS(NSUInteger, CKInsetComponentTestEdge) {

--- a/ComponentKitApplicationTests/CKNetworkImageComponentTests.mm
+++ b/ComponentKitApplicationTests/CKNetworkImageComponentTests.mm
@@ -10,7 +10,7 @@
 
 #import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
-#import "CKNetworkImageComponent.h"
+#import <ComponentKit/CKNetworkImageComponent.h>
 
 #pragma mark - Helpers
 

--- a/ComponentKitApplicationTests/CKOverlayLayoutComponentTests.mm
+++ b/ComponentKitApplicationTests/CKOverlayLayoutComponentTests.mm
@@ -10,7 +10,7 @@
 
 #import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
-#import "CKOverlayLayoutComponent.h"
+#import <ComponentKit/CKOverlayLayoutComponent.h>
 
 static const CKSizeRange kSize = {{320, 320}, {320, 320}};
 

--- a/ComponentKitApplicationTests/CKStackLayoutComponentTests.mm
+++ b/ComponentKitApplicationTests/CKStackLayoutComponentTests.mm
@@ -10,10 +10,10 @@
 
 #import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
-#import "CKComponent.h"
-#import "CKComponentSubclass.h"
-#import "CKRatioLayoutComponent.h"
-#import "CKStackLayoutComponent.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKRatioLayoutComponent.h>
+#import <ComponentKit/CKStackLayoutComponent.h>
 
 static CKComponentViewConfiguration whiteBg = {[UIView class], {{@selector(setBackgroundColor:), [UIColor whiteColor]}}};
 

--- a/ComponentKitTests/CKComponentAccessibilityTests.mm
+++ b/ComponentKitTests/CKComponentAccessibilityTests.mm
@@ -12,8 +12,8 @@
 
 #import <ComponentKit/CKComponent.h>
 
-#import "CKComponentAccessibility.h"
-#import "CKComponentAccessibility_Private.h"
+#import <ComponentKit/CKComponentAccessibility.h>
+#import <ComponentKit/CKComponentAccessibility_Private.h>
 
 using namespace CK::Component::Accessibility;
 

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -13,11 +13,11 @@
 
 #import <ComponentKitTestHelpers/CKTestActionComponent.h>
 
-#import "CKComponentAction.h"
-#import "CKCompositeComponent.h"
-#import "CKComponentSubclass.h"
-#import "CKComponentInternal.h"
-#import "CKComponentLayout.h"
+#import <ComponentKit/CKComponentAction.h>
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentLayout.h>
 
 @interface CKComponentActionTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentContextTests.mm
+++ b/ComponentKitTests/CKComponentContextTests.mm
@@ -10,7 +10,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponentContext.h"
+#import <ComponentKit/CKComponentContext.h>
 
 @interface CKComponentContextTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentControllerLifecycleMethodTests.mm
+++ b/ComponentKitTests/CKComponentControllerLifecycleMethodTests.mm
@@ -12,12 +12,12 @@
 
 #import <ComponentKitTestLib/CKComponentTestRootScope.h>
 
-#import "CKComponent.h"
-#import "CKComponentController.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentProvider.h"
-#import "CKComponentScope.h"
-#import "CKComponentSubclass.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentController.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentSubclass.h>
 
 @interface CKComponentControllerLifecycleMethodTests : XCTestCase <CKComponentProvider>
 @end

--- a/ComponentKitTests/CKComponentControllerTests.mm
+++ b/ComponentKitTests/CKComponentControllerTests.mm
@@ -12,13 +12,13 @@
 
 #import <ComponentKitTestLib/CKComponentTestRootScope.h>
 
-#import "CKComponent.h"
-#import "CKComponentController.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentProvider.h"
-#import "CKComponentScope.h"
-#import "CKComponentSubclass.h"
-#import "CKComponentViewInterface.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentController.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKComponentViewInterface.h>
 
 @interface CKComponentControllerTests : XCTestCase <CKComponentProvider>
 @end

--- a/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
@@ -11,11 +11,11 @@
 #import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
 
-#import "CKComponent.h"
-#import "CKComponentInternal.h"
-#import "CKComponentLayout.h"
-#import "CKComponentDataSourceAttachController.h"
-#import "CKComponentDataSourceAttachControllerInternal.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentDataSourceAttachController.h>
+#import <ComponentKit/CKComponentDataSourceAttachControllerInternal.h>
 
 @interface CKComponentDataSourceAttachControllerTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentDelegateAttributeTests.mm
+++ b/ComponentKitTests/CKComponentDelegateAttributeTests.mm
@@ -12,13 +12,13 @@
 
 #import <OCMock/OCMock.h>
 
-#import "CKCompositeComponent.h"
-#import "CKComponent.h"
-#import "CKComponentDelegateAttribute.h"
-#import "CKComponentViewInterface.h"
-#import "CKComponentLayout.h"
-#import "CKComponentSubclass.h"
-#import "CKComponentInternal.h"
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentDelegateAttribute.h>
+#import <ComponentKit/CKComponentViewInterface.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKComponentInternal.h>
 
 
 @interface CKDetectScrollComponent : CKCompositeComponent <UIScrollViewDelegate>

--- a/ComponentKitTests/CKComponentFlexibleSizeRangeProviderTests.mm
+++ b/ComponentKitTests/CKComponentFlexibleSizeRangeProviderTests.mm
@@ -10,7 +10,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponentFlexibleSizeRangeProvider.h"
+#import <ComponentKit/CKComponentFlexibleSizeRangeProvider.h>
 
 @interface CKComponentFlexibleSizeRangeProviderTests : XCTestCase
 

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -13,10 +13,10 @@
 
 #import <OCMock/OCMock.h>
 
-#import "CKComponent.h"
-#import "CKComponentGestureActions.h"
-#import "CKComponentGestureActionsInternal.h"
-#import "CKComponentViewInterface.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentGestureActions.h>
+#import <ComponentKit/CKComponentGestureActionsInternal.h>
+#import <ComponentKit/CKComponentViewInterface.h>
 
 @interface CKFakeActionComponent : CKComponent <UIGestureRecognizerDelegate>
 - (void)test:(CKComponent *)sender;

--- a/ComponentKitTests/CKComponentHostingViewAsyncStateUpdateTests.mm
+++ b/ComponentKitTests/CKComponentHostingViewAsyncStateUpdateTests.mm
@@ -12,13 +12,13 @@
 
 #import "CKTestRunLoopRunning.h"
 
-#import "CKComponent.h"
-#import "CKComponentFlexibleSizeRangeProvider.h"
-#import "CKComponentHostingView.h"
-#import "CKComponentHostingViewInternal.h"
-#import "CKComponentInternal.h"
-#import "CKComponentScope.h"
-#import "CKComponentSubclass.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentFlexibleSizeRangeProvider.h>
+#import <ComponentKit/CKComponentHostingView.h>
+#import <ComponentKit/CKComponentHostingViewInternal.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentSubclass.h>
 
 @interface CKComponentHostingViewAsyncStateUpdateTests : XCTestCase <CKComponentProvider>
 @end

--- a/ComponentKitTests/CKComponentHostingViewTests.mm
+++ b/ComponentKitTests/CKComponentHostingViewTests.mm
@@ -13,12 +13,12 @@
 #import "CKComponentHostingViewTestModel.h"
 #import "CKTestRunLoopRunning.h"
 
-#import "CKComponent.h"
-#import "CKComponentFlexibleSizeRangeProvider.h"
-#import "CKComponentHostingView.h"
-#import "CKComponentHostingViewDelegate.h"
-#import "CKComponentHostingViewInternal.h"
-#import "CKComponentViewInterface.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentFlexibleSizeRangeProvider.h>
+#import <ComponentKit/CKComponentHostingView.h>
+#import <ComponentKit/CKComponentHostingViewDelegate.h>
+#import <ComponentKit/CKComponentHostingViewInternal.h>
+#import <ComponentKit/CKComponentViewInterface.h>
 
 @interface CKComponentHostingViewTests : XCTestCase <CKComponentProvider, CKComponentHostingViewDelegate>
 @end

--- a/ComponentKitTests/CKComponentLifecycleManagerTests.mm
+++ b/ComponentKitTests/CKComponentLifecycleManagerTests.mm
@@ -10,14 +10,14 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentAnimation.h"
-#import "CKComponentController.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentProvider.h"
-#import "CKComponentScope.h"
-#import "CKComponentViewInterface.h"
-#import "CKCompositeComponent.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentAnimation.h>
+#import <ComponentKit/CKComponentController.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentViewInterface.h>
+#import <ComponentKit/CKCompositeComponent.h>
 
 static BOOL notified;
 

--- a/ComponentKitTests/CKComponentMemoizerTests.mm
+++ b/ComponentKitTests/CKComponentMemoizerTests.mm
@@ -1,15 +1,15 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentMemoizer.h"
-#import "CKComponentScopeRoot.h"
-#import "CKComponentSubclass.h"
-#import "CKComponentInternal.h"
-#import "CKInternalHelpers.h"
-#import "CKMacros.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentMemoizer.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKInternalHelpers.h>
+#import <ComponentKit/CKMacros.h>
 
-#import "CKStackLayoutComponent.h"
+#import <ComponentKit/CKStackLayoutComponent.h>
 
 @interface CKComponentMemoizerTests : XCTestCase
 

--- a/ComponentKitTests/CKComponentMountContextLayoutGuideTests.mm
+++ b/ComponentKitTests/CKComponentMountContextLayoutGuideTests.mm
@@ -10,11 +10,11 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentInternal.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentSubclass.h"
-#import "CKStaticLayoutComponent.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKStaticLayoutComponent.h>
 
 @interface CKComponentMountContextLayoutGuideTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentMountTests.mm
+++ b/ComponentKitTests/CKComponentMountTests.mm
@@ -10,10 +10,10 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentInternal.h"
-#import "CKComponentLayout.h"
-#import "CKComponentSubclass.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentSubclass.h>
 
 @interface CKComponentMountTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentSizeTests.mm
+++ b/ComponentKitTests/CKComponentSizeTests.mm
@@ -10,7 +10,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
+#import <ComponentKit/CKComponent.h>
 
 
 @interface CKComponentSizeTests : XCTestCase

--- a/ComponentKitTests/CKComponentViewAttributeTests.mm
+++ b/ComponentKitTests/CKComponentViewAttributeTests.mm
@@ -11,9 +11,9 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentSubclass.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentSubclass.h>
 
 @interface CKComponentViewAttributeTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentViewContextTests.mm
+++ b/ComponentKitTests/CKComponentViewContextTests.mm
@@ -10,12 +10,12 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentAnimation.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentProvider.h"
-#import "CKCompositeComponent.h"
-#import "CKStaticLayoutComponent.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentAnimation.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKStaticLayoutComponent.h>
 
 @interface CKComponentViewContextTests : XCTestCase
 @end

--- a/ComponentKitTests/CKComponentViewManagerTests.mm
+++ b/ComponentKitTests/CKComponentViewManagerTests.mm
@@ -12,8 +12,9 @@
 
 #import "ComponentViewManager.h"
 #import "ComponentViewReuseUtilities.h"
-#import "CKComponent.h"
-#import "CKComponentInternal.h"
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
 
 using CK::Component::ViewManager;
 

--- a/ComponentKitTests/CKComponentViewReuseTests.mm
+++ b/ComponentKitTests/CKComponentViewReuseTests.mm
@@ -12,11 +12,12 @@
 
 #import "ComponentViewManager.h"
 #import "ComponentViewReuseUtilities.h"
-#import "CKComponent.h"
-#import "CKComponentInternal.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentProvider.h"
-#import "CKCompositeComponent.h"
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKCompositeComponent.h>
 
 @interface CKComponentViewReuseTests : XCTestCase <CKComponentProvider>
 @end

--- a/ComponentKitTests/CKDimensionTests.mm
+++ b/ComponentKitTests/CKDimensionTests.mm
@@ -10,7 +10,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKDimension.h"
+#import <ComponentKit/CKDimension.h>
 
 
 @interface CKDimensionTests : XCTestCase

--- a/ComponentKitTests/CKOptimisticViewMutationsTests.mm
+++ b/ComponentKitTests/CKOptimisticViewMutationsTests.mm
@@ -10,11 +10,11 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentAnimation.h"
-#import "CKComponentLifecycleManager.h"
-#import "CKComponentSubclass.h"
-#import "CKOptimisticViewMutations.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentAnimation.h>
+#import <ComponentKit/CKComponentLifecycleManager.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKOptimisticViewMutations.h>
 
 @interface CKOptimisticViewMutationsTests : XCTestCase
 @end

--- a/ComponentKitTests/CKStateExposingComponent.h
+++ b/ComponentKitTests/CKStateExposingComponent.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import "CKComponent.h"
+#import <ComponentKit/CKComponent.h>
 
 @interface CKStateExposingComponent : CKComponent
 @property (nonatomic, strong, readonly) id state;

--- a/ComponentKitTests/CKStateExposingComponent.mm
+++ b/ComponentKitTests/CKStateExposingComponent.mm
@@ -10,7 +10,7 @@
 
 #import "CKStateExposingComponent.h"
 
-#import "CKComponentScope.h"
+#import <ComponentKit/CKComponentScope.h>
 
 @implementation CKStateExposingComponent
 + (id)initialState

--- a/ComponentKitTests/Scope/CKComponentScopeTests.mm
+++ b/ComponentKitTests/Scope/CKComponentScopeTests.mm
@@ -12,11 +12,11 @@
 
 #import <ComponentKit/CKCompositeComponent.h>
 
-#import "CKComponentScope.h"
-#import "CKComponentScopeFrame.h"
-#import "CKComponentScopeHandle.h"
-#import "CKComponentScopeRoot.h"
-#import "CKThreadLocalComponentScope.h"
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentScopeFrame.h>
+#import <ComponentKit/CKComponentScopeHandle.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKThreadLocalComponentScope.h>
 
 @interface CKComponentScopeTests : XCTestCase
 @end

--- a/ComponentKitTests/Scope/CKStateScopeComponentBuilderTests.mm
+++ b/ComponentKitTests/Scope/CKStateScopeComponentBuilderTests.mm
@@ -12,15 +12,15 @@
 
 #import <OCMock/OCMock.h>
 
-#import "CKComponentController.h"
-#import "CKComponentSubclass.h"
-#import "CKCompositeComponent.h"
+#import <ComponentKit/CKComponentController.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentScopeFrame.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKThreadLocalComponentScope.h>
 
-#import "CKComponentScope.h"
-#import "CKComponentInternal.h"
-#import "CKComponentScopeFrame.h"
-#import "CKComponentScopeRoot.h"
-#import "CKThreadLocalComponentScope.h"
 #import "CKStateExposingComponent.h"
 
 #pragma mark - Test Components and Controllers

--- a/ComponentKitTests/StatefulViews/CKTestStatefulViewComponent.mm
+++ b/ComponentKitTests/StatefulViews/CKTestStatefulViewComponent.mm
@@ -8,10 +8,10 @@
  *
  */
 
-#import "CKTestStatefulViewComponent.h"
-
 #import <ComponentKit/CKComponentScope.h>
-#import <ComponentKit/CKStatefulViewComponentController.h>
+
+#import "CKTestStatefulViewComponent.h"
+#import "CKStatefulViewComponentController.h"
 
 @interface CKTestStatefulViewComponent ()
 @property (nonatomic, strong) UIColor *color;

--- a/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceTests.mm
@@ -12,10 +12,10 @@
 #import <OCMock/OCMock.h>
 #import <UIKit/UIKit.h>
 
-#import "CKCollectionViewTransactionalDataSource.h"
-#import "CKTransactionalComponentDataSourceConfiguration.h"
-#import "CKSupplementaryViewDataSource.h"
-#import "CKSizeRange.h"
+#import <ComponentKit/CKCollectionViewTransactionalDataSource.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
+#import <ComponentKit/CKSupplementaryViewDataSource.h>
+#import <ComponentKit/CKSizeRange.h>
 
 @interface CKCollectionViewTransactionalDataSource () <UICollectionViewDataSource>
 @end

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetModificationTests.mm
@@ -12,15 +12,16 @@
 
 #include <stdlib.h>
 
-#import "CKComponent.h"
-#import "CKComponentLayout.h"
-#import "CKComponentProvider.h"
-#import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
-#import "CKTransactionalComponentDataSourceChange.h"
-#import "CKTransactionalComponentDataSourceChangeset.h"
-#import "CKTransactionalComponentDataSourceItem.h"
-#import "CKTransactionalComponentDataSourceChangesetModification.h"
-#import "CKTransactionalComponentDataSourceState.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceAppliedChangesInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChange.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChangeset.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChangesetModification.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 
 @interface CKModelExposingComponent : CKComponent

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceReloadModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceReloadModificationTests.mm
@@ -12,14 +12,15 @@
 
 #include <stdlib.h>
 
-#import "CKComponent.h"
-#import "CKComponentLayout.h"
-#import "CKComponentProvider.h"
-#import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
-#import "CKTransactionalComponentDataSourceChange.h"
-#import "CKTransactionalComponentDataSourceItem.h"
-#import "CKTransactionalComponentDataSourceReloadModification.h"
-#import "CKTransactionalComponentDataSourceState.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceAppliedChangesInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChange.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceReloadModification.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 
 // Some tests manipulate this to simulate global singleton state changing.

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
@@ -10,16 +10,16 @@
 
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 
-#import "CKTransactionalComponentDataSourceConfiguration.h"
-#import "CKComponentProvider.h"
-#import "CKComponentLayout.h"
-#import "CKComponentScopeRoot.h"
-#import "CKComponentSubclass.h"
-#import "CKTransactionalComponentDataSource.h"
-#import "CKTransactionalComponentDataSourceChangeset.h"
-#import "CKTransactionalComponentDataSourceConfiguration.h"
-#import "CKTransactionalComponentDataSourceItemInternal.h"
-#import "CKTransactionalComponentDataSourceStateInternal.h"
+#import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKTransactionalComponentDataSource.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChangeset.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItemInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceStateInternal.h>
 
 static CKTransactionalComponentDataSourceItem *item(CKTransactionalComponentDataSourceConfiguration *configuration, id<CKComponentStateListener> listener, id model)
 {

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
@@ -10,10 +10,11 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentProvider.h"
-#import "CKTransactionalComponentDataSourceState.h"
-#import "CKTransactionalComponentDataSourceItem.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 
 @interface CKTransactionalComponentDataSourceStateTests : XCTestCase <CKComponentProvider>

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateUpdateTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateUpdateTests.mm
@@ -10,15 +10,16 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponentInternal.h"
-#import "CKComponentSubclass.h"
-#import "CKComponentLayout.h"
-#import "CKComponentProvider.h"
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKTransactionalComponentDataSource.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+
 #import "CKStateExposingComponent.h"
 #import "CKTestRunLoopRunning.h"
-#import "CKTransactionalComponentDataSource.h"
-#import "CKTransactionalComponentDataSourceItem.h"
-#import "CKTransactionalComponentDataSourceState.h"
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 
 @interface CKTransactionalComponentDataSourceStateUpdateTests : XCTestCase <CKComponentProvider>

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceTests.mm
@@ -10,15 +10,16 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponent.h"
-#import "CKComponentProvider.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKTransactionalComponentDataSource.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceAppliedChangesInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChangeset.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceListener.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+
 #import "CKTestRunLoopRunning.h"
-#import "CKTransactionalComponentDataSource.h"
-#import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
-#import "CKTransactionalComponentDataSourceChangeset.h"
-#import "CKTransactionalComponentDataSourceConfiguration.h"
-#import "CKTransactionalComponentDataSourceListener.h"
-#import "CKTransactionalComponentDataSourceState.h"
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 
 @interface CKTransactionalComponentDataSourceTests : XCTestCase <CKComponentProvider, CKTransactionalComponentDataSourceListener>

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm
@@ -12,15 +12,16 @@
 
 #include <stdlib.h>
 
-#import "CKComponent.h"
-#import "CKComponentLayout.h"
-#import "CKComponentProvider.h"
-#import "CKCompositeComponent.h"
-#import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
-#import "CKTransactionalComponentDataSourceChange.h"
-#import "CKTransactionalComponentDataSourceConfiguration.h"
-#import "CKTransactionalComponentDataSourceItem.h"
-#import "CKTransactionalComponentDataSourceState.h"
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceAppliedChangesInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChange.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 #import "CKTransactionalComponentDataSourceUpdateConfigurationModification.h"
 

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
@@ -10,15 +10,16 @@
 
 #import <XCTest/XCTest.h>
 
-#import "CKComponentLayout.h"
-#import "CKComponentProvider.h"
-#import "CKComponentScope.h"
-#import "CKComponentScopeRoot.h"
-#import "CKComponentSubclass.h"
-#import "CKTransactionalComponentDataSourceAppliedChangesInternal.h"
-#import "CKTransactionalComponentDataSourceChange.h"
-#import "CKTransactionalComponentDataSourceItem.h"
-#import "CKTransactionalComponentDataSourceState.h"
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponentScope.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKComponentSubclass.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceAppliedChangesInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChange.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceState.h>
+
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
 #import "CKTransactionalComponentDataSourceUpdateStateModification.h"
 

--- a/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.mm
+++ b/ComponentSnapshotTestCase/CKComponentSnapshotTestCase.mm
@@ -8,7 +8,7 @@
  *
  */
 
-#import "CKComponentSnapshotTestCase.h"
+#import <ComponentSnapshotTestCase/CKComponentSnapshotTestCase.h>
 
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentLifecycleManager.h>

--- a/ComponentTextKitApplicationTests/CKTextKitTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextKitTests.mm
@@ -13,10 +13,10 @@
 
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
-#import "CKTextKitEntityAttribute.h"
-#import "CKTextKitAttributes.h"
-#import "CKTextKitRenderer.h"
-#import "CKTextKitRenderer+Positioning.h"
+#import <ComponentKit/CKTextKitEntityAttribute.h>
+#import <ComponentKit/CKTextKitAttributes.h>
+#import <ComponentKit/CKTextKitRenderer.h>
+#import <ComponentKit/CKTextKitRenderer+Positioning.h>
 
 @interface CKTextKitTests : XCTestCase
 


### PR DESCRIPTION
Split from #495 to contain import path changes beyond the scope of #496.

- Import all files linked with CocoaPods using the pod's prefix: <ComponentKit/*.h>. These small changes prevent local import(of ComponentKit files by the target) and adds clarity to "where" these files are coming from.