### PR TITLE
Move component scope collision detection to component layout

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		18644AE51B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE11B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm */; };
 		18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */; };
 		18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */; };
+		2DBF1D7A1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2DBF1D7B1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */; };
 		2DF899011CDD4064003C3507 /* ReferenceImages_IOS9 in Resources */ = {isa = PBXBuildFile; fileRef = 2DF899001CDD4064003C3507 /* ReferenceImages_IOS9 */; };
 		39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */; };
 		497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */; };
@@ -479,6 +481,8 @@
 		18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStatefulViewReusePoolTests.mm; sourceTree = "<group>"; };
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
+		2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKDetectComponentScopeCollisions.h; sourceTree = "<group>"; };
+		2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKDetectComponentScopeCollisions.mm; sourceTree = "<group>"; };
 		2DF899001CDD4064003C3507 /* ReferenceImages_IOS9 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS9; sourceTree = "<group>"; };
 		39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDataSourceAttachControllerTests.mm; sourceTree = "<group>"; };
 		497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceTests.mm; sourceTree = "<group>"; };
@@ -1202,6 +1206,8 @@
 				D0B47B091CBD926700BB33CE /* CKComponentScopeRoot.mm */,
 				D0B47B0A1CBD926700BB33CE /* CKComponentScopeRootInternal.h */,
 				D0B47B0B1CBD926700BB33CE /* CKComponentScopeTypes.h */,
+				2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */,
+				2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */,
 				D0B47B0C1CBD926700BB33CE /* CKThreadLocalComponentScope.h */,
 				D0B47B0D1CBD926700BB33CE /* CKThreadLocalComponentScope.mm */,
 			);
@@ -1658,6 +1664,7 @@
 				D0B47D711CBD948E00BB33CE /* CKAsyncLayer.h in Headers */,
 				D0B47D6E1CBD948E00BB33CE /* CKTextKitShadower.h in Headers */,
 				D0B47D0D1CBD948E00BB33CE /* CKComponentScopeRoot.h in Headers */,
+				2DBF1D7A1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h in Headers */,
 				D0B47CE81CBD948E00BB33CE /* CKAssert.h in Headers */,
 				D0B47D6C1CBD948E00BB33CE /* CKTextKitRenderer.h in Headers */,
 				D0B47D101CBD948E00BB33CE /* CKThreadLocalComponentScope.h in Headers */,
@@ -2154,6 +2161,7 @@
 				D0B47CB71CBD943400BB33CE /* CKStaticLayoutComponent.mm in Sources */,
 				D0B47CB81CBD943400BB33CE /* CKStatefulViewComponent.mm in Sources */,
 				D0B47CB91CBD943400BB33CE /* CKStatefulViewComponentController.mm in Sources */,
+				2DBF1D7B1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm in Sources */,
 				D0B47CBA1CBD943400BB33CE /* CKStatefulViewReusePool.mm in Sources */,
 				D0B47CBB1CBD943400BB33CE /* CKTransactionalComponentDataSource.mm in Sources */,
 				D0B47CBC1CBD943400BB33CE /* CKTransactionalComponentDataSourceAppliedChanges.mm in Sources */,

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -295,7 +295,7 @@ static void *kRootComponentMountedViewKey = &kRootComponentMountedViewKey;
   return _scopeHandle.controller;
 }
 
-- (NSNumber *)scopeFrameToken
+- (id<NSObject>)scopeFrameToken
 {
   return _scopeHandle ? @(_scopeHandle.globalIdentifier) : nil;
 }

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -295,7 +295,7 @@ static void *kRootComponentMountedViewKey = &kRootComponentMountedViewKey;
   return _scopeHandle.controller;
 }
 
-- (id)scopeFrameToken
+- (NSNumber *)scopeFrameToken
 {
   return _scopeHandle ? @(_scopeHandle.globalIdentifier) : nil;
 }

--- a/ComponentKit/Core/CKComponentInternal.h
+++ b/ComponentKit/Core/CKComponentInternal.h
@@ -65,7 +65,7 @@
 @property (nonatomic, weak) UIView *rootComponentMountedView;
 
 /** For internal use only; don't touch this. */
-@property (nonatomic, strong, readonly) NSNumber *scopeFrameToken;
+@property (nonatomic, strong, readonly) id<NSObject> scopeFrameToken;
 
 @end
 

--- a/ComponentKit/Core/CKComponentInternal.h
+++ b/ComponentKit/Core/CKComponentInternal.h
@@ -65,7 +65,7 @@
 @property (nonatomic, weak) UIView *rootComponentMountedView;
 
 /** For internal use only; don't touch this. */
-@property (nonatomic, strong, readonly) id scopeFrameToken;
+@property (nonatomic, strong, readonly) NSNumber *scopeFrameToken;
 
 @end
 

