### PR TITLE
Fix maximumNumberOfLines on CKTextKitRenderer

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRenderer.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRenderer.mm
@@ -125,10 +125,16 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
 {
   __block NSUInteger lineCount = 0;
   [_context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
-    for (NSRange lineRange = { 0, 0 }; NSMaxRange(lineRange) < [layoutManager numberOfGlyphs]; lineCount++) {
-      [layoutManager lineFragmentRectForGlyphAtIndex:NSMaxRange(lineRange) effectiveRange:&lineRange];
+    NSUInteger numberOfGlyphs = [layoutManager numberOfGlyphs];
+    for (NSRange lineRange = { 0, 0 }; NSMaxRange(lineRange) < numberOfGlyphs;) {
+      CGRect lineRect = [layoutManager lineFragmentRectForGlyphAtIndex:NSMaxRange(lineRange) effectiveRange:&lineRange];
+      if (CGRectIsEmpty(lineRect)) {
+        break;
+      }
+      lineCount++;
     }
   }];
+
   return lineCount;
 }
 

--- a/ComponentTextKitApplicationTests/CKTextKitTruncationTests.mm
+++ b/ComponentTextKitApplicationTests/CKTextKitTruncationTests.mm
@@ -140,4 +140,30 @@
                                                    constrainedSize:constrainedSize]);
 }
 
+- (void)testNoLimitOfMaximumNumberOfLines
+{
+  const NSUInteger maximumNumberOfLines = 0;
+  NSAttributedString *attributedString = [self _sentenceAttributedString];
+  CKTextKitRenderer *renderer = [[CKTextKitRenderer alloc]
+                                 initWithTextKitAttributes:{
+                                   .attributedString = attributedString,
+                                   .maximumNumberOfLines = maximumNumberOfLines,
+                                 }
+                                 constrainedSize:CGSizeMake(50, INFINITY)];
+  XCTAssertTrue(renderer.lineCount > maximumNumberOfLines);
+}
+
+- (void)testEnforcementOfMaximumNumberOfLines
+{
+  const NSUInteger maximumNumberOfLines = 3;
+  NSAttributedString *attributedString = [self _sentenceAttributedString];
+  CKTextKitRenderer *renderer = [[CKTextKitRenderer alloc]
+                                 initWithTextKitAttributes:{
+                                   .attributedString = attributedString,
+                                   .maximumNumberOfLines = maximumNumberOfLines,
+                                 }
+                                 constrainedSize:CGSizeMake(50, INFINITY)];
+  XCTAssertEqual(renderer.lineCount, maximumNumberOfLines);
+}
+
 @end


### PR DESCRIPTION
This is an attempt to address the issue that @conradev illustrated with #553.

The issue is that our loop is looking at `[layoutManager numberOfGlyphs]` which counts all glyphs and not just what is visible. I am adding a check to ensure that `lineFragmentRectForGlyphAtIndex` returns non empty rect before increasing the count. This was modeled as the documentation [describes](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/TextLayout/Tasks/CountLines.html) and it worked as expected when `maximumNumberOfLines` was not set.

Any suggestions would be appreciated.