### PR TITLE
Docs and fixes for CKComponentScope stateUpdater

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScope.h
+++ b/ComponentKit/Core/Scope/CKComponentScope.h
@@ -56,7 +56,13 @@ public:
   /** @return The current state for the component being built. */
   id state(void) const;
 
-  /** @return A block that schedules a state update. Usually, use [CKComponent -updateState:mode:] instead. */
+  /**
+   @return A block that schedules a state update when invoked.
+   @discussion Usually, prefer the more idiomatic [CKComponent -updateState:mode:]. Use this in the rare case where you
+   need to pass a state updater to a child component during +new. (Usually, the child should communicate back via
+   CKComponentAction and the parent should call -updateState:mode: on itself; this hides the implementation details
+   of the parent's state from the child.)
+  */
   CKComponentStateUpdater stateUpdater(void) const;
 
 private:

--- a/ComponentKit/Core/Scope/CKComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKComponentScope.mm
@@ -43,5 +43,7 @@ id CKComponentScope::state(void) const
 
 CKComponentStateUpdater CKComponentScope::stateUpdater(void) const
 {
-  return ^(id (^update)(id), CKUpdateMode mode){ [_scopeHandle updateState:update mode:mode]; };
+  // We must capture _scopeHandle in a local, since this may be destroyed by the time the block executes.
+  CKComponentScopeHandle *const scopeHandle = _scopeHandle;
+  return ^(id (^update)(id), CKUpdateMode mode){ [scopeHandle updateState:update mode:mode]; };
 }


### PR DESCRIPTION
This outright crashed because it captured a member variable on an instance that will be destroyed when the stack unwinds.