### PR TITLE
Changes definition of equality for CKTransactionalComponentDataSource…

### DIFF
--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceState.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceState.mm
@@ -13,6 +13,7 @@
 #import "CKEqualityHashHelpers.h"
 #import "CKMacros.h"
 #import "CKTransactionalComponentDataSourceConfiguration.h"
+#import "CKTransactionalComponentDataSourceItem.h"
 
 @implementation CKTransactionalComponentDataSourceState
 
@@ -75,7 +76,7 @@
     return NO;
   } else {
     CKTransactionalComponentDataSourceState *obj = ((CKTransactionalComponentDataSourceState *)object);
-    return [_configuration isEqual:obj.configuration] && [_sections isEqualToArray:obj.sections];
+    return [_configuration isEqual:obj.configuration] && [flattenedModelsFromSections(_sections) isEqualToArray:flattenedModelsFromSections(obj.sections)];
   }
 }
 
@@ -86,6 +87,19 @@
     [_sections hash]
   };
   return CKIntegerArrayHash(hashes, CK_ARRAY_COUNT(hashes));
+}
+
+static NSArray *flattenedModelsFromSections(NSArray *sections)
+{
+  NSMutableArray *modelSections = [NSMutableArray new];
+  for (NSArray *section in sections) {
+    NSMutableArray *modelSection = [NSMutableArray new];
+    for (CKTransactionalComponentDataSourceItem *item in section) {
+      [modelSection addObject:item.model];
+    }
+    [modelSections addObject:modelSection];
+  }
+  return modelSections;
 }
 
 @end

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
@@ -11,9 +11,10 @@
 #import <XCTest/XCTest.h>
 
 #import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentLayout.h>
 #import <ComponentKit/CKComponentProvider.h>
 #import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
-#import <ComponentKit/CKTransactionalComponentDataSourceItem.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItemInternal.h>
 #import <ComponentKit/CKTransactionalComponentDataSourceStateInternal.h>
 
 #import "CKTransactionalComponentDataSourceStateTestHelpers.h"
@@ -89,22 +90,26 @@
 
 - (void)testStateEquality
 {
+  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *firstConfiguration = [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class] context:@"context" sizeRange:CKSizeRange()];
-  CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[@"a"]]];
+  CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[firstItem]]];
 
+  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *secondConfiguration = [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class] context:@"context" sizeRange:CKSizeRange()];
-  CKTransactionalComponentDataSourceState *secondState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:secondConfiguration sections:@[@[@"a"]]];
+  CKTransactionalComponentDataSourceState *secondState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:secondConfiguration sections:@[@[secondItem]]];
 
   XCTAssertEqualObjects(firstState, secondState);
 }
 
 - (void)testNonEqualStates
 {
+  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *firstConfiguration = [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class] context:@"context" sizeRange:CKSizeRange()];
-  CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[@"a"]]];
+  CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[firstItem]]];
 
+  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model2" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *secondConfiguration = [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class] context:@"context" sizeRange:CKSizeRange()];
-  CKTransactionalComponentDataSourceState *secondState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:secondConfiguration sections:@[@[@"b"]]];
+  CKTransactionalComponentDataSourceState *secondState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:secondConfiguration sections:@[@[secondItem]]];
 
   XCTAssertNotEqualObjects(firstState, secondState);
 }


### PR DESCRIPTION
…State so only the models are checked in CKTransactionalComponentDataSourceItems (instead of the layouts, scope roots, components inside the layouts, etc)