### PR TITLE
[ck] Fix controller.component = nil before mount

### DIFF
--- a/ComponentKit/Core/CKComponentController.h
+++ b/ComponentKit/Core/CKComponentController.h
@@ -79,4 +79,13 @@
  */
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
 
+/** 
+ Initializes a controller with the first generation of component. You should not directly initialize a controller,
+ they are initialized for you by the infrastructure.
+ */
+- (instancetype)initWithComponent:(CKComponent *)component NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 @end

--- a/ComponentKit/Core/CKComponentController.mm
+++ b/ComponentKit/Core/CKComponentController.mm
@@ -79,6 +79,14 @@ static void eraseAnimation(CKAppliedComponentAnimationMap &map, CKComponentAnima
   CKAppliedComponentAnimationMap _appliedAnimations;
 }
 
+- (instancetype)initWithComponent:(CKComponent *)component
+{
+  if (self = [super init]) {
+    _component = component;
+  }
+  return self;
+}
+
 - (void)willMount {}
 - (void)didMount {}
 - (void)willRemount {}

--- a/ComponentKit/Core/Scope/CKComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKComponentScope.mm
@@ -17,6 +17,7 @@
 CKComponentScope::~CKComponentScope()
 {
   if (_threadLocalScope != nullptr) {
+    [_scopeHandle resolve];
     _threadLocalScope->stack.pop();
   }
 }

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -163,8 +163,6 @@ namespace std {
                                       componentClass:componentClass
                                  initialStateCreator:initialStateCreator];
 
-  [newRoot registerAnnounceableEventsForController:newHandle.controller];
-
   CKComponentScopeFrame *newChild = [[CKComponentScopeFrame alloc] initWithHandle:newHandle];
   pair.frame->_children.insert({{componentClass, identifier}, newChild});
   return {.frame = newChild, .equivalentPreviousFrame = existingChildFrameOfEquivalentPreviousFrame};

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -42,6 +42,13 @@
 
 - (void)updateState:(id (^)(id))updateFunction mode:(CKUpdateMode)mode;
 
+/** Informs the scope handle that it should complete its configuration. This will generate the controller */
+- (void)resolve;
+
+/**
+ Should not be called until after handleForComponent:. The controller will assert (if assertions are compiled), and
+ return nil until `resolve` is called.
+ */
 @property (nonatomic, strong, readonly) CKComponentController *controller;
 @property (nonatomic, strong, readonly) id state;
 @property (nonatomic, readonly) CKComponentScopeHandleIdentifier globalIdentifier;

