### PR TITLE
Introduce a build matrix for Travis CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
+os: osx
 language: objective-c
-osx_image: xcode7.3
 
-script: ./build.sh ci
+install: carthage bootstrap
 
-# Whitelist for branches
+script:
+  - set -o pipefail
+  - xcodebuild clean test -project ComponentKit.xcodeproj $MATRIX_TARGET
+
+matrix:
+  include:
+    - osx_image: xcode7.3
+      env: MATRIX_TARGET="-scheme ComponentKit -sdk iphonesimulator9.3"
+    - osx_image: xcode7.3
+      env: MATRIX_TARGET="-scheme ComponentKitAppleTV -sdk appletvsimulator9.2"
+
 branches:
   only:
     - master


### PR DESCRIPTION
Let's try dropping the custom `build.sh` script and try let Travis CI do all the heavy lifting.

Odds are this won't work right off the bat so this is a bit of a work in progress.