--- a/ComponentKit/Core/CKComponentLayout.h
+++ b/ComponentKit/Core/CKComponentLayout.h
@@ -62,10 +62,17 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
                               CKComponent *supercomponent);
 
 /**
- This exists as a safe alternative to layoutThatFits:parentSize: by guarding against nil components
- @param component The component being laid out
- @param sizeRange The size range for laying out the component
- @param parentSize The size of the parent of the component being laid out
+ Safely computes the layout of the given top-level component by guarding against nil components.
+ @param component The top-level component to compute the layout for.
+ @param sizeRange The size range to compute the component layout within.
+ */
+CKComponentLayout CKComputeTopLevelComponentLayout(CKComponent *component, const CKSizeRange &sizeRange);
+
+/**
+ Safely computes the layout of the given component by guarding against nil components.
+ @param component The component to compute the layout for.
+ @param sizeRange The size range to compute the component layout within.
+ @param parentSize The parent size of the component to compute the layout for.
  */
 CKComponentLayout CKComputeComponentLayout(CKComponent *component,
                                            const CKSizeRange &sizeRange,

--- a/ComponentKit/Core/CKComponentLayout.h
+++ b/ComponentKit/Core/CKComponentLayout.h
@@ -67,9 +67,9 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
  @param sizeRange The size range for laying out the component
  @param parentSize The size of the parent of the component being laid out
  */
-CKComponentLayout CKComponentComputeLayout(CKComponent *component,
+CKComponentLayout CKComputeComponentLayout(CKComponent *component,
                                            const CKSizeRange &sizeRange,
-                                           CGSize parentSize);
+                                           const CGSize parentSize);
 
 /** Unmounts all components returned by a previous call to CKMountComponentLayout. */
 void CKUnmountComponents(NSSet *componentsToUnmount);

--- a/ComponentKit/Core/CKComponentLayout.h
+++ b/ComponentKit/Core/CKComponentLayout.h
@@ -62,11 +62,11 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
                               CKComponent *supercomponent);
 
 /**
- Safely computes the layout of the given top-level component by guarding against nil components.
- @param component The top-level component to compute the layout for.
+ Safely computes the layout of the given root component by guarding against nil components.
+ @param rootComponent The root component to compute the layout for.
  @param sizeRange The size range to compute the component layout within.
  */
-CKComponentLayout CKComputeTopLevelComponentLayout(CKComponent *component, const CKSizeRange &sizeRange);
+CKComponentLayout CKComputeRootComponentLayout(CKComponent *rootComponent, const CKSizeRange &sizeRange);
 
 /**
  Safely computes the layout of the given component by guarding against nil components.

--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -93,9 +93,9 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
   return mountedComponents;
 }
 
-CKComponentLayout CKComponentComputeLayout(CKComponent *component,
+CKComponentLayout CKComputeComponentLayout(CKComponent *component,
                                            const CKSizeRange &sizeRange,
-                                           CGSize parentSize)
+                                           const CGSize parentSize)
 {
   return component ? [component layoutThatFits:sizeRange parentSize:parentSize] : (CKComponentLayout){};
 }

--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -94,9 +94,9 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
   return mountedComponents;
 }
 
-CKComponentLayout CKComputeTopLevelComponentLayout(CKComponent *component, const CKSizeRange &sizeRange)
+CKComponentLayout CKComputeRootComponentLayout(CKComponent *rootComponent, const CKSizeRange &sizeRange)
 {
-  const CKComponentLayout layout = CKComputeComponentLayout(component, sizeRange, sizeRange.max);
+  const CKComponentLayout layout = CKComputeComponentLayout(rootComponent, sizeRange, sizeRange.max);
   CKDetectComponentScopeCollisions(layout);
   return layout;
 }

--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -18,6 +18,7 @@
 #import "ComponentUtilities.h"
 #import "CKComponentInternal.h"
 #import "CKComponentSubclass.h"
+#import "CKDetectComponentScopeCollisions.h"
 #import "CKTransactionalComponentDataSourceItemInternal.h"
 
 using namespace CK::Component;
@@ -95,7 +96,9 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
 
 CKComponentLayout CKComputeTopLevelComponentLayout(CKComponent *component, const CKSizeRange &sizeRange)
 {
-  return CKComputeComponentLayout(component, sizeRange, sizeRange.max);
+  const CKComponentLayout layout = CKComputeComponentLayout(component, sizeRange, sizeRange.max);
+  CKDetectComponentScopeCollisions(layout);
+  return layout;
 }
 
 CKComponentLayout CKComputeComponentLayout(CKComponent *component,

--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -93,6 +93,11 @@ NSSet *CKMountComponentLayout(const CKComponentLayout &layout,
   return mountedComponents;
 }
 
+CKComponentLayout CKComputeTopLevelComponentLayout(CKComponent *component, const CKSizeRange &sizeRange)
+{
+  return CKComputeComponentLayout(component, sizeRange, sizeRange.max);
+}
+
 CKComponentLayout CKComputeComponentLayout(CKComponent *component,
                                            const CKSizeRange &sizeRange,
                                            const CGSize parentSize)

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -94,7 +94,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
     return [_componentProvider componentForModel:model context:context];
   });
 
-  const CKComponentLayout layout = CKComponentComputeLayout(result.component, constrainedSize, constrainedSize.max);
+  const CKComponentLayout layout = CKComputeComponentLayout(result.component, constrainedSize, constrainedSize.max);
 
   _previousRoot = result.scopeRoot;
   _pendingStateUpdates.clear();

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -94,7 +94,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
     return [_componentProvider componentForModel:model context:context];
   });
 
-  const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, constrainedSize);
+  const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, constrainedSize);
 
   _previousRoot = result.scopeRoot;
   _pendingStateUpdates.clear();

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -94,7 +94,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
     return [_componentProvider componentForModel:model context:context];
   });
 
-  const CKComponentLayout layout = CKComputeComponentLayout(result.component, constrainedSize, constrainedSize.max);
+  const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, constrainedSize);
 
   _previousRoot = result.scopeRoot;
   _pendingStateUpdates.clear();

--- a/ComponentKit/Core/CKComponentMemoizer.h
+++ b/ComponentKit/Core/CKComponentMemoizer.h
@@ -47,7 +47,7 @@ id CKMemoize(CKMemoizationKey memoizationKey, id (^block)(void));
  
    result = CKBuildComponent(...)
  
-   layout = CKComponentComputeLayout(result.component, constrainedSize, constrainedSize.max);
+   layout = CKComputeComponentLayout(result.component, constrainedSize, constrainedSize.max);
  
     ...
    CKMountComponentLayout(layout)

--- a/ComponentKit/Core/CKComponentSubclass.h
+++ b/ComponentKit/Core/CKComponentSubclass.h
@@ -37,7 +37,7 @@ extern CGSize const kCKComponentParentSizeUndefined;
  Call this on children components to compute their layouts within your implementation of -computeLayoutThatFits:.
 
  @warning You may not override this method. Override -computeLayoutThatFits: instead.
- @warning In almost all cases, prefer the use of CKComponentComputeLayout in CKcomponentLayout
+ @warning In almost all cases, prefer the use of CKComputeComponentLayout in CKComponentLayout
 
  @param constrainedSize Specifies a minimum and maximum size. The receiver must choose a size that is in this range.
  @param parentSize The parent component's size. If the parent component does not have a final size in a given dimension,

--- a/ComponentKit/Core/Scope/CKComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKComponentScope.mm
@@ -1,4 +1,4 @@
-  /*
+/*
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -68,7 +68,7 @@ namespace std {
   if (!pair.frame->_children.empty() && (existingChild != pair.frame->_children.end())) {
     /*
      The component was involved in a scope collision and the scope handle needs to be reacquired.
-     In the event of a component scope collision the component scope frames reuses the existing scope handle; any
+     In the event of a component scope collision the component scope frame reuses the existing scope handle; any
      existing state will be made available to the component that introduced the scope collision. This leads to some
      interesting side effects:
 

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -65,7 +65,7 @@ namespace std {
   }
 
   const auto existingChild = pair.frame->_children.find({componentClass, identifier});
-  if (existingChild != pair.frame->_children.end()) {
+  if (!pair.frame->_children.empty() && (existingChild != pair.frame->_children.end())) {
     /*
      The component was involved in a scope collision and the scope handle needs to be reacquired.
      In the event of a component scope collision the component scope frames reuses the existing scope handle; any

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -80,7 +80,7 @@ namespace std {
      component scope collision detection to component layout makes it possible to create multiple components that may
      normally result in a scope collision even if only one component actually makes it to layout.
     */