--- a/ComponentKitTests/CKComponentControllerLifecycleMethodTests.mm
+++ b/ComponentKitTests/CKComponentControllerLifecycleMethodTests.mm
@@ -53,7 +53,6 @@ struct CKLifecycleMethodCounts {
 @end
 
 @interface CKLifecycleComponent : CKComponent
-@property (nonatomic, weak) CKLifecycleComponentController *controller;
 - (void)updateStateToIncludeNewAttribute;
 @end
 
@@ -73,7 +72,7 @@ struct CKLifecycleMethodCounts {
 
   UIView *view = [[UIView alloc] init];
   [clm attachToView:view];
-  CKLifecycleComponentController *controller = ((CKLifecycleComponent *)state.layout.component).controller;
+  CKLifecycleComponentController *controller = (CKLifecycleComponentController *)state.layout.component.controller;
   const CKLifecycleMethodCounts actual = controller->_counts;
   const CKLifecycleMethodCounts expected = {.willMount = 1, .didMount = 1};
   XCTAssertTrue(actual == expected, @"Expected %@ but got %@", expected.description(), actual.description());
@@ -90,7 +89,7 @@ struct CKLifecycleMethodCounts {
   [clm attachToView:view];
   [clm detachFromView];
 
-  CKLifecycleComponentController *controller = ((CKLifecycleComponent *)state.layout.component).controller;
+  CKLifecycleComponentController *controller = (CKLifecycleComponentController *)state.layout.component.controller;
   const CKLifecycleMethodCounts actual = controller->_counts;
   const CKLifecycleMethodCounts expected = {.willMount = 1, .didMount = 1, .willUnmount = 1, .didUnmount = 1};
   XCTAssertTrue(actual == expected, @"Expected %@ but got %@", expected.description(), actual.description());
@@ -108,7 +107,7 @@ struct CKLifecycleMethodCounts {
   CKLifecycleComponent *component = (CKLifecycleComponent *)state.layout.component;
   [component updateStateToIncludeNewAttribute];
 
-  CKLifecycleComponentController *controller = component.controller;
+  CKLifecycleComponentController *controller = (CKLifecycleComponentController *)component.controller;
   const CKLifecycleMethodCounts actual = controller->_counts;
   const CKLifecycleMethodCounts expected = {.willMount = 1, .didMount = 1, .willRemount = 1, .didRemount = 1};
   XCTAssertTrue(actual == expected, @"Expected %@ but got %@", expected.description(), actual.description());
@@ -126,7 +125,7 @@ struct CKLifecycleMethodCounts {
   [clm detachFromView];
 
   CKLifecycleComponent *component = (CKLifecycleComponent *)state.layout.component;
-  CKLifecycleComponentController *controller = component.controller;
+  CKLifecycleComponentController *controller = (CKLifecycleComponentController *)component.controller;
   {
     const CKLifecycleMethodCounts actual = controller->_counts;
     const CKLifecycleMethodCounts expected = {.willMount = 1, .didMount = 1, .willUnmount = 1, .didUnmount = 1};
@@ -177,12 +176,6 @@ struct CKLifecycleMethodCounts {
 @end
 
 @implementation CKLifecycleComponentController
-
-- (void)didUpdateComponent
-{
-  [super didUpdateComponent];
-  [(CKLifecycleComponent *)[self component] setController:self];
-}
 
 - (void)willMount { [super willMount]; _counts.willMount++; }
 - (void)didMount { [super didMount]; _counts.didMount++; }

--- a/ComponentKitTests/CKComponentControllerTests.mm
+++ b/ComponentKitTests/CKComponentControllerTests.mm
@@ -30,7 +30,7 @@
 @end
 
 @interface CKFooComponent : CKComponent
-@property (nonatomic, weak) CKFooComponentController *controller;
+- (CKFooComponentController *)controller;
 - (void)updateStateToIncludeNewAttribute;
 @end
 
@@ -41,12 +41,11 @@
   return [CKFooComponent new];
 }
 
-- (void)testThatCreatingComponentDoesNotInstantiateItsController
+- (void)testThatCreatingComponentCreatesAController
 {
   CKComponentTestRootScope scope;
-
   CKFooComponent *fooComponent = [CKFooComponent new];
-  XCTAssertNil(fooComponent.controller, @"Didn't expect creating a component to create a controller");
+  XCTAssertNotNil(fooComponent.controller);
 }
 
 - (void)testThatAttachingManagerInstantiatesComponentController
@@ -202,6 +201,12 @@
   return [super newWithView:{[UIView class], std::move(attrs)} size:{}];
 }
 
+- (CKFooComponentController *)controller
+{
+  // We provide this convenience method here to avoid having all the casts in the tests above.
+  return (CKFooComponentController *)[super controller];
+}
+
 - (void)updateStateToIncludeNewAttribute
 {
   [self updateState:^(id oldState){
@@ -221,7 +226,6 @@
 - (void)didUpdateComponent
 {
   [super didUpdateComponent];
-  ((CKFooComponent *)self.component).controller = self;
   _calledDidUpdateComponent = YES;
 }
 


### PR DESCRIPTION
As discussed in https://github.com/facebook/componentkit/issues/504
CKComponentController component can be nil until first mount. This diff
changes the initializer of CKComponentController to instead take in a
component on init, and changes the initialization order for controllers
inside scope handles.