### PR TITLE
Register for announceable events after state updates

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -157,7 +157,8 @@ namespace std {
 
   CKComponentScopeHandle *newHandle =
   existingChildFrameOfEquivalentPreviousFrame
-  ? [existingChildFrameOfEquivalentPreviousFrame.handle newHandleWithStateUpdates:stateUpdates]
+  ? [existingChildFrameOfEquivalentPreviousFrame.handle newHandleWithStateUpdates:stateUpdates
+                                                               componentScopeRoot:newRoot]
   : [[CKComponentScopeHandle alloc] initWithListener:newRoot.listener
                                       rootIdentifier:newRoot.globalIdentifier
                                       componentClass:componentClass

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -35,7 +35,8 @@
              initialStateCreator:(id (^)(void))initialStateCreator;
 
 /** Creates a new instance of the scope handle that incorporates the given state updates. */
-- (instancetype)newHandleWithStateUpdates:(const CKComponentStateUpdateMap &)stateUpdates;
+- (instancetype)newHandleWithStateUpdates:(const CKComponentStateUpdateMap &)stateUpdates
+                       componentScopeRoot:(CKComponentScopeRoot *)componentScopeRoot;
 
 /** Creates a new, but identical, instance of the scope handle that will be reacquired due to a scope collision. */
 - (instancetype)newHandleToBeReacquiredDueToScopeCollision;

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -85,12 +85,14 @@
 }
 
 - (instancetype)newHandleWithStateUpdates:(const CKComponentStateUpdateMap &)stateUpdates
+                       componentScopeRoot:(CKComponentScopeRoot *)componentScopeRoot
 {
   id updatedState = _state;
   const auto range = stateUpdates.equal_range(_globalIdentifier);
   for (auto it = range.first; it != range.second; ++it) {
     updatedState = it->second(updatedState);
   }
+  [componentScopeRoot registerAnnounceableEventsForController:_controller];
   return [[CKComponentScopeHandle alloc] initWithListener:_listener
                                          globalIdentifier:_globalIdentifier
                                            rootIdentifier:_rootIdentifier
@@ -205,7 +207,6 @@ static CKComponentController *newController(CKComponent *component, CKComponentS
     CKCAssert([controllerClass isSubclassOfClass:[CKComponentController class]],
               @"%@ must inherit from CKComponentController", controllerClass);
     CKComponentController *controller = [[controllerClass alloc] initWithComponent:component];
-
     [root registerAnnounceableEventsForController:controller];
     return controller;
   }


### PR DESCRIPTION
To help address nil components in component controllers we changed the lifecycle of component controllers. Unfortunately this introduced a regression in "announceable" event registration. More concretely folks are not receiving the following appearance events after a state update has been applied:

1. `-[CKComponentController componentTreeWillAppear]`
2. `-[CKComponentController componentTreeDidDisappear]`

To fix this problem `CKComponentScopeHandle` must make sure to register component controllers for announceable events with the new `CKComponentScopeRoot`. This should only happen when an existing `CKComponentScopeHandle` is updated with the relevant state updates.

Prior to this change the only time a component controller would register for announceable events is at the point in time the component controller was created.