### PR TITLE
Removed accessibilityIdentifier from context (fixes issue #590)

### DIFF
--- a/ComponentKit/Accessibility/CKComponentAccessibility.h
+++ b/ComponentKit/Accessibility/CKComponentAccessibility.h
@@ -43,17 +43,16 @@ private:
 
 /**
  Separate structure to handle accessibility as we want the components infrastructure to decide wether to use it or not depending if accessibility is enabled or not.
+ Not to be confused with accessibilityIdentifier which is used for automation to identify elements on the screen. To set the identifier pass in {@selector(setAccessibilityIdentifier:), @"accessibilityId"} with the viewConfiguration's attributes
  */
 struct CKComponentAccessibilityContext {
   NSNumber *isAccessibilityElement;
-  NSString *accessibilityIdentifier;
   CKComponentAccessibilityTextAttribute accessibilityLabel;
   CKComponentAction accessibilityComponentAction;
 
   bool operator==(const CKComponentAccessibilityContext &other) const
   {
-    return CKObjectIsEqual(other.accessibilityIdentifier, accessibilityIdentifier)
-    && CKObjectIsEqual(other.isAccessibilityElement, isAccessibilityElement)
+    return CKObjectIsEqual(other.isAccessibilityElement, isAccessibilityElement)
     && CKObjectIsEqual(other.accessibilityLabel.value(), accessibilityLabel.value())
     && other.accessibilityComponentAction == accessibilityComponentAction;
   }
@@ -64,8 +63,8 @@ namespace CK {
     namespace Accessibility {
       /**
        @return A modified configuration for which extra view component attributes have been added to handle accessibility.
-       e.g: The following view configuration `{[UIView class], {{@selector(setBlah:), @"Blah"}}, {.accessibilityIdentifier = @"accessibilityId"}}`
-       will become `{[UIView class], {{@selector(setBlah:), @"Blah"}, {@selector(setAccessibilityIdentifier), @"accessibilityId"}}, {.accessibilityIdentifier = @"accessibilityId"}}`
+       e.g: The following view configuration `{[UIView class], {{@selector(setBlah:), @"Blah"}}, {.accessibilityLabel = @"accessibilityLabel"}}`
+       will become `{[UIView class], {{@selector(setBlah:), @"Blah"}, {@selector(setAccessibilityLabel), @"accessibilityLabel"}}, {.accessibilityLabel = @"accessibilityLabel"}}`
        */
       CKComponentViewConfiguration AccessibleViewConfiguration(const CKComponentViewConfiguration &viewConfiguration);
       BOOL IsAccessibilityEnabled();

--- a/ComponentKit/Accessibility/CKComponentAccessibility.mm
+++ b/ComponentKit/Accessibility/CKComponentAccessibility.mm
@@ -20,9 +20,6 @@
 static CKViewComponentAttributeValueMap ViewAttributesFromAccessibilityContext(const CKComponentAccessibilityContext &accessibilityContext)
 {
   CKViewComponentAttributeValueMap accessibilityAttributes;
-  if (accessibilityContext.accessibilityIdentifier) {
-    accessibilityAttributes[@selector(setAccessibilityIdentifier:)] = accessibilityContext.accessibilityIdentifier;
-  }
   if (accessibilityContext.isAccessibilityElement) {
     accessibilityAttributes[@selector(setIsAccessibilityElement:)] = accessibilityContext.isAccessibilityElement;
   }

--- a/ComponentKit/Components/CKButtonComponent.h
+++ b/ComponentKit/Components/CKButtonComponent.h
@@ -14,8 +14,6 @@
 #import <ComponentKit/CKComponentAction.h>
 
 struct CKButtonComponentAccessibilityConfiguration {
-  /** Accessibility identifier */
-  NSString *accessibilityIdentifier;
   /** Accessibility label for the button. If one is not provided, the button title will be used as a label */
   NSString *accessibilityLabel;
 };

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -146,7 +146,6 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
     {titleFontAttribute, titleFont},
     {@selector(setSelected:), @(selected)},
     {@selector(setEnabled:), @(enabled)},
-    {@selector(setAccessibilityIdentifier:), accessibilityConfiguration.accessibilityIdentifier},
     CKComponentActionAttribute(action, UIControlEventTouchUpInside),
   });
 
@@ -161,7 +160,6 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                             [UIButton class],
                             std::move(attributes),
                             {
-                              .accessibilityIdentifier = accessibilityConfiguration.accessibilityIdentifier,
                               .accessibilityLabel = accessibilityConfiguration.accessibilityLabel,
                               .accessibilityComponentAction = enabled ? action : NULL
                             }

--- a/ComponentKitTests/CKComponentAccessibilityTests.mm
+++ b/ComponentKitTests/CKComponentAccessibilityTests.mm
@@ -33,15 +33,15 @@ using namespace CK::Component::Accessibility;
 {
   CKComponentViewConfiguration viewConfiguration = {
     [UIView class],
-    {{@selector(setBlah:), @"Blah"}},
+    {{@selector(setBlah:), @"Blah"}, {@selector(setAccessibilityIdentifier:), @"batman"}},
     {
-      .accessibilityIdentifier = @"batman", .isAccessibilityElement = @NO, .accessibilityLabel = ^{ return @"accessibleBatman"; }
+      .isAccessibilityElement = @NO, .accessibilityLabel = ^{ return @"accessibleBatman"; }
     }};
   CKComponentViewConfiguration expectedViewConfiguration = {
     [UIView class],
     {{@selector(setBlah:), @"Blah"}, {@selector(setAccessibilityIdentifier:), @"batman"}, {@selector(setAccessibilityLabel:), @"accessibleBatman"}, {@selector(setIsAccessibilityElement:), @NO}},
     {
-      .accessibilityIdentifier = @"batman", .isAccessibilityElement = @NO, .accessibilityLabel = @"accessibleBatman"
+      .isAccessibilityElement = @NO, .accessibilityLabel = @"accessibleBatman"
     }};
   XCTAssertTrue(AccessibleViewConfiguration(viewConfiguration) == expectedViewConfiguration, @"Accessibility attributes were applied incorrectly");
 }

--- a/ComponentTextKit/CKTextComponent.h
+++ b/ComponentTextKit/CKTextComponent.h
@@ -16,7 +16,6 @@
 struct CKTextComponentAccessibilityContext
 {
   NSNumber *isAccessibilityElement;
-  NSString *accessibilityIdentifier;
   NSNumber *providesAccessibleElements;
   /**
    Should rarely be used, the component's text will be used by default.

--- a/ComponentTextKit/CKTextComponent.mm
+++ b/ComponentTextKit/CKTextComponent.mm
@@ -74,7 +74,6 @@ static CKTextKitRenderer *rendererForAttributes(CKTextKitAttributes &attributes,
     std::move(copiedMap),
     {
       .isAccessibilityElement = options.accessibilityContext.isAccessibilityElement,
-      .accessibilityIdentifier = options.accessibilityContext.accessibilityIdentifier,
       .accessibilityLabel = options.accessibilityContext.accessibilityLabel.hasText()
       ? options.accessibilityContext.accessibilityLabel : ^{ return copyAttributes.attributedString.string; }
     }


### PR DESCRIPTION
We shouldn't pass in accessibilityIdentifier as part of accessibility context as it's an automation feature, not an accessibility one. See issue #590 for more details.

This diff removes the use of the identifier, forcing people to pass it in correctly and consistently if they want to use it (e.g. `{@selector(setAccessibilityIdentifier:), @"accessibilityId"}` in attributes).

Test plan: ran all the tests, made sure that passing accessibilityIdentifier correctly works as expected