### PR TITLE
Share the initial component scope tree across all colliding component scopes

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -68,6 +68,7 @@ namespace std {
   if (!pair.frame->_children.empty() && (existingChild != pair.frame->_children.end())) {
     /*
      The component was involved in a scope collision and the scope handle needs to be reacquired.
+
      In the event of a component scope collision the component scope frame reuses the existing scope handle; any
      existing state will be made available to the component that introduced the scope collision. This leads to some
      interesting side effects:
@@ -82,6 +83,75 @@ namespace std {
     */
     CKComponentScopeHandle *newHandle = [existingChild->second.handle newHandleToBeReacquiredDueToScopeCollision];
     CKComponentScopeFrame *newChild = [[CKComponentScopeFrame alloc] initWithHandle:newHandle];
+    /*
+     Share the initial component scope tree across all colliding component scopes.
+
+     This behavior ensures the initial component scope tree "wins" in the event of a component scope collision:
+
+                                       +-------+         +-------+         +-------+
+                                       |       |         |       |         |       |
+                                       |   A   |         |   A   |         |   A   |
+                                       |      1|         |      2|         |      3|
+                                       +-------+         +-------+         +-------+
+                                           |                 | collision       | collision
+                                           +-----------------+-----------------+
+                                          /|\
+                                         / | \
+                                        /  |  \
+                                   +---+ +---+ +---+
+                                   | 1 | | 2 | | 3 |
+                                   +---+ +---+ +---+
+                                    / \
+                                +---+ +---+
+                                | 4 | | 5 |
+                                +---+ +---+
+
+     In the example above the component scope frames labeled as "A" are involved in scope collisions. Notice that only
+     one component scope tree exists for all three component scope frames involved in the collision. Any component state
+     or component controllers present in the intial component scope tree are now present across all colliding component
+     scope frames.
+
+     Now assume each component scope frame above is paired with a matching component. Component scope frame A1 belongs
+     to component A1, colliding component scope frame A2 belongs to component A2, component scope frame 4 belongs to
+     component 4, and so on. If only component A2 finds its way to layout (i.e. both A1 and A3 were simply created and
+     not added to the component hierarchy) this behavior guarantees that component 4 always acquires the same component
+     scope.
+
+     Compare this behavior to the behavior that would exist if the initial component scope tree were not shared:
+
+                                       +-------+         +-------+         +-------+
+                                       |       |         |       |         |       |
+                                       |   A   |         |   A   |         |   A   |
+                                       |      1|         |      2|         |      3|
+                                       +-------+         +-------+         +-------+
+                                           |                 | collision       | collision
+                                           +-----------------+-----------------+
+                                          /|\                .                /|\
+                                         / | \               .               / | \
+                                        /  |  \              .              /  |  \
+                                   +---+ +---+ +---+                   +---+ +---+ +---+
+                                   | 1 | | 2 | | 3 |                   | 1'| | 2'| | 3'|
+                                   +---+ +---+ +---+                   +---+ +---+ +---+
+                                    / \                                 / \
+                                +---+ +---+                         +---+ +---+
+                                | 4 | | 5 |                         | 4'| | 5'|
+                                +---+ +---+                         +---+ +---+
+
+     Each component scope frame participating in the collision now has its own unique component scope tree. For
+     component scope frame A1 the outcome is largely the same. Things get a bit more interesting for A2 and A3. Notice
+     that A3 now has its own, nearly identical, component scope tree. The structure is the same but the component state
+     and component controllers are different.
+
+     Problems arise when the component that owns component scope frame A3 is added to the component hierarchy. Suppose
+     A3 is building its component scope tree for the first time. The component that owns component scope frame 4' will
+     acquire a new component controller as there is no equivalent previous frame, as expected.
+
+     The next time the component hierarchy is created (e.g. after a component state update) component scope frame 4'
+     actually finds component scope frame 4 in the equivalent previous frame. This means component 4' will acquire a
+     DIFFERENT component controller instance than it had originally. Why? Because the component scope frame above
+     component scope frame A will only ever have A1 as a child because A1 was inserted before A2 and A3.
+     */
+    newChild->_children = existingChild->second->_children;
     return {.frame = newChild, .equivalentPreviousFrame = existingChildFrameOfEquivalentPreviousFrame};
   }
 

--- a/ComponentKitTests/Scope/CKComponentScopeTests.mm
+++ b/ComponentKitTests/Scope/CKComponentScopeTests.mm
@@ -53,6 +53,28 @@
   XCTAssertTrue(currentFrame != rootFrame);
 }
 
