### PR TITLE
Change CKOffMainThreadDeleter to use function pointers instead of blocks

### DIFF
--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -22,12 +22,16 @@
 
 using namespace CK::Component;
 
+static void _deleteComponentLayoutChild(void *target)
+{
+  delete (std::vector<CKComponentLayoutChild> *)target;
+}
+
 void CKOffMainThreadDeleter::operator()(std::vector<CKComponentLayoutChild> *target)
 {
   if ([NSThread isMainThread]) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      delete target;
-    });
+    // use dispatch_async_f to avoid block allocations
+    dispatch_async_f(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), target, &_deleteComponentLayoutChild);
   } else {
     delete target;
   }


### PR DESCRIPTION
This function is on pretty hot path and allocating a block is
unnecessary for such a simple and static a function.