### PR TITLE
Do not attempt to apply bounds animations if the collection view is not visible

### DIFF
--- a/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
+++ b/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
@@ -49,14 +49,12 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
 
     // We might need to use a snapshot view to animate cells that are going offscreen, but we don't know which ones yet.
     // Grab a snapshot view for every cell; they'll be used or discarded in -applyBoundsAnimationToCollectionView:.
-
     const CGSize visibleSize = collectionView.bounds.size;
     const CGRect visibleRect = { collectionView.contentOffset, visibleSize };
 
     // Obviously we want to animate all visible cells. But what about cells that were not previously visible, but become
     // visible as a result of an item becoming smaller? We grab the layout attributes of a few more items that are
     // offscreen so that we can animate them too. (Only some, though; we don't attempt to get *all* layout attributes.)
-
     const CGFloat offscreenHeight = visibleSize.height / 2;
     const CGRect extendedRect = { visibleRect.origin, { visibleSize.width, visibleSize.height + offscreenHeight } };
 
@@ -64,7 +62,7 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
     NSMutableDictionary *indexPathsToOriginalLayoutAttributes = [NSMutableDictionary dictionary];
     NSMutableDictionary *supplementaryElementIndexPathsToSnapshotViews = [NSMutableDictionary dictionary];
     NSMutableDictionary *supplementaryElementIndexPathsToOriginalLayoutAttributes = [NSMutableDictionary dictionary];
-    for (UICollectionViewLayoutAttributes  *attributes in [collectionView.collectionViewLayout layoutAttributesForElementsInRect:extendedRect]) {
+    for (UICollectionViewLayoutAttributes *attributes in [collectionView.collectionViewLayout layoutAttributesForElementsInRect:extendedRect]) {
       NSIndexPath * const indexPath = attributes.indexPath;
       switch (attributes.representedElementCategory) {
         case UICollectionElementCategoryCell: {
@@ -115,13 +113,18 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
       return;
     }
   }
+  const CGRect visibleRect = {.origin = [_collectionView contentOffset], .size = [_collectionView bounds].size};
+  // If for some reason the collection view is not visible do not attempt to apply any bounds animations.
+  if (CGRectIsEmpty(visibleRect)) {
+    return;
+  }
 
   // First, move the cells to their old positions without animation:
   NSMutableDictionary *indexPathsToAnimatingViews = [NSMutableDictionary dictionary];
   NSMutableDictionary *indexPathsToAnimatingSupplementaryViews = [NSMutableDictionary dictionary];
   NSMutableDictionary *indexPathsToSupplementaryElementKinds = [NSMutableDictionary dictionary];
   NSMutableArray *snapshotViewsToRemoveAfterAnimation = [NSMutableArray array];
-  const CGRect visibleRect = {.origin = [_collectionView contentOffset], .size = [_collectionView bounds].size};
+
   NSIndexPath *largestAnimatingVisibleElement = largestAnimatingVisibleElementForOriginalLayout(_indexPathsToOriginalLayoutAttributes, visibleRect);
   [UIView performWithoutAnimation:^{
     [_indexPathsToOriginalLayoutAttributes enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPath, UICollectionViewLayoutAttributes *attributes, BOOL *stop) {

--- a/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
+++ b/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
@@ -124,7 +124,6 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
   NSMutableDictionary *indexPathsToAnimatingSupplementaryViews = [NSMutableDictionary dictionary];
   NSMutableDictionary *indexPathsToSupplementaryElementKinds = [NSMutableDictionary dictionary];
   NSMutableArray *snapshotViewsToRemoveAfterAnimation = [NSMutableArray array];
-
   NSIndexPath *largestAnimatingVisibleElement = largestAnimatingVisibleElementForOriginalLayout(_indexPathsToOriginalLayoutAttributes, visibleRect);
   [UIView performWithoutAnimation:^{
     [_indexPathsToOriginalLayoutAttributes enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPath, UICollectionViewLayoutAttributes *attributes, BOOL *stop) {


### PR DESCRIPTION
It's possible that the collection view driving bounds animations may not be visible. In these situations the mapping of index paths to original layout attributes will be empty. If ComponentKit cannot determine the largest animating visible element it will crash when trying to lookup the layout attributes.

To avoid the crash bounds animations should not be applied if the visible rect is empty.