### PR TITLE
Changes CKComponentDeciding to have only a class method that returns …

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -56,7 +56,7 @@ CK_FINAL_CLASS([CKCollectionViewDataSource class]);
   if (self) {
     _componentDataSource = [[CKComponentDataSource alloc] initWithComponentProvider:componentProvider
                                                                             context:context
-                                                                            decider:[[CKComponentConstantDecider alloc] initWithEnabled:YES]];
+                                                                            decider:[CKComponentConstantApprovingDecider class]];
     _supplementaryViewDataSource = supplementaryViewDataSource;
     _cellConfigurationFunction = cellConfigurationFunction;
     _componentDataSource.delegate = self;

--- a/ComponentKit/DataSources/Common/CKComponentConstantDecider.h
+++ b/ComponentKit/DataSources/Common/CKComponentConstantDecider.h
@@ -12,8 +12,8 @@
 
 #import <ComponentKit/CKComponentDeciding.h>
 
-@interface CKComponentConstantDecider : NSObject <CKComponentDeciding>
+@interface CKComponentConstantApprovingDecider : NSObject <CKComponentDeciding>
+@end
 
-- (instancetype)initWithEnabled:(BOOL)enabled;
-
+@interface CKComponentConstantDenyingDecider : NSObject <CKComponentDeciding>
 @end

--- a/ComponentKit/DataSources/Common/CKComponentConstantDecider.m
+++ b/ComponentKit/DataSources/Common/CKComponentConstantDecider.m
@@ -10,22 +10,20 @@
 
 #import "CKComponentConstantDecider.h"
 
-@implementation CKComponentConstantDecider
+@implementation CKComponentConstantApprovingDecider : NSObject
+
++ (BOOL)isModelComponentCompliant:(id)model
 {
-  BOOL _enabled;
+  return YES;
 }
 
-- (instancetype)initWithEnabled:(BOOL)enabled
-{
-  if (self = [super init]) {
-    _enabled = enabled;
-  }
-  return self;
-}
+@end
 
-- (id)componentCompliantModel:(id)model
+@implementation CKComponentConstantDenyingDecider : NSObject
+
++ (BOOL)isModelComponentCompliant:(id)model
 {
-  return _enabled ? model : nil;
+  return NO;
 }
 
 @end

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.h
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.h
@@ -48,7 +48,7 @@ class CKComponentBoundsAnimation;
  */
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
                                   context:(id<NSObject>)context
-                                  decider:(id<CKComponentDeciding>)decider;
+                                  decider:(Class<CKComponentDeciding>)decider;
 
 /**
  @see `CKComponentDataSourceDelegate`

--- a/ComponentKit/DataSources/Common/CKComponentDataSource.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSource.mm
@@ -39,7 +39,7 @@ CKComponentLifecycleManagerAsynchronousUpdateHandler
 
 @implementation CKComponentDataSource
 {
-  id<CKComponentDeciding> _decider;
+  Class<CKComponentDeciding> _decider;
   id<NSObject> _context;
 
   /*
@@ -62,7 +62,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
 #pragma mark - Lifecycle
 
 - (instancetype)initWithLifecycleManagerFactory:(CKComponentLifecycleManagerFactory)lifecycleManagerFactory
-                                        decider:(id<CKComponentDeciding>)decider
+                                        decider:(Class<CKComponentDeciding>)decider
                                         context:(id<NSObject>)context
                            inputArrayController:(CKSectionedArrayController *)inputArrayController
                           outputArrayController:(CKSectionedArrayController *)outputArrayController
@@ -84,7 +84,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
 
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
                                   context:(id<NSObject>)context
-                                  decider:(id<CKComponentDeciding>)decider
+                                  decider:(Class<CKComponentDeciding>)decider
 {
   return [self initWithComponentProvider:componentProvider
                                  context:context
@@ -94,7 +94,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
 
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
                                   context:(id<NSObject>)context
-                                  decider:(id<CKComponentDeciding>)decider
+                                  decider:(Class<CKComponentDeciding>)decider
                     preparationQueueWidth:(NSInteger)preparationQueueWidth
 {
   CKComponentLifecycleManagerFactory lifecycleManagerFactory = ^{
@@ -223,7 +223,6 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
   ^(const CKArrayControllerOutputChange &change, CKArrayControllerChangeType type, BOOL *stop) {
     CKComponentDataSourceInputItem *before = change.before;
     CKComponentDataSourceInputItem *after = change.after;
-    id componentCompliantModel = [_decider componentCompliantModel:[after model]];
 
     CKSizeRange constrainedSize = (type == CKArrayControllerChangeTypeDelete) ? CKSizeRange() : [after constrainedSize];
     CKComponentPreparationInputItem *queueItem =
@@ -235,7 +234,7 @@ CK_FINAL_CLASS([CKComponentDataSource class]);
                                                       sourceIndexPath:change.sourceIndexPath.toNSIndexPath()
                                                  destinationIndexPath:change.destinationIndexPath.toNSIndexPath()
                                                            changeType:type
-                                                          passthrough:(componentCompliantModel == nil)
+                                                          passthrough:![_decider isModelComponentCompliant:[after model]]
                                                               context:_context];
     preparationQueueBatch.items.push_back(queueItem);
   };

--- a/ComponentKit/DataSources/Common/CKComponentDeciding.h
+++ b/ComponentKit/DataSources/Common/CKComponentDeciding.h
@@ -13,9 +13,9 @@
 @protocol CKComponentDeciding <NSObject>
 
 /*
- * Returns a component compliant model if possible
- * Nil otherwise
+ * Returns YES if the model is component-eligible
+ * No otherwise
  */
