### PR TITLE
More advanced API for optimistic view mutations

### DIFF
--- a/ComponentKit/Utilities/CKOptimisticViewMutations.h
+++ b/ComponentKit/Utilities/CKOptimisticViewMutations.h
@@ -10,13 +10,32 @@
 
 #import <UIKit/UIKit.h>
 
+typedef id (*CKOptimisticViewMutationGetter)(UIView *view, id context);
+typedef void (*CKOptimisticViewMutationSetter)(UIView *view, id value, id context);
+
 /**
  Use this function to optimistically mutate the view owned by a CKComponent. When the view is recycled, the mutation
  will be safely undone, resetting all properties to their original values.
 
  @warning Optimistically mutating the view for a component is **strongly** discouraged. You should instead use
  updateState: or trigger a change in the source model object.
+
+ @param view The view to modify.
+ @param getter A function that accepts a view instance and returns the value of the property you want to modify.
+ @param setter A function that accepts a view instance and some target value and sets the property to that target value.
+ @param value The value you want to be set on the view using the setter.
+ @param context Passed to both the getter and setter functions. Optional.
+
+ The getter will be invoked to fetch the current value; then the setter will be invoked with the passed value.
+ When the view is recycled, the setter will be invoked again with the saved result from the getter block.
  */
+void CKPerformOptimisticViewMutation(UIView *view,
+                                     CKOptimisticViewMutationGetter getter,
+                                     CKOptimisticViewMutationSetter setter,
+                                     id value,
+                                     id context = nil);
+
+/** A helper that creates a getter and setter for a given keypath. */
 void CKPerformOptimisticViewMutation(UIView *view, NSString *keyPath, id value);
 
 /** Used by the infrastructure to tear down optimistic mutations. Don't call this yourself. */

