### PR TITLE
Allow CKComponentHostingView to rerender with empty bounds

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -92,14 +92,12 @@ struct CKComponentHostingViewInputs {
   [super layoutSubviews];
   _containerView.frame = self.bounds;
 
-  if (!CGRectIsEmpty(self.bounds)) {
-    [self _synchronouslyUpdateComponentIfNeeded];
-    const CGSize size = self.bounds.size;
-    if (_mountedLayout.component != _component || !CGSizeEqualToSize(_mountedLayout.size, size)) {
-      _mountedLayout = [_component layoutThatFits:{size, size} parentSize:size];
-    }
-    _mountedComponents = [CKMountComponentLayout(_mountedLayout, _containerView, _mountedComponents, nil) copy];
+  [self _synchronouslyUpdateComponentIfNeeded];
+  const CGSize size = self.bounds.size;
+  if (_mountedLayout.component != _component || !CGSizeEqualToSize(_mountedLayout.size, size)) {
+    _mountedLayout = [_component layoutThatFits:{size, size} parentSize:size];
   }
+  _mountedComponents = [CKMountComponentLayout(_mountedLayout, _containerView, _mountedComponents, nil) copy];
 }
 
 - (CGSize)sizeThatFits:(CGSize)size

--- a/ComponentKitTests/CKComponentHostingViewTests.mm
+++ b/ComponentKitTests/CKComponentHostingViewTests.mm
@@ -114,7 +114,7 @@ static CKComponentHostingView *hostingView()
   XCTAssertTrue(_calledSizeDidInvalidate);
 }
 
-- (void)testUpdateWithEmptyBoundsDoesntMountLayout
+- (void)testUpdateWithEmptyBoundsMountLayout
 {
   CKComponentHostingViewTestModel *model = [[CKComponentHostingViewTestModel alloc] initWithColor:[UIColor orangeColor] size:CKComponentSize::fromCGSize(CGSizeMake(50, 50))];
   CKComponentHostingView *view = [[CKComponentHostingView alloc] initWithComponentProvider:[self class]
@@ -122,7 +122,7 @@ static CKComponentHostingView *hostingView()
   [view updateModel:model mode:CKUpdateModeSynchronous];
   [view layoutIfNeeded];
 
-  XCTAssertEqual([view.containerView.subviews count], 0u, @"Expect the component is not mounted with empty bounds");
+  XCTAssertEqual([view.containerView.subviews count], 1u, @"Expect the component is mounted with empty bounds");
 }
 
 #pragma mark - CKComponentHostingViewDelegate


### PR DESCRIPTION
As titled.