### PR TITLE
Allow CK::map to work with any iterable

### DIFF
--- a/ComponentKit/Core/ComponentUtilities.h
+++ b/ComponentKit/Core/ComponentUtilities.h
@@ -33,7 +33,7 @@ namespace CK {
     // Let std::transform apply `func` to all elements
     // (use perfect forwarding for the function object)
     std::transform(
-                   begin(iterable), end(iterable), res.begin(),
+                   std::begin(iterable), std::end(iterable), res.begin(),
                    std::forward<Func>(func)
                    );
 


### PR DESCRIPTION
These should be using the std::begin/std::end iterators explicitly.

Previous this worked with std::collections due to argument dependent lookup, but by being explicit we can allow any collection class that is compatible with std::iterators to be passed to the iterable map.