### PR TITLE
Migrate WildeGuess to CKCollectionViewTransactionalDataSource

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.h
@@ -67,6 +67,18 @@
                        mode:(CKUpdateMode)mode
                    userInfo:(NSDictionary *)userInfo;
 
+/**
+ Sends -componentTreeWillAppear to all CKComponentControllers for the given cell.
+ If needed, call this from -collectionView:willDisplayCell:forItemAtIndexPath:
+ */
+- (void)announceWillDisplayCell:(UICollectionViewCell *)cell;
+
+/**
+ Sends -componentTreeDidDisappear to all CKComponentControllers for the given cell.
+ If needed, call this from -collectionView:didEndDisplayingCell:forItemAtIndexPath:
+ */
+- (void)announceDidEndDisplayingCell:(UICollectionViewCell *)cell;
+
 @property (readonly, nonatomic, strong) UICollectionView *collectionView;
 /**
  Supplementary views are not handled with components; the datasource will forward any call to

--- a/Examples/WildeGuess/WildeGuess.xcodeproj/project.pbxproj
+++ b/Examples/WildeGuess/WildeGuess.xcodeproj/project.pbxproj
@@ -186,9 +186,9 @@
 		B3E848C21ABE848900377D52 /* WildeGuess */ = {
 			isa = PBXGroup;
 			children = (
+				B34FB95C1ABE8BA300D2D896 /* Components */,
 				B34FB95A1ABE8BA300D2D896 /* AppDelegate.h */,
 				B34FB95B1ABE8BA300D2D896 /* AppDelegate.mm */,
-				B34FB95C1ABE8BA300D2D896 /* Components */,
 				B34FB96B1ABE8BA300D2D896 /* Quote.h */,
 				B34FB96C1ABE8BA300D2D896 /* Quote.m */,
 				B34FB96D1ABE8BA300D2D896 /* QuoteContext.h */,


### PR DESCRIPTION
Per #558 one of the first steps in removing `CKComponentDataSource` is migrating the WildeGuess example app to the `CKCollectionViewTransactionalDataSource`.

Test Plan:

Build and run the WildeGuess example app. Ensure quotes are rendered and interaction is supported.