### PR TITLE
Add main thread assertions for mount info

### DIFF
--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -101,6 +101,7 @@ struct CKComponentMountInfo {
 
 - (CKComponentViewContext)viewContext
 {
+  CKAssertMainThread();
   return _mountInfo ? _mountInfo->viewContext : CKComponentViewContext();
 }
 
@@ -111,6 +112,7 @@ struct CKComponentMountInfo {
                                     children:(std::shared_ptr<const std::vector<CKComponentLayoutChild>>)children
                               supercomponent:(CKComponent *)supercomponent
 {
+  CKAssertMainThread();
   // Taking a const ref to a temporary extends the lifetime of the temporary to the lifetime of the const ref
   const CKComponentViewConfiguration &viewConfiguration = CK::Component::Accessibility::IsAccessibilityEnabled() ? CK::Component::Accessibility::AccessibleViewConfiguration(_viewConfiguration) : _viewConfiguration;
 
@@ -154,6 +156,7 @@ struct CKComponentMountInfo {
 
 - (void)unmount
 {
+  CKAssertMainThread();
   if (_mountInfo != nullptr) {
     [_scopeHandle.controller componentWillUnmount:self];
     [self _relinquishMountedView];
@@ -164,12 +167,16 @@ struct CKComponentMountInfo {
 
 - (void)_relinquishMountedView
 {
-  UIView *view = _mountInfo->view;
-  if (view) {
-    CKAssert(view.ck_component == self, @"");
-    [_scopeHandle.controller component:self willRelinquishView:view];
-    view.ck_component = nil;
-    _mountInfo->view = nil;
+  CKAssertMainThread();
+  CKAssert(_mountInfo != nullptr, @"_mountInfo should not be null");
+  if (_mountInfo != nullptr) {
+    UIView *view = _mountInfo->view;
+    if (view) {
+      CKAssert(view.ck_component == self, @"");
+      [_scopeHandle.controller component:self willRelinquishView:view];
+      view.ck_component = nil;
+      _mountInfo->view = nil;
+    }
   }
 }
 
@@ -197,6 +204,7 @@ struct CKComponentMountInfo {
 
 - (UIView *)viewForAnimation
 {
+  CKAssertMainThread();
   return _mountInfo ? _mountInfo->view : nil;
 }
 
@@ -248,6 +256,7 @@ struct CKComponentMountInfo {
 
 - (id)nextResponderAfterController
 {
+  CKAssertMainThread();
   return (_mountInfo ? _mountInfo->supercomponent : nil) ?: [self rootComponentMountedView];
 }
 


### PR DESCRIPTION
_mountInfo is a mutable main-thread affined portion of the component. We don't lock on access, yet internally have some crashes due to what appears may be multithreaded access to the mount info. If any of this is ever accessed off-main, then you're likely to corrupt the heap, since you can't control when you are unmounted, and that pointer is unset on the main thread. There is no atomic barrier around the unique_ptr reset().