+- (void)testThreadLocalComponentScopeCanBeOverridden
+{
+  CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
+  CKThreadLocalComponentScope threadScope(root, {});
+  CKThreadLocalComponentScope *threadScopePtr = &threadScope;
+
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    XCTAssertTrue(CKThreadLocalComponentScope::currentScope() == nullptr);
+    {
+      CKThreadLocalComponentScopeOverride scopeOverride(threadScopePtr);
+      XCTAssertEqual(CKThreadLocalComponentScope::currentScope(), threadScopePtr);
+    }
+    XCTAssertTrue(CKThreadLocalComponentScope::currentScope() == nullptr);
+    dispatch_semaphore_signal(sema);
+  });
+  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC));
+  dispatch_semaphore_wait(sema, timeout);
+
+  XCTAssertEqual(CKThreadLocalComponentScope::currentScope(), threadScopePtr);
+}
+
 #pragma mark - Component Scope Frame
 
 - (void)testComponentScopeFrameIsPoppedWhenComponentScopeCloses
@@ -219,28 +241,67 @@
   }
 }
 
-#pragma mark - Component scope override
-
-- (void)testComponentScopeCanBeOverridden
+- (void)testComponentScopeHandleGlobalIdentifierIsTheSameBetweenDescendantsWithComponentScopeCollision
 {
   CKComponentScopeRoot *root = [CKComponentScopeRoot rootWithListener:nil];
-  CKThreadLocalComponentScope threadScope(root, {});
-  CKThreadLocalComponentScope *threadScopePtr = &threadScope;
-
-  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    XCTAssertTrue(CKThreadLocalComponentScope::currentScope() == nullptr);
+  {
+    CKThreadLocalComponentScope threadScope(root, {});
+    int32_t globalIdentifier;
     {
-      CKThreadLocalComponentScopeOverride scopeOverride(threadScopePtr);
-      XCTAssertEqual(CKThreadLocalComponentScope::currentScope(), threadScopePtr);
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      {
+        CKComponentScope scope([CKCompositeComponent class], @"moose");
+        globalIdentifier = CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier;
+      }
     }
-    XCTAssertTrue(CKThreadLocalComponentScope::currentScope() == nullptr);
-    dispatch_semaphore_signal(sema);
-  });
-  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC));
-  dispatch_semaphore_wait(sema, timeout);
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      {
+        CKComponentScope scope([CKCompositeComponent class], @"moose");
+        XCTAssertEqual(globalIdentifier, CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier);
+      }
+    }
+  }
+}
 
-  XCTAssertEqual(CKThreadLocalComponentScope::currentScope(), threadScopePtr);
+- (void)testComponentScopeHandleGlobalIdentifierIsTheSameBetweenDescendantsWithComponentScopeCollisionAcrossComponentScopeRoots
+{
+  CKComponentScopeRoot *root1 = [CKComponentScopeRoot rootWithListener:nil];
+  CKComponentScopeRoot *root2;
+  int32_t globalIdentifier;
+  {
+    CKThreadLocalComponentScope threadScope(root1, {});
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      {
+        CKComponentScope scope([CKCompositeComponent class], @"moose");
+      }
+    }
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      {
+        CKComponentScope scope([CKCompositeComponent class], @"moose");
+        globalIdentifier = CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier;
+      }
+    }
+    root2 = threadScope.newScopeRoot;
+  }
+  {
+    CKThreadLocalComponentScope threadScope(root2, {});
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      {
+        CKComponentScope scope([CKCompositeComponent class], @"moose");
+      }
+    }
+    {
+      CKComponentScope scope([CKCompositeComponent class], @"macaque");
+      {
+        CKComponentScope scope([CKCompositeComponent class], @"moose");
+        XCTAssertEqual(globalIdentifier, CKThreadLocalComponentScope::currentScope()->stack.top().frame.handle.globalIdentifier);
+      }
+    }
+  }
 }
 
 @end


### PR DESCRIPTION
See comment in `CKComponentScopeFrame` for details.