### PR TITLE
Use xcodebuild instead of xctool for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: objective-c
 osx_image: xcode7.3
 
-before_install:
-  - brew update
-  - brew outdated xctool || brew upgrade xctool
-
 script: ./build.sh ci
 
 # Whitelist for branches

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ set -eu
 MODE=$1
 
 function ci() {
-  xctool \
+  xcodebuild \
       -project $1.xcodeproj \
       -scheme $1 \
       -sdk iphonesimulator9.3 \


### PR DESCRIPTION
`xctool` has been reported to run into trouble with Xcode 7.3. For some context read through some of the more recent comments in https://github.com/travis-ci/travis-ci/issues/3986.

Let's just stick with `xcodebuild` instead.