### PR TITLE
Xcode 8 travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode7.3
+osx_image: xcode8
 language: objective-c
 
 install:

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,3 @@
 github "erikdoe/ocmock" ~> 3.3
 github "facebook/ios-snapshot-test-case" ~> 2.1
 github "jspahrsummers/xcconfigs" ~> 0.9
-

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "facebook/ios-snapshot-test-case" "2.1.2"
+github "facebook/ios-snapshot-test-case" "2.1.3"
 github "erikdoe/ocmock" "v3.3.1"
 github "jspahrsummers/xcconfigs" "0.9"

--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -2554,7 +2554,7 @@
 		B3EECEBA1AC2366500BFC5DA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				TargetAttributes = {
 					035FD0351D83212400D28351 = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -3286,7 +3286,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0B47D7D1CBD9C6600BB33CE /* ComponentKit.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				INFOPLIST_FILE = ComponentKit/Info.plist;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = ComponentKit;
@@ -3299,7 +3299,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0B47D7D1CBD9C6600BB33CE /* ComponentKit.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				INFOPLIST_FILE = ComponentKit/Info.plist;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = ComponentKit;
@@ -3474,8 +3474,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -3484,6 +3486,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -3518,8 +3521,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -3527,6 +3532,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -3545,6 +3551,7 @@
 		B3EECEE61AC2366600BFC5DA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_CXX0X_EXTENSIONS = YES;
@@ -3557,7 +3564,6 @@
 				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
 				CLANG_WARN__EXIT_TIME_DESTRUCTORS = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -3584,6 +3590,7 @@
 		B3EECEE71AC2366600BFC5DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_CXX0X_EXTENSIONS = YES;
@@ -3596,7 +3603,6 @@
 				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = YES;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
 				CLANG_WARN__EXIT_TIME_DESTRUCTORS = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -3624,6 +3630,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0B47D7D1CBD9C6600BB33CE /* ComponentKit.xcconfig */;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 			};
 			name = Debug;
 		};
@@ -3631,6 +3638,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D0B47D7D1CBD9C6600BB33CE /* ComponentKit.xcconfig */;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 			};
 			name = Release;
 		};
@@ -3644,6 +3652,7 @@
 				035FD03D1D83212400D28351 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		035FD05B1D83223700D28351 /* Build configuration list for PBXNativeTarget "ComponentKitTestLibAppleTV" */ = {
 			isa = XCConfigurationList;
@@ -3652,6 +3661,7 @@
 				035FD05D1D83223700D28351 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		03A98A6F1D2B2BFD00C5BAC2 /* Build configuration list for PBXNativeTarget "ComponentKitTestHelpersAppleTV" */ = {
 			isa = XCConfigurationList;

--- a/ComponentKit.xcodeproj/xcshareddata/xcschemes/ComponentKit.xcscheme
+++ b/ComponentKit.xcodeproj/xcshareddata/xcschemes/ComponentKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ComponentKit.xcodeproj/xcshareddata/xcschemes/ComponentKitAppleTV.xcscheme
+++ b/ComponentKit.xcodeproj/xcshareddata/xcschemes/ComponentKitAppleTV.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/build.sh
+++ b/build.sh
@@ -31,11 +31,11 @@ function ci() {
 }
 
 function ios_ci() {
-  ci $1 $2 iphonesimulator9.3 "platform=iOS Simulator,OS=9.3,name=iPhone 5s" $3
+  ci $1 $2 iphonesimulator10.0 "platform=iOS Simulator,OS=10.0,name=iPhone 5s" $3
 }
 
 function tvos_ci() {
-  ci $1 $2 appletvsimulator9.2 "platform=tvOS Simulator,OS=9.2,name=Apple TV 1080p" $3
+  ci $1 $2 appletvsimulator10.0 "platform=tvOS Simulator,OS=10.0,name=Apple TV 1080p" $3
 }
 
 if [ "$MODE" = "ci-componentkit-ios" ]; then


### PR DESCRIPTION
Now that `ios-snapshot-test-case` 2.1.3 is out we can move ComponentKit Travis CI builds to Xcode 8, iOS 10, and tvOS 10.