### PR TITLE
update CKComponentScope prompt to the correct format

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -40,7 +40,7 @@
     return handle;
   }
   CKCAssertNil(controllerClassForComponentClass([component class]), @"%@ has a controller but no scope! "
-               "Use CKComponentScope(self) before constructing the component or CKComponentTestRootScope "
+               "Use CKComponentScope scope(self) before constructing the component or CKComponentTestRootScope "
                "at the start of the test.", [component class]);
   return nil;
 }


### PR DESCRIPTION
The prompt was saying 'Use CKComponentScope(self)' but put that in code will get you a compile error. The most common way to add scope is 'CKComponentScope scope(self)'