### PR TITLE
Install and update Carthage in build script

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "facebook/ios-snapshot-test-case" "2.1.0"
-github "erikdoe/ocmock" "v3.3"
+github "facebook/ios-snapshot-test-case" "2.1.2"
+github "erikdoe/ocmock" "v3.3.1"
 github "jspahrsummers/xcconfigs" "0.9"

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,9 @@ function tvos_ci() {
 }
 
 if [ "$MODE" = "ci" ]; then
+  brew install carthage
+  carthage update
+
   ios_ci ComponentKit test
   tvos_ci ComponentKit test
 


### PR DESCRIPTION
As noted in https://github.com/facebook/componentkit/pull/373, `build.sh` doesn't appear to be fully set up to build using Carthage. Hot-wiring here :). Looking good now.