### PR TITLE
Don't dispatch the deleter off the main thread if the layout vector is empty

### DIFF
--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -22,12 +22,16 @@
 
 using namespace CK::Component;
 
+static void _deleteComponentLayoutChild(void *target)
+{
+  delete (std::vector<CKComponentLayoutChild> *)target;
+}
+
 void CKOffMainThreadDeleter::operator()(std::vector<CKComponentLayoutChild> *target)
 {
   if ([NSThread isMainThread]) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      delete target;
-    });
+    // use dispatch_async_f to avoid block allocations
+    dispatch_async_f(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), target, &_deleteComponentLayoutChild);
   } else {
     delete target;
   }


### PR DESCRIPTION
When you set an CKComponentLayout ivar for the first time, it’s already
initialized with the default initializer. Because of this, the deleter
is triggered with an empty array. The innocuous setting of an ivar
therefore triggers a semi-expensive dispatch. It’s a lot cheaper to
simply delete this object on the main thread.