### PR TITLE
Ratio layout fixes

### DIFF
--- a/ComponentKit/LayoutComponents/CKRatioLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKRatioLayoutComponent.mm
@@ -28,7 +28,7 @@
                    component:(CKComponent *)component
 {
   CKAssert(ratio > 0, @"Ratio should be strictly positive, but received %f", ratio);
-  if (ratio <= 0) {
+  if (ratio <= 0 || component == nil) {
     return nil;
   }
 
@@ -62,7 +62,8 @@
   });
 
   // If there is no max size in *either* dimension, we can't apply the ratio, so just pass our size range through.
-  const CKSizeRange childRange = (bestSize == sizeOptions.end()) ? constrainedSize : CKSizeRange(*bestSize, *bestSize);
+  const CKSizeRange childRange = (bestSize == sizeOptions.end())
+  ? constrainedSize : constrainedSize.intersect(CKSizeRange(*bestSize, *bestSize));
   const CGSize parentSize = (bestSize == sizeOptions.end()) ? kCKComponentParentSizeUndefined : *bestSize;
   const CKComponentLayout childLayout = CKComputeComponentLayout(_component, childRange, parentSize);
   return {self, childLayout.size, {{{0,0}, childLayout}}};

--- a/ComponentKitApplicationTests/CKRatioLayoutComponentTests.mm
+++ b/ComponentKitApplicationTests/CKRatioLayoutComponentTests.mm
@@ -53,4 +53,14 @@ static CKRatioLayoutComponent *ratioLayoutComponent(CGFloat ratio, const CKCompo
   CKSnapshotVerifyComponent(ratioLayoutComponent(10.0, tallSize), kFixedSize, @"TenTimesRatioWithItemTooBig");
 }
 
+- (void)testRatioLayoutRendersToNilForNilInput
+{
+  CKRatioLayoutComponent *c =
+  [CKRatioLayoutComponent
+   newWithRatio:0.5
+   size:{}
+   component:nil];
+  XCTAssertNil(c);
+}
+
 @end


### PR DESCRIPTION
Ensure that we always choose a size within the constrainedSize; render to nil for a nil component.
