### PR TITLE
Introduce CK_ASSERTIONS_ENABLED

### DIFF
--- a/ComponentKit/Base/CKAssert.h
+++ b/ComponentKit/Base/CKAssert.h
@@ -10,6 +10,12 @@
 
 #pragma once
 
+#if !defined(NS_BLOCK_ASSERTIONS)
+#define CK_ASSERTIONS_ENABLED 1
+#else
+#define CK_ASSERTIONS_ENABLED 0
+#endif
+
 #define CKAssert(condition, description, ...) NSAssert(condition, description, ##__VA_ARGS__)
 #define CKCAssert(condition, description, ...) NSCAssert(condition, description, ##__VA_ARGS__)
 

--- a/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
+++ b/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
@@ -17,7 +17,7 @@
 
 void CKDetectComponentScopeCollisions(const CKComponentLayout &layout)
 {
-#if DEBUG
+#if CK_ASSERTIONS_ENABLED
   std::queue<const CKComponentLayout> queue;
   NSMutableSet<id<NSObject>> *previouslySeenScopeFrameTokens = [NSMutableSet new];
   queue.push(layout);


### PR DESCRIPTION
To test I added `CKCFailAssert` immediate after `#if CK_ASSERTIONS_ENABLED` in `CKDetectComponentScopeCollisions`. I then ran the example app with both `Debug` and `Release` build configurations and verified that the former triggered the assertion, the latter did not.