--- a/ComponentKit/Utilities/CKOptimisticViewMutations.h
+++ b/ComponentKit/Utilities/CKOptimisticViewMutations.h
@@ -28,6 +28,7 @@ typedef void (*CKOptimisticViewMutationSetter)(UIView *view, id value, id contex
 
  The getter will be invoked to fetch the current value; then the setter will be invoked with the passed value.
  When the view is recycled, the setter will be invoked again with the saved result from the getter block.
+ The getter and setter should be free of any side effects that modify other views, global state, etc.
  */
 void CKPerformOptimisticViewMutation(UIView *view,
                                      CKOptimisticViewMutationGetter getter,

--- a/ComponentKit/Utilities/CKOptimisticViewMutations.mm
+++ b/ComponentKit/Utilities/CKOptimisticViewMutations.mm
@@ -13,37 +13,63 @@
 #import <objc/runtime.h>
 
 #import <ComponentKit/CKAssert.h>
+#import <ComponentKit/ComponentUtilities.h>
 
-const char kOptimisticViewMutationOriginalValuesAssociatedObjectKey = ' ';
+typedef void (^CKOptimisticViewMutationTeardown)(UIView *v);
 
-void CKPerformOptimisticViewMutation(UIView *view, NSString *keyPath, id value)
+const char kOptimisticViewMutationMutationsAssociatedObjectKey = ' ';
+
+void CKPerformOptimisticViewMutation(UIView *view,
+                                     CKOptimisticViewMutationGetter getter,
+                                     CKOptimisticViewMutationSetter setter,
+                                     id value,
+                                     id context)
 {
   CKCAssertMainThread();
   CKCAssertNotNil(view, @"Must have a non-nil view");
+  CKCAssertNotNil(getter, @"Must have a non-nil getter");
+  CKCAssertNotNil(setter, @"Must have a non-nil getter");
+  if (view == nil || getter == nil || setter == nil) {
+    return;
+  }
+
+  NSMutableArray<CKOptimisticViewMutationTeardown> *mutations = objc_getAssociatedObject(view, &kOptimisticViewMutationMutationsAssociatedObjectKey);
+  if (mutations == nil) {
+    mutations = [NSMutableArray array];
+    objc_setAssociatedObject(view, &kOptimisticViewMutationMutationsAssociatedObjectKey, mutations, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  }
+  id oldValue = getter(view, context);
+  [mutations addObject:^(UIView *v) {
+    setter(v, oldValue, context);
+    CKCAssert(CKObjectIsEqual(getter(view, context), oldValue), @"Setter failed to restore old value");
+  }];
+  setter(view, value, context);
+  CKCAssert(CKObjectIsEqual(getter(view, context), value), @"Setter failed to apply new value");
+}
+
+static id keyPathGetter(UIView *view, id keyPath)
+{
+  return [view valueForKeyPath:keyPath];
+}
+
+static void keyPathSetter(UIView *view, id value, id keyPath)
+{
+  [view setValue:value forKey:keyPath];
+}
+
+void CKPerformOptimisticViewMutation(UIView *view, NSString *keyPath, id value)
+{
   CKCAssertNotNil(keyPath, @"Must have a non-nil keyPath");
-
-  NSMutableDictionary *originalValues = objc_getAssociatedObject(view, &kOptimisticViewMutationOriginalValuesAssociatedObjectKey);
-  if (originalValues == nil) {
-    originalValues = [NSMutableDictionary dictionary];
-    objc_setAssociatedObject(view, &kOptimisticViewMutationOriginalValuesAssociatedObjectKey, originalValues, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-  }
-
-  if (originalValues[keyPath] == nil) {
-    // First mutation for this keypath; store the old value.
-    originalValues[keyPath] = [view valueForKeyPath:keyPath] ?: [NSNull null];
-  }
-
-  [view setValue:value forKeyPath:keyPath];
+  CKPerformOptimisticViewMutation(view, &keyPathGetter, &keyPathSetter, value, keyPath);
 }
 
 void CKResetOptimisticMutationsForView(UIView *view)
 {
-  NSDictionary *originalValues = objc_getAssociatedObject(view, &kOptimisticViewMutationOriginalValuesAssociatedObjectKey);
-  if (originalValues) {
-    for (NSString *keyPath in originalValues) {
-      id value = originalValues[keyPath];
-      [view setValue:(value == [NSNull null] ? nil : value) forKeyPath:keyPath];
-    }
-    objc_setAssociatedObject(view, &kOptimisticViewMutationOriginalValuesAssociatedObjectKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  NSArray *mutations = [objc_getAssociatedObject(view, &kOptimisticViewMutationMutationsAssociatedObjectKey) copy];
+  objc_setAssociatedObject(view, &kOptimisticViewMutationMutationsAssociatedObjectKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  // We must tear down the mutations in the *reverse* order in which they were applied, or we could end up restoring
+  // the wrong value.
+  for (CKOptimisticViewMutationTeardown teardown in [mutations reverseObjectEnumerator]) {
+    teardown(view);
   }
 }

--- a/ComponentKitTests/CKOptimisticViewMutationsTests.mm
+++ b/ComponentKitTests/CKOptimisticViewMutationsTests.mm
@@ -10,6 +10,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <ComponentKit/CKButtonComponent.h>
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentAnimation.h>
 #import <ComponentKit/CKComponentLifecycleManager.h>
@@ -23,9 +24,8 @@
 
 - (void)testOptimisticViewMutationIsTornDown
 {
-  CKComponent *blueComponent = [CKComponent newWithView:{[UIView class], {
-    {@selector(setBackgroundColor:), [UIColor blueColor]},
-  }} size:{}];
+  CKComponent *blueComponent =
+  [CKComponent newWithView:{[UIView class], {{@selector(setBackgroundColor:), [UIColor blueColor]}}} size:{}];
   CKComponentLifecycleManager *clm = [[CKComponentLifecycleManager alloc] init];
   [clm updateWithState:{
     .layout = [blueComponent layoutThatFits:{{0, 0}, {10, 10}} parentSize:kCKComponentParentSizeUndefined]
@@ -44,6 +44,76 @@
   [clm detachFromView];
   [clm attachToView:container];
   XCTAssertEqualObjects(view.backgroundColor, [UIColor blueColor], @"Expected blue to be reset by OptimisticViewMutation");
+}
+
+- (void)testTwoSequentialOptimisticViewMutationsAreTornDown
+{
+  CKComponent *blueComponent =
+  [CKComponent newWithView:{[UIView class], {{@selector(setBackgroundColor:), [UIColor blueColor]}}} size:{}];
+  CKComponentLifecycleManager *clm = [[CKComponentLifecycleManager alloc] init];
+  [clm updateWithState:{
+    .layout = [blueComponent layoutThatFits:{{0, 0}, {10, 10}} parentSize:kCKComponentParentSizeUndefined]
+  }];
+
+  UIView *container = [[UIView alloc] init];
+  [clm attachToView:container];
+
+  UIView *view = [blueComponent viewContext].view;
+  XCTAssertEqualObjects(view.backgroundColor, [UIColor blueColor], @"Expected blue view");
+
+  CKPerformOptimisticViewMutation(view, @"backgroundColor", [UIColor redColor]);
+  CKPerformOptimisticViewMutation(view, @"backgroundColor", [UIColor yellowColor]);
+  XCTAssertEqualObjects(view.backgroundColor, [UIColor yellowColor], @"Expected optimistic red mutation");
+
+  // detaching and reattaching to the view should reset it back to blue.
+  [clm detachFromView];
+  [clm attachToView:container];
+  XCTAssertEqualObjects(view.backgroundColor, [UIColor blueColor], @"Expected blue to be reset by OptimisticViewMutation");
+}
+
+- (void)testFunctionBasedViewMutationsAreAppliedAndTornDownCorrectly
+{
+  CKButtonComponent *button =
+  [CKButtonComponent
+   newWithTitles:{{UIControlStateNormal, @"Original"}}
+   titleColors:{}
+   images:{}
+   backgroundImages:{}
+   titleFont:nil
+   selected:NO
+   enabled:YES
+   action:NULL
+   size:{}
+   attributes:{}
+   accessibilityConfiguration:{}];
+   CKComponentLifecycleManager *clm = [[CKComponentLifecycleManager alloc] init];
+  [clm updateWithState:{
+    .layout = [button layoutThatFits:{{0, 0}, {10, 10}} parentSize:kCKComponentParentSizeUndefined]
+  }];
+
+  UIView *container = [[UIView alloc] init];
+  [clm attachToView:container];
+
+  UIButton *view = (UIButton *)[button viewContext].view;
+  XCTAssertEqualObjects([view titleForState:UIControlStateNormal], @"Original");
+
+  CKPerformOptimisticViewMutation(view, &buttonTitleGetter, &buttonTitleSetter, @"NewValue");
+  XCTAssertEqualObjects([view titleForState:UIControlStateNormal], @"NewValue");
+
+  // detaching and reattaching to the view should reset it back to blue.
+  [clm detachFromView];
+  [clm attachToView:container];
+  XCTAssertEqualObjects([view titleForState:UIControlStateNormal], @"Original", @"Expected title to be reset by OptimisticViewMutation");
+}
+
+static id buttonTitleGetter(UIView *button, id context)
+{
+  return [(UIButton *)button titleForState:UIControlStateNormal];
+}
+
+static void buttonTitleSetter(UIView *button, id value, id context)
+{
+  [(UIButton *)button setTitle:value forState:UIControlStateNormal];
 }
 
 @end

--- a/ComponentKitTests/CKOptimisticViewMutationsTests.mm
+++ b/ComponentKitTests/CKOptimisticViewMutationsTests.mm
@@ -63,7 +63,7 @@
 
   CKPerformOptimisticViewMutation(view, @"backgroundColor", [UIColor redColor]);
   CKPerformOptimisticViewMutation(view, @"backgroundColor", [UIColor yellowColor]);
-  XCTAssertEqualObjects(view.backgroundColor, [UIColor yellowColor], @"Expected optimistic red mutation");
+  XCTAssertEqualObjects(view.backgroundColor, [UIColor yellowColor], @"Expected view to yellow after second optimistic mutation");
 
   // detaching and reattaching to the view should reset it back to blue.
   [clm detachFromView];


### PR DESCRIPTION
Sometimes an optimistic view mutation may want to affect the view in a way that cannot be expressed as a keypath; for example, a UIButton's title.

This pull request adds a new API for expressing these optimistic view mutations and introduces tests for it.