### PR TITLE
Add ability to temporarily override CKThreadLocalComponentScope

### DIFF
--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
@@ -28,3 +28,12 @@ public:
   const CKComponentStateUpdateMap stateUpdates;
   std::stack<CKComponentScopeFramePair> stack;
 };
+
+class CKThreadLocalComponentScopeOverride {
+public:
+  CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope);
+  ~CKThreadLocalComponentScopeOverride();
+
+private:
+  CKThreadLocalComponentScope *const previousScope;
+};

--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
@@ -29,6 +29,10 @@ public:
   std::stack<CKComponentScopeFramePair> stack;
 };
 
+/**
+ Temporarily overrides the current thread's component scope.
+ Use for testing and advanced integration purposes only.
+ */
 class CKThreadLocalComponentScopeOverride {
 public:
   CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope);

--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.mm
@@ -47,3 +47,14 @@ CKThreadLocalComponentScope::~CKThreadLocalComponentScope()
   CKCAssert(stack.empty(), @"Didn't expect stack to contain anything in destructor");
   pthread_setspecific(_threadKey(), nullptr);
 }
+
+CKThreadLocalComponentScopeOverride::CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope)
+: previousScope(CKThreadLocalComponentScope::currentScope())
+{
+  pthread_setspecific(_threadKey(), scope);
+}
+
+CKThreadLocalComponentScopeOverride::~CKThreadLocalComponentScopeOverride()
+{
+  pthread_setspecific(_threadKey(), previousScope);
+}


### PR DESCRIPTION
For some threading experiments we're doing, we need to able to temporarily override the current thread local component scope. I encapsulated this in a C++ class so cleanup is guaranteed to happen.