### PR TITLE
Fix stateful view reuse pool bug with superview changes

### DIFF
--- a/ComponentKitTests/StatefulViews/CKStatefulViewReusePoolTests.mm
+++ b/ComponentKitTests/StatefulViews/CKStatefulViewReusePoolTests.mm
@@ -131,6 +131,34 @@
   XCTAssertTrue(firstView != dequeuedView, @"Expected different view to be vended.");
 }
 
+- (void)testEnqueueingOneViewThatLostItSuperviewThenDequeueingWithDifferentPreferredSuperviews
+{
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+
+  UIView *container1 = [[UIView alloc] init];
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+  [container1 addSubview:view];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil];
+
+  // remove the statefull view from the container
+  [view removeFromSuperview];
+
+  UIView *container2 = [[UIView alloc] init];
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                  preferredSuperview:container2
+                                                             context:nil];
+  XCTAssertTrue(dequeuedView == view, @"Expected view in container1 to be returned");
+
+  XCTAssertNil([pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                        preferredSuperview:container1
+                                                   context:nil], @"Didn't expect to vend view from empty pool");
+  XCTAssertNil([pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                        preferredSuperview:container2
+                                                   context:nil], @"Didn't expect to vend view from empty pool");
+}
+
 - (void)testMaximumPoolSizeOfOneByEnqueueingTwoViewsThenDequeueingTwoViewsReturnsNewView
 {
   CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];


### PR DESCRIPTION
Credit to @RomanoffAlex for finding this and proposing a fix. His description of the problem follows:

If we have preferredSuperviewMap like the following:

```
superview: [view].
```

and allViews:

```
[view].
```

Imagine that we call `viewWithPreferredSuperview(UIView *preferredSuperview)` with some `preferredSuperview` that is not in the map and a corresponding stateful view (which was picked to be recycled) doesn't have a superview.

In this case we will remove the `preferredSuperview` from `allViews` but keep it in `preferredSuperviewMap` which is really bad because if we later call `viewWithPreferredSuperview` with a superview that is a key in the map, we will reuse the view that already is used by some component that means we are stealing a stateful view from another superview that is on screen.

To fix this, get rid of the complexity of `preferredSuperviewMap` entirely. The map does not grow so large that its algorithmic efficiency is needed. Replace it with a simple linear search.

Introduce a new test for this behavior.