-- (id)componentCompliantModel:(id)model;
++ (BOOL)isModelComponentCompliant:(id)model;
 
 @end

--- a/ComponentKitTests/CKComponentDataSourceTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceTests.mm
@@ -100,10 +100,9 @@ namespace CK {
 - (void)setUp
 {
   [super setUp];
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:NO];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:nil
                                                                                        context:nil
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantDenyingDecider class]];
   _dataSource = dataSource;
 }
 
@@ -115,10 +114,9 @@ namespace CK {
 
 - (void)testInitialState
 {
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:NO];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:nil
                                                                                        context:nil
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantDenyingDecider class]];
   XCTAssertNotNil(dataSource);
   XCTAssertEqual([dataSource numberOfSections], 0);
   XCTAssertThrowsSpecificNamed([dataSource objectAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]],
@@ -148,10 +146,9 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
 
   CKComponentDataSourceTestDelegate *delegate = [[CKComponentDataSourceTestDelegate alloc] init];
 
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:NO];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:nil
                                                                                        context:nil
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantDenyingDecider class]];
 
   dataSource.delegate = delegate;
 
@@ -402,10 +399,9 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
 
   CKComponentDataSourceTestDelegate *delegate = [[CKComponentDataSourceTestDelegate alloc] init];
 
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:NO];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:nil
                                                                                        context:nil
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantDenyingDecider class]];
 
   dataSource.delegate = delegate;
 
@@ -849,10 +845,9 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
 
   CKComponentDataSourceTestDelegate *delegate = [[CKComponentDataSourceTestDelegate alloc] init];
 
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:NO];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:nil
                                                                                        context:nil
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantDenyingDecider class]];
 
   dataSource.delegate = delegate;
 
@@ -1014,10 +1009,9 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
 
   CKComponentDataSourceTestDelegate *delegate = [[CKComponentDataSourceTestDelegate alloc] init];
 
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:NO];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:nil
                                                                                        context:nil
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantDenyingDecider class]];
 
   dataSource.delegate = delegate;
 
@@ -1099,10 +1093,9 @@ static const CKSizeRange constrainedSize = {{320, 0}, {320, INFINITY}};
   
   CKComponentDataSourceTestDelegate *delegate = [[CKComponentDataSourceTestDelegate alloc] init];
   
-  CKComponentConstantDecider *decider = [[CKComponentConstantDecider alloc] initWithEnabled:YES];
   CKComponentDataSource *dataSource = [[CKComponentDataSource alloc] initWithComponentProvider:[self class]
                                                                                        context:@"context"
-                                                                                       decider:decider];
+                                                                                       decider:[CKComponentConstantApprovingDecider class]];
   
   dataSource.delegate = delegate;
   


### PR DESCRIPTION
…a boolean

This also removes CKComponentConstantDecider and adds CKComponentConstantApprovingDecider and CKComponentConstantDenyingDecider as a replacement so that we don't need to keep the '_enabled' state like we did when it was an instance.