### PR TITLE
Do not limit Travis CI builds to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,3 @@ env:
     - BUILD_SUBCOMMAND="ci-componentkit-ios"
     - BUILD_SUBCOMMAND="ci-componentkit-tvos"
     - BUILD_SUBCOMMAND="ci-wildeguess-ios"
-
-branches:
-  only:
-    - master


### PR DESCRIPTION
Not sure why we're whitelisting Travis CI builds. Omitting the whitelist makes it easier for folks to use Travis CI with their own forks.