-    CKComponentScopeHandle *newHandle = [existingChild->second.handle newHandleWillBeReacquiredDueToScopeCollision];
+    CKComponentScopeHandle *newHandle = [existingChild->second.handle newHandleToBeReacquiredDueToScopeCollision];
     CKComponentScopeFrame *newChild = [[CKComponentScopeFrame alloc] initWithHandle:newHandle];
     return {.frame = newChild, .equivalentPreviousFrame = existingChildFrameOfEquivalentPreviousFrame};
   }

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -80,8 +80,7 @@ namespace std {
   [newRoot registerAnnounceableEventsForController:newHandle.controller];
 
   CKComponentScopeFrame *newChild = [[CKComponentScopeFrame alloc] initWithHandle:newHandle];
-  const auto __attribute__((unused)) result = pair.frame->_children.insert({{componentClass, identifier}, newChild});
-  CKAssert(result.second, @"Scope collision: attempting to create duplicate scope %@:%@", componentClass, identifier);
+  pair.frame->_children.insert({{componentClass, identifier}, newChild});
   return {.frame = newChild, .equivalentPreviousFrame = existingChildFrameOfEquivalentPreviousFrame};
 }
 

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -38,7 +38,7 @@
 - (instancetype)newHandleWithStateUpdates:(const CKComponentStateUpdateMap &)stateUpdates;
 
 /** Creates a new, but identical, instance of the scope handle that will be reacquired due to a scope collision. */
-- (instancetype)newHandleWillBeReacquiredDueToScopeCollision;
+- (instancetype)newHandleToBeReacquiredDueToScopeCollision;
 
 - (void)updateState:(id (^)(id))updateFunction mode:(CKUpdateMode)mode;
 

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -30,6 +30,7 @@
 
 /** Creates a conceptually brand new scope handle */
 - (instancetype)initWithListener:(id<CKComponentStateListener>)listener
+                globalIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
                   rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
                   componentClass:(Class)componentClass
              initialStateCreator:(id (^)(void))initialStateCreator;

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -22,26 +22,28 @@
 @interface CKComponentScopeHandle : NSObject
 
 /**
- This is only meant to be called when constructing a component and as part of the implementation
- itself. This method looks to see if the currently defined scope matches that of the argument and
- if so it returns the state-scope frame corresponding to the current scope. Otherwise it returns nil.
+ This method looks to see if the currently defined scope matches that of the given component; if so it returns the
+ handle corresponding to the current scope. Otherwise it returns nil.
+ This is only meant to be called when constructing a component and as part of the implementation itself.
  */
 + (instancetype)handleForComponent:(CKComponent *)component;
 
 /** Creates a conceptually brand new scope handle */
 - (instancetype)initWithListener:(id<CKComponentStateListener>)listener
-                globalIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
                   rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
                   componentClass:(Class)componentClass
              initialStateCreator:(id (^)(void))initialStateCreator;
 
