### PR TITLE
Re-attach existing cells using new state to support animations in reloads

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 		2DF899011CDD4064003C3507 /* ReferenceImages_IOS9 in Resources */ = {isa = PBXBuildFile; fileRef = 2DF899001CDD4064003C3507 /* ReferenceImages_IOS9 */; };
 		39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */; };
 		497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */; };
+		49FA174E1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 49FA174D1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm */; };
 		991DE3411B3B308900AA05B2 /* CKComponentMemoizerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */; };
 		994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */; };
 		A2100E0D1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */; };
@@ -817,6 +818,7 @@
 		2DF899001CDD4064003C3507 /* ReferenceImages_IOS9 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS9; sourceTree = "<group>"; };
 		39B090BE1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDataSourceAttachControllerTests.mm; sourceTree = "<group>"; };
 		497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKCollectionViewTransactionalDataSourceTests.mm; sourceTree = "<group>"; };
+		49FA174D1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceIntegrationTests.mm; sourceTree = "<group>"; };
 		991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentMemoizerTests.mm; sourceTree = "<group>"; };
 		994EF6FA1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentDelegateAttributeTests.mm; sourceTree = "<group>"; };
 		A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm; sourceTree = "<group>"; };
@@ -1289,6 +1291,7 @@
 				A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */,
 				A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */,
 				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */,
+				49FA174D1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm */,
 				B761C8AA1CB36AAE00CDD03F /* CKTransactionalComponentDataSourceConfigurationTests.mm */,
 				B761C8AD1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm */,
 				B761C8B01CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm */,
@@ -2841,6 +2844,7 @@
 				B342DC701AC23EA900ACAC53 /* CKComponentDataSourceTestDelegate.mm in Sources */,
 				B342DC831AC23EA900ACAC53 /* CKTestRunLoopRunning.mm in Sources */,
 				B342DC731AC23EA900ACAC53 /* CKComponentGestureActionsTests.mm in Sources */,
+				49FA174E1D182C1200EA8126 /* CKTransactionalComponentDataSourceIntegrationTests.mm in Sources */,
 				18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */,
 				B342DC821AC23EA900ACAC53 /* CKSectionedArrayControllerTests.mm in Sources */,
 				A27C72751AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm in Sources */,

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceIntegrationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceIntegrationTests.mm
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import "CKComponent.h"
+#import "CKComponentProvider.h"
+#import "CKComponentScope.h"
+#import "CKComponentSubclass.h"
+#import "CKCompositeComponent.h"
+#import "CKComponentController.h"
+#import "CKCollectionViewTransactionalDataSource.h"
+#import "CKTransactionalComponentDataSourceConfiguration.h"
+#import "CKTransactionalComponentDataSourceChangeset.h"
+
+@interface CKTransactionalComponentDataSourceIntegrationTestComponent : CKCompositeComponent
+@end
+
+@implementation CKTransactionalComponentDataSourceIntegrationTestComponent
++ (instancetype)newWithIdentifier:(id)identifier {
+  CKComponentScope scope(self, identifier);
+  return [self newWithComponent:[CKComponent new]];
+}
+@end
+
+@interface CKTransactionalComponentDataSourceIntegrationTestComponentController : CKComponentController
+@property (strong) NSMutableArray *callbacks;
+@end
+
+@implementation CKTransactionalComponentDataSourceIntegrationTestComponentController
+- (instancetype)initWithComponent:(CKComponent *)component {
+  if ((self = [super initWithComponent:component])) {
+    self.callbacks = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)willUpdateComponent {
+  [super willUpdateComponent];
+  [self.callbacks addObject:NSStringFromSelector(_cmd)];
+}
+- (void)willRemount {
+  [super willRemount];
+  [self.callbacks addObject:NSStringFromSelector(_cmd)];
+}
+- (void)didRemount {
+  [super didRemount];
+  [self.callbacks addObject:NSStringFromSelector(_cmd)];
+}
+- (void)didUpdateComponent {
+  [super didUpdateComponent];
+  [self.callbacks addObject:NSStringFromSelector(_cmd)];
+}
+@end
+
+@interface CKTransactionalComponentDataSourceIntegrationTests : XCTestCase
+@property (strong) UICollectionViewController *collectionViewController;
+@property (strong) CKCollectionViewTransactionalDataSource *dataSource;
+@property (strong) NSMutableSet <CKComponent *> *components;
+@property (strong) CKTransactionalComponentDataSourceIntegrationTestComponentController *componentController;
+@end
+
+@implementation CKTransactionalComponentDataSourceIntegrationTests
+
+- (void)setUp {
+  [super setUp];
+
+  self.collectionViewController = [[UICollectionViewController alloc]
+                                   initWithCollectionViewLayout:[UICollectionViewFlowLayout new]];
+
+  CKTransactionalComponentDataSourceConfiguration *config = [[CKTransactionalComponentDataSourceConfiguration alloc]
+                                                             initWithComponentProvider:(id) self
+                                                             context:nil
+                                                             sizeRange:CKSizeRange({50, 50}, {50, 50})];
+
+  self.components = [NSMutableSet set];
+  self.dataSource = [[CKCollectionViewTransactionalDataSource alloc]
+                     initWithCollectionView:self.collectionViewController.collectionView
+                     supplementaryViewDataSource:nil
+                     configuration:config];
+
+  [self.dataSource applyChangeset:
+   [[[[CKTransactionalComponentDataSourceChangesetBuilder new]
+      withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+     withInsertedItems:@{ [NSIndexPath indexPathForItem:0 inSection:0] : @"" }]
+    build] mode:CKUpdateModeSynchronous userInfo:nil];
+
+  XCTAssertEqual(self.components.count, 1);
+  XCTAssertNotNil(self.components.anyObject.controller);
+  XCTAssertTrue([self.components.anyObject.controller isKindOfClass:[CKTransactionalComponentDataSourceIntegrationTestComponentController class]]);
+
+  self.componentController =
+  (CKTransactionalComponentDataSourceIntegrationTestComponentController*) self.components.anyObject.controller;
+}
+
+- (CKComponent *)componentForModel:(NSString*)model context:(id<NSObject>)context {
+  CKComponent *component = [CKTransactionalComponentDataSourceIntegrationTestComponent newWithIdentifier:@"TestComponent"];
+  [self.components addObject:component];
+  return component;
+}
+
+- (void)testUpdateModelShouldCreateNewComponentAndTriggerControllerCallbacksForRemount {
+  [self.dataSource applyChangeset:
+   [[[CKTransactionalComponentDataSourceChangesetBuilder new]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:0 inSection:0] : @""}]
+    build] mode:CKUpdateModeSynchronous userInfo:nil];
+
+  XCTAssertEqual(self.components.count, 2);
+  XCTAssertEqualObjects(self.componentController.callbacks, (@[
+                                                              NSStringFromSelector(@selector(willUpdateComponent)),
+                                                              NSStringFromSelector(@selector(willRemount)),
+                                                              NSStringFromSelector(@selector(didRemount)),
+                                                              NSStringFromSelector(@selector(didUpdateComponent))
+                                                              ]));
+}
+
+@end


### PR DESCRIPTION
Hi all :),

So had a chance to revisit this (https://github.com/facebook/componentkit/pull/373) and refresh my memory. New version should be cleaner and more sensical.

In particular, found a better way to approach the test: by force-casting `CKTransactionalComponentDataSourceConfiguration` to accept the `XCTestCase` instance itself as the component provider, it's possible to retain the generated components and access the controller directly. Then, can just log the callbacks received and everything becomes straightforward and conventional enough. Not to mention far shorter.

Other comments on their respective lines.

Thanks!