### PR TITLE
Expose a way to get state updater from CKComponentScope

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScope.h
+++ b/ComponentKit/Core/Scope/CKComponentScope.h
@@ -10,7 +10,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <ComponentKit/CKUpdateMode.h>
+
 class CKThreadLocalComponentScope;
+@class CKComponentScopeHandle;
+
+typedef void (^CKComponentStateUpdater)(id (^)(id), CKUpdateMode mode);
 
 /**
  Components have local "state" that is independent of the values passed into its +new method. Components can update
@@ -49,11 +54,14 @@ public:
   ~CKComponentScope();
 
   /** @return The current state for the component being built. */
-  id state() const;
+  id state(void) const;
+
+  /** @return A block that schedules a state update. Usually, use [CKComponent -updateState:mode:] instead. */
+  CKComponentStateUpdater stateUpdater(void) const;
 
 private:
   CKComponentScope(const CKComponentScope&) = delete;
   CKComponentScope &operator=(const CKComponentScope&) = delete;
   CKThreadLocalComponentScope *_threadLocalScope;
-  id _state;
+  CKComponentScopeHandle *_scopeHandle;
 };

--- a/ComponentKit/Core/Scope/CKComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKComponentScope.mm
@@ -32,11 +32,16 @@ CKComponentScope::CKComponentScope(Class __unsafe_unretained componentClass, id 
                                                initialStateCreator:initialStateCreator
                                                       stateUpdates:_threadLocalScope->stateUpdates];
     _threadLocalScope->stack.push({.frame = childPair.frame, .equivalentPreviousFrame = childPair.equivalentPreviousFrame});
-    _state = childPair.frame.handle.state;
+    _scopeHandle = childPair.frame.handle;
   }
 }
 
-id CKComponentScope::state() const
+id CKComponentScope::state(void) const
 {
-  return _state;
+  return _scopeHandle.state;
+}
+
+CKComponentStateUpdater CKComponentScope::stateUpdater(void) const
+{
+  return ^(id (^update)(id), CKUpdateMode mode){ [_scopeHandle updateState:update mode:mode]; };
 }


### PR DESCRIPTION
This is useful when you want to pass a state updater off to some element that is a sub-element of your component (and thus you can't wait until the component is created to pass it off).