-/** Creates a new version of an existing scope handle that incorporates the given state updates */
+/** Creates a new instance of the scope handle that incorporates the given state updates. */
 - (instancetype)newHandleWithStateUpdates:(const CKComponentStateUpdateMap &)stateUpdates;
+
+/** Creates a new, but identical, instance of the scope handle that will be reacquired due to a scope collision. */
+- (instancetype)newHandleWillBeReacquiredDueToScopeCollision;
+
+- (void)updateState:(id (^)(id))updateFunction mode:(CKUpdateMode)mode;
 
 @property (nonatomic, strong, readonly) CKComponentController *controller;
 @property (nonatomic, strong, readonly) id state;
 @property (nonatomic, readonly) CKComponentScopeHandleIdentifier globalIdentifier;
-
-- (void)updateState:(id (^)(id))updateFunction mode:(CKUpdateMode)mode;
 
 @end

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -46,13 +46,14 @@
 }
 
 - (instancetype)initWithListener:(id<CKComponentStateListener>)listener
+                globalIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
                   rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
                   componentClass:(Class)componentClass
              initialStateCreator:(id (^)(void))initialStateCreator
 {
   static int32_t nextGlobalIdentifier = 0;
   return [self initWithListener:listener
-               globalIdentifier:OSAtomicIncrement32(&nextGlobalIdentifier)
+               globalIdentifier:(globalIdentifier > 0) ? globalIdentifier : OSAtomicIncrement32(&nextGlobalIdentifier)
                  rootIdentifier:rootIdentifier
                  componentClass:componentClass
                           state:initialStateCreator ? initialStateCreator() : [componentClass initialState]

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -92,7 +92,7 @@
                                                controller:_controller];
 }
 
-- (instancetype)newHandleWillBeReacquiredDueToScopeCollision
+- (instancetype)newHandleToBeReacquiredDueToScopeCollision
 {
   return [[CKComponentScopeHandle alloc] initWithListener:_listener
                                          globalIdentifier:_globalIdentifier

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -46,14 +46,13 @@
 }
 
 - (instancetype)initWithListener:(id<CKComponentStateListener>)listener
-                globalIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
                   rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
                   componentClass:(Class)componentClass
              initialStateCreator:(id (^)(void))initialStateCreator
 {
   static int32_t nextGlobalIdentifier = 0;
   return [self initWithListener:listener
-               globalIdentifier:(globalIdentifier > 0) ? globalIdentifier : OSAtomicIncrement32(&nextGlobalIdentifier)
+               globalIdentifier:OSAtomicIncrement32(&nextGlobalIdentifier)
                  rootIdentifier:rootIdentifier
                  componentClass:componentClass
                           state:initialStateCreator ? initialStateCreator() : [componentClass initialState]
@@ -90,6 +89,16 @@
                                            rootIdentifier:_rootIdentifier
                                            componentClass:_componentClass
                                                     state:updatedState
+                                               controller:_controller];
+}
+
+- (instancetype)newHandleWillBeReacquiredDueToScopeCollision
+{
+  return [[CKComponentScopeHandle alloc] initWithListener:_listener
+                                         globalIdentifier:_globalIdentifier
+                                           rootIdentifier:_rootIdentifier
+                                           componentClass:_componentClass
+                                                    state:_state
                                                controller:_controller];
 }
 

--- a/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.h
+++ b/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+struct CKComponentLayout;
+
+/**
+ Detects, and reports, component scope collisions found in the given component layout.
+ @param layout The top-level component layout of the component hierarchy.
+ */
+void CKDetectComponentScopeCollisions(const CKComponentLayout &layout);

--- a/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
+++ b/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKDetectComponentScopeCollisions.h"
+
+#import <queue>
+
+#import "CKAssert.h"
+#import "CKComponentInternal.h"
+
+void CKDetectComponentScopeCollisions(const CKComponentLayout &layout)
+{
+#if DEBUG
+  std::queue<const CKComponentLayout> queue;
+  NSMutableSet<NSNumber *> *previouslySeenScopeFrameTokens = [NSMutableSet new];
+  queue.push(layout);
+  while (!queue.empty()) {
+    auto currentLayout = queue.front();
+    queue.pop();
+    NSNumber *scopeFrameToken = [currentLayout.component scopeFrameToken];
+    if (scopeFrameToken && [previouslySeenScopeFrameTokens containsObject:scopeFrameToken]) {
+      CKCFailAssert(@"Scope collision. Attempting to create duplicate scope for component %@", [currentLayout.component class]);
+    }
+    if (scopeFrameToken) {
+      [previouslySeenScopeFrameTokens addObject:scopeFrameToken];
+    }
+    if (currentLayout.children) {
+      for (auto child : *currentLayout.children) {
+        queue.push(child.layout);
+      }
+    }
+  }
+#endif
+}

--- a/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
+++ b/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
@@ -19,12 +19,12 @@ void CKDetectComponentScopeCollisions(const CKComponentLayout &layout)
 {
 #if DEBUG
   std::queue<const CKComponentLayout> queue;
-  NSMutableSet<NSNumber *> *previouslySeenScopeFrameTokens = [NSMutableSet new];
+  NSMutableSet<id<NSObject>> *previouslySeenScopeFrameTokens = [NSMutableSet new];
   queue.push(layout);
   while (!queue.empty()) {
     auto currentLayout = queue.front();
     queue.pop();
-    NSNumber *scopeFrameToken = [currentLayout.component scopeFrameToken];
+    id<NSObject> scopeFrameToken = [currentLayout.component scopeFrameToken];
     if (scopeFrameToken && [previouslySeenScopeFrameTokens containsObject:scopeFrameToken]) {
       CKCFailAssert(@"Scope collision. Attempting to create duplicate scope for component %@", [currentLayout.component class]);
     }

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -95,7 +95,7 @@ struct CKComponentHostingViewInputs {
   [self _synchronouslyUpdateComponentIfNeeded];
   const CGSize size = self.bounds.size;
   if (_mountedLayout.component != _component || !CGSizeEqualToSize(_mountedLayout.size, size)) {
-    _mountedLayout = CKComponentComputeLayout(_component, {size, size}, size);
+    _mountedLayout = CKComputeComponentLayout(_component, {size, size}, size);
   }
   _mountedComponents = [CKMountComponentLayout(_mountedLayout, _containerView, _mountedComponents, nil) copy];
 }
@@ -105,7 +105,7 @@ struct CKComponentHostingViewInputs {
   CKAssertMainThread();
   [self _synchronouslyUpdateComponentIfNeeded];
   const CKSizeRange constrainedSize = [_sizeRangeProvider sizeRangeForBoundingSize:size];
-  return CKComponentComputeLayout(_component, constrainedSize, constrainedSize.max).size;
+  return CKComputeComponentLayout(_component, constrainedSize, constrainedSize.max).size;
 }
 
 #pragma mark - Accessors

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -95,7 +95,7 @@ struct CKComponentHostingViewInputs {
   [self _synchronouslyUpdateComponentIfNeeded];
   const CGSize size = self.bounds.size;
   if (_mountedLayout.component != _component || !CGSizeEqualToSize(_mountedLayout.size, size)) {
-    _mountedLayout = CKComputeComponentLayout(_component, {size, size}, size);
+    _mountedLayout = CKComputeTopLevelComponentLayout(_component, {size, size});
   }
   _mountedComponents = [CKMountComponentLayout(_mountedLayout, _containerView, _mountedComponents, nil) copy];
 }
@@ -105,7 +105,7 @@ struct CKComponentHostingViewInputs {
   CKAssertMainThread();
   [self _synchronouslyUpdateComponentIfNeeded];
   const CKSizeRange constrainedSize = [_sizeRangeProvider sizeRangeForBoundingSize:size];
-  return CKComputeComponentLayout(_component, constrainedSize, constrainedSize.max).size;
+  return CKComputeTopLevelComponentLayout(_component, constrainedSize).size;
 }
 
 #pragma mark - Accessors

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -95,7 +95,7 @@ struct CKComponentHostingViewInputs {
   [self _synchronouslyUpdateComponentIfNeeded];
   const CGSize size = self.bounds.size;
   if (_mountedLayout.component != _component || !CGSizeEqualToSize(_mountedLayout.size, size)) {
-    _mountedLayout = CKComputeTopLevelComponentLayout(_component, {size, size});
+    _mountedLayout = CKComputeRootComponentLayout(_component, {size, size});
   }
   _mountedComponents = [CKMountComponentLayout(_mountedLayout, _containerView, _mountedComponents, nil) copy];
 }
@@ -105,7 +105,7 @@ struct CKComponentHostingViewInputs {
   CKAssertMainThread();
   [self _synchronouslyUpdateComponentIfNeeded];
   const CKSizeRange constrainedSize = [_sizeRangeProvider sizeRangeForBoundingSize:size];
-  return CKComputeTopLevelComponentLayout(_component, constrainedSize).size;
+  return CKComputeRootComponentLayout(_component, constrainedSize).size;
 }
 
 #pragma mark - Accessors

--- a/ComponentKit/LayoutComponents/CKCenterLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKCenterLayoutComponent.mm
@@ -50,7 +50,7 @@
     (_centeringOptions & CKCenterLayoutComponentCenteringX) != 0 ? 0 : constrainedSize.min.width,
     (_centeringOptions & CKCenterLayoutComponentCenteringY) != 0 ? 0 : constrainedSize.min.height,
   };
-  const CKComponentLayout childLayout = CKComponentComputeLayout(_child, {minChildSize, {constrainedSize.max}}, size);
+  const CKComponentLayout childLayout = CKComputeComponentLayout(_child, {minChildSize, {constrainedSize.max}}, size);
 
   // If we have an undetermined height or width, use the child size to define the layout
   // size

--- a/ComponentKit/LayoutComponents/CKOverlayLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKOverlayLayoutComponent.mm
@@ -56,7 +56,7 @@
     contentsLayout.size,
     _overlay ? std::vector<CKComponentLayoutChild> {
       {{0,0}, contentsLayout},
-      {{0,0}, CKComponentComputeLayout(_overlay, {contentsLayout.size, contentsLayout.size}, contentsLayout.size)}
+      {{0,0}, CKComputeComponentLayout(_overlay, {contentsLayout.size, contentsLayout.size}, contentsLayout.size)}
     } : std::vector<CKComponentLayoutChild> {
       {{0,0}, contentsLayout},
     }

--- a/ComponentKit/LayoutComponents/CKRatioLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKRatioLayoutComponent.mm
@@ -64,7 +64,7 @@
   // If there is no max size in *either* dimension, we can't apply the ratio, so just pass our size range through.
   const CKSizeRange childRange = (bestSize == sizeOptions.end()) ? constrainedSize : CKSizeRange(*bestSize, *bestSize);
   const CGSize parentSize = (bestSize == sizeOptions.end()) ? kCKComponentParentSizeUndefined : *bestSize;
-  const CKComponentLayout childLayout = CKComponentComputeLayout(_component, childRange, parentSize);
+  const CKComponentLayout childLayout = CKComputeComponentLayout(_component, childRange, parentSize);
   return {self, childLayout.size, {{{0,0}, childLayout}}};
 }
 

--- a/ComponentKit/LayoutComponents/CKStackUnpositionedLayout.mm
+++ b/ComponentKit/LayoutComponents/CKStackUnpositionedLayout.mm
@@ -35,7 +35,7 @@ static CKComponentLayout crossChildLayout(const CKStackLayoutComponentChild &chi
   // stretched children will have a cross dimension of at least crossMin
   const CGFloat childCrossMin = alignItems == CKStackLayoutAlignItemsStretch ? crossMin : 0;
   const CKSizeRange childSizeRange = directionSizeRange(style.direction, stackMin, stackMax, childCrossMin, crossMax);
-  return CKComponentComputeLayout(child.component, childSizeRange, size);
+  return CKComputeComponentLayout(child.component, childSizeRange, size);
 }
 
 /**

--- a/ComponentKit/LayoutComponents/CKStaticLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKStaticLayoutComponent.mm
@@ -48,7 +48,7 @@
       constrainedSize.max.height - child.position.y
     };
     CKSizeRange childConstraint = child.size.resolveSizeRange(size, {{0,0}, autoMaxSize});
-    return CKComponentLayoutChild({child.position, CKComponentComputeLayout(child.component, childConstraint, size)});
+    return CKComponentLayoutChild({child.position, CKComputeComponentLayout(child.component, childConstraint, size)});
   });
 
   if (isnan(size.width)) {

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -62,7 +62,7 @@
     const CKBuildComponentResult result = CKBuildComponent([oldItem scopeRoot], {}, ^{
       return [componentProvider componentForModel:model context:context];
     });
-    const CKComponentLayout layout = CKComponentComputeLayout(result.component, sizeRange, sizeRange.max);
+    const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
 
     [section replaceObjectAtIndex:indexPath.item withObject:
      [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot]];
@@ -108,7 +108,7 @@
     const CKBuildComponentResult result = CKBuildComponent([CKComponentScopeRoot rootWithListener:_stateListener], {}, ^{
       return [componentProvider componentForModel:model context:context];
     });
-    const CKComponentLayout layout = CKComponentComputeLayout(result.component, sizeRange, sizeRange.max);
+    const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
     insertedItemsBySection[indexPath.section][indexPath.item] =
     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
   }];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -62,7 +62,7 @@
     const CKBuildComponentResult result = CKBuildComponent([oldItem scopeRoot], {}, ^{
       return [componentProvider componentForModel:model context:context];
     });
-    const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
+    const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
 
     [section replaceObjectAtIndex:indexPath.item withObject:
      [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot]];
@@ -108,7 +108,7 @@
     const CKBuildComponentResult result = CKBuildComponent([CKComponentScopeRoot rootWithListener:_stateListener], {}, ^{
       return [componentProvider componentForModel:model context:context];
     });
-    const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
+    const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
     insertedItemsBySection[indexPath.section][indexPath.item] =
     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
   }];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -62,7 +62,7 @@
     const CKBuildComponentResult result = CKBuildComponent([oldItem scopeRoot], {}, ^{
       return [componentProvider componentForModel:model context:context];
     });
-    const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
+    const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
 
     [section replaceObjectAtIndex:indexPath.item withObject:
      [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot]];
@@ -108,7 +108,7 @@
     const CKBuildComponentResult result = CKBuildComponent([CKComponentScopeRoot rootWithListener:_stateListener], {}, ^{
       return [componentProvider componentForModel:model context:context];
     });
-    const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
+    const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
     insertedItemsBySection[indexPath.section][indexPath.item] =
     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
   }];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -49,7 +49,7 @@
       const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
         return [componentProvider componentForModel:[item model] context:context];
       });
-      const CKComponentLayout layout = CKComponentComputeLayout(result.component, sizeRange, sizeRange.max);
+      const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
       [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                    model:[item model]
                                                                                scopeRoot:result.scopeRoot]];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -49,7 +49,7 @@
       const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
         return [componentProvider componentForModel:[item model] context:context];
       });
-      const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
+      const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
       [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                    model:[item model]
                                                                                scopeRoot:result.scopeRoot]];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -49,7 +49,7 @@
       const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
         return [componentProvider componentForModel:[item model] context:context];
       });
-      const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
+      const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
       [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                    model:[item model]
                                                                                scopeRoot:result.scopeRoot]];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -55,7 +55,7 @@
 
       CKTransactionalComponentDataSourceItem *newItem;
       if (onlySizeRangeChanged) {
-        const CKComponentLayout layout = CKComponentComputeLayout(item.layout.component, sizeRange, sizeRange.max);
+        const CKComponentLayout layout = CKComputeComponentLayout(item.layout.component, sizeRange, sizeRange.max);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
                                                                        scopeRoot:[item scopeRoot]];
@@ -63,7 +63,7 @@
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });
-        const CKComponentLayout layout = CKComponentComputeLayout(result.component, sizeRange, sizeRange.max);
+        const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
                                                                        scopeRoot:result.scopeRoot];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -55,7 +55,7 @@
 
       CKTransactionalComponentDataSourceItem *newItem;
       if (onlySizeRangeChanged) {
-        const CKComponentLayout layout = CKComputeComponentLayout(item.layout.component, sizeRange, sizeRange.max);
+        const CKComponentLayout layout = CKComputeTopLevelComponentLayout(item.layout.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
                                                                        scopeRoot:[item scopeRoot]];
@@ -63,7 +63,7 @@
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });
-        const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
+        const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
                                                                        scopeRoot:result.scopeRoot];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -55,7 +55,7 @@
 
       CKTransactionalComponentDataSourceItem *newItem;
       if (onlySizeRangeChanged) {
-        const CKComponentLayout layout = CKComputeTopLevelComponentLayout(item.layout.component, sizeRange);
+        const CKComponentLayout layout = CKComputeRootComponentLayout(item.layout.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
                                                                        scopeRoot:[item scopeRoot]];
@@ -63,7 +63,7 @@
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });
-        const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
+        const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
                                                                        scopeRoot:result.scopeRoot];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -53,7 +53,7 @@
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], stateUpdatesForItem->second, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });
-        const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
+        const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
         [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                      model:[item model]
                                                                                  scopeRoot:result.scopeRoot]];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -53,7 +53,7 @@
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], stateUpdatesForItem->second, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });
-        const CKComponentLayout layout = CKComponentComputeLayout(result.component, sizeRange, sizeRange.max);
+        const CKComponentLayout layout = CKComputeComponentLayout(result.component, sizeRange, sizeRange.max);
         [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                      model:[item model]
                                                                                  scopeRoot:result.scopeRoot]];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -53,7 +53,7 @@
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], stateUpdatesForItem->second, ^{
           return [componentProvider componentForModel:[item model] context:context];
         });
-        const CKComponentLayout layout = CKComputeTopLevelComponentLayout(result.component, sizeRange);
+        const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
         [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                      model:[item model]
                                                                                  scopeRoot:result.scopeRoot]];

--- a/ComponentKitTests/Scope/CKComponentScopeTests.mm
+++ b/ComponentKitTests/Scope/CKComponentScopeTests.mm
@@ -23,44 +23,42 @@
 
 @implementation CKComponentScopeTests
 
-- (void)testThreadLocalStateIsEmptyByDefault
+#pragma mark - Thread Local Component Scope
+
+- (void)testThreadLocalComponentScopeIsEmptyWhenNoScopeExists
 {
   XCTAssertTrue(CKThreadLocalComponentScope::currentScope() == nullptr);
 }
 
-- (void)testThreadLocalStateIsNotNullAfterCreatingThreadStateScope
+- (void)testThreadLocalComponentScopeIsNotEmptyWhenTheScopeExists
 {
   CKThreadLocalComponentScope threadScope([CKComponentScopeRoot rootWithListener:nil], {});
   XCTAssertTrue(CKThreadLocalComponentScope::currentScope() != nullptr);
 }
 
-- (void)testThreadLocalStateStoresPassedInFrameAsEquivalentPreviousFrame
+- (void)testThreadLocalComponentScopeStoresTheProvidedFrameAsTheEquivalentPreviousFrame
 {
   CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
   CKThreadLocalComponentScope threadScope(root, {});
   XCTAssertEqualObjects(CKThreadLocalComponentScope::currentScope()->stack.top().equivalentPreviousFrame, root.rootFrame);
 }
 
-- (void)testThreadLocalStatePushesChildScope
+- (void)testThreadLocalComponentScopePushesChildComponentScope
 {
   CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
   CKThreadLocalComponentScope threadScope(root, {});
-
   CKComponentScopeFrame *rootFrame = CKThreadLocalComponentScope::currentScope()->stack.top().frame;
-
   CKComponentScope scope([CKCompositeComponent class]);
-
   CKComponentScopeFrame *currentFrame = CKThreadLocalComponentScope::currentScope()->stack.top().frame;
   XCTAssertTrue(currentFrame != rootFrame);
 }
 
-#pragma mark - Scope Frame
+#pragma mark - Component Scope Frame
 
-- (void)testFrameIsPoppedWhenScopeCloses
+- (void)testComponentScopeFrameIsPoppedWhenComponentScopeCloses
 {
   CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
   CKThreadLocalComponentScope threadScope(root, {});
-
   CKComponentScopeFrame *rootFrame = CKThreadLocalComponentScope::currentScope()->stack.top().frame;
   {
     CKComponentScope scope([CKCompositeComponent class], @"moose");
@@ -69,19 +67,9 @@
   XCTAssertEqual(CKThreadLocalComponentScope::currentScope()->stack.top().frame, rootFrame);
 }
 
-- (void)testHasChildScopeIsTrueEvenAfterScopeClosesAndPopsAFrame
-{
-  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-  CKThreadLocalComponentScope threadScope(root, {});
+#pragma mark - Component Scope State
 
-  CKComponentScopeFrame *rootFrame = CKThreadLocalComponentScope::currentScope()->stack.top().frame;
-  {
-    CKComponentScope scope([CKCompositeComponent class], @"moose");
-  }
-  XCTAssertEqual(CKThreadLocalComponentScope::currentScope()->stack.top().frame, rootFrame);
-}
-
-- (void)testThreadStateScopeAcquiringPreviousScopeStateOneLevelDown
+- (void)testComponentScopeStateIsAcquiredFromPreviousComponentScopeStateOneLevelDown
 {
   CKComponentScopeRoot *root1 = [CKComponentScopeRoot rootWithListener:nil];
   CKComponentScopeRoot *root2;
@@ -89,12 +77,9 @@
     CKThreadLocalComponentScope threadScope(root1, {});
     {
       CKComponentScope scope([CKCompositeComponent class], @"macaque", ^{ return @42; });
-      id __unused state = scope.state();
     }
-
     root2 = CKThreadLocalComponentScope::currentScope()->newScopeRoot;
   }
-
   {
     CKThreadLocalComponentScope threadScope(root2, {});
     {
@@ -111,30 +96,7 @@
   }
 }
 
-- (void)testThreadStateScopeAcquiringPreviousScopeGlobalIdentifierOneLevelDown
-{
-  CKComponentScopeRoot *root1 = [CKComponentScopeRoot rootWithListener:nil];
-  CKComponentScopeRoot *root2;
-  int32_t childGlobalIdentifier;
-  {
-    CKThreadLocalComponentScope threadScope(root1, {});
-    {
-      CKComponentScope scope([CKCompositeComponent class], @"macaque");
-      childGlobalIdentifier = CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier;
-    }
-    root2 = CKThreadLocalComponentScope::currentScope()->newScopeRoot;
-  }
-
-  {
-    CKThreadLocalComponentScope threadScope(root2, {});
-    {
-      CKComponentScope scope([CKCompositeComponent class], @"macaque");
-      XCTAssertEqual(childGlobalIdentifier, CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier);
-    }
-  }
-}
-
-- (void)testThreadStateScopeAcquiringPreviousScopeStateOneLevelDownWithSibling
+- (void)testComponentScopeStateIsAcquiredFromPreviousComponentScopeStateOneLevelDownWithSibling
 {
   CKComponentScopeRoot *root1 = [CKComponentScopeRoot rootWithListener:nil];
   CKComponentScopeRoot *root2;
@@ -148,10 +110,8 @@
       CKComponentScope scope([CKCompositeComponent class], @"patrick", ^{ return @"HAHA"; });
       id __unused state = scope.state();
     }
-
     root2 = CKThreadLocalComponentScope::currentScope()->newScopeRoot;
   }
-
   {
     CKThreadLocalComponentScope threadScope(root2, {});
     {
@@ -169,7 +129,7 @@
   }
 }
 
-- (void)testThreadStateScopeAcquiringPreviousScopeStateOneLevelDownWithSiblingThatDoesNotAcquire
+- (void)testComponentScopeStateIsAcquiredFromPreviousComponentScopeStateOneLevelDownWithSiblingThatDoesNotAcquire
 {
   CKComponentScopeRoot *root1 = [CKComponentScopeRoot rootWithListener:nil];
   CKComponentScopeRoot *root2;
@@ -183,10 +143,8 @@
       CKComponentScope scope([CKCompositeComponent class], @"perched", ^{ return @"raven"; });
       id __unused state = scope.state();
     }
-
     root2 = CKThreadLocalComponentScope::currentScope()->newScopeRoot;
   }
-
   {
     CKThreadLocalComponentScope threadScope(root2, {});
     {
@@ -199,6 +157,64 @@
       CKComponentScope scope([CKCompositeComponent class], @"chamber", ^{ return @"door"; });
       id state = scope.state();
       XCTAssertEqualObjects(state, @"door");
+    }
+  }
+}
+
+#pragma mark - Component Scope Handle Global Identifier
+
+- (void)testComponentScopeHandleGlobalIdentifierIsAcquiredFromPreviousComponentScopeOneLevelDown
+{
+  CKComponentScopeRoot *root1 = [CKComponentScopeRoot rootWithListener:nil];
+  CKComponentScopeRoot *root2;
+  int32_t globalIdentifier;
+  {
+    CKThreadLocalComponentScope threadScope(root1, {});
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      globalIdentifier = CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier;
+    }
+    root2 = CKThreadLocalComponentScope::currentScope()->newScopeRoot;
+  }
+  {
+    CKThreadLocalComponentScope threadScope(root2, {});
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      XCTAssertEqual(globalIdentifier, CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier);
+    }
+  }
+}
+
+- (void)testComponentScopeHandleGlobalIdentifierIsNotTheSameBetweenSiblings
+{
+  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
+  {
+    CKThreadLocalComponentScope threadScope(root, {});
+    int32_t globalIdentifier;
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"moose");
+      globalIdentifier = CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier;
+    }
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      XCTAssertNotEqual(globalIdentifier, CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier);
+    }
+  }
+}
+
+- (void)testComponentScopeHandleGlobalIdentifierIsTheSameBetweenSiblingsWithComponentScopeCollision
+{
+  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
+  {
+    CKThreadLocalComponentScope threadScope(root, {});
+    int32_t globalIdentifier;
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      globalIdentifier = CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier;
+    }
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      XCTAssertEqual(globalIdentifier, CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier);
     }
   }
 }


### PR DESCRIPTION
Component scope collision detection originally took place at component scope creation, during component preparation. This behavior wasn't entirely correct because components created during component preparation may not actually make their way to component layout.

Instead ComponentKit should attempt to detect component scope collisions during component layout. Not only is this more correct behavior but it also allows us to provide (not yet implemented) a more actionable error message.

To support this new behavior a couple of other notable changes were required:

1. Propagate the global identifiers of component scope handles with the same component class and identifier pair
2. Add a new `CKComputeTopLevelComponentLayout` function responsible for computing component layouts for top-level components; this avoids a problem where component scope collision detection would only be applied to portions of the overall component layout

I plan to improve the error message reported during component scope collisions in a follow up. For now the behavior is largely the same except for the omission of the scope identifier (it isn't available during component layout) in the component scope collision error message.