### PR TITLE
Add support for CKTransactionalComponentDataSourceChangeset verification

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -325,6 +325,14 @@
 		2D03A6601D3869A800E4F890 /* CKDetectComponentScopeCollisions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */; };
 		2D03A6611D3869C700E4F890 /* CKDetectComponentScopeCollisions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D34A4AA1D777EB80020B11C /* CKArrayControllerChangesetVerification.mm in Sources */ = {isa = PBXBuildFile; fileRef = B797C03F1D49F701006461CC /* CKArrayControllerChangesetVerification.mm */; };
+		2D7A98161DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */; };
+		2D7A98171DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */; };
+		2D7A98181DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A98151DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm */; };
+		2D7A98191DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A98151DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm */; };
+		2D7A98251DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A98241DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm */; };
+		2D7A98261DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A98241DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm */; };
+		2D7A98281DB571700064FC6D /* CKBadChangesetOperationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7A98271DB571700064FC6D /* CKBadChangesetOperationType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D7A98291DB571700064FC6D /* CKBadChangesetOperationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7A98271DB571700064FC6D /* CKBadChangesetOperationType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D8C3D441D64F41E00E6D47A /* ReferenceImages_IOS10_64 in Resources */ = {isa = PBXBuildFile; fileRef = 2D8C3D421D64F41E00E6D47A /* ReferenceImages_IOS10_64 */; };
 		2D8C3D521D64F43E00E6D47A /* ReferenceImages_IOS10_64 in Resources */ = {isa = PBXBuildFile; fileRef = 2D8C3D501D64F43E00E6D47A /* ReferenceImages_IOS10_64 */; };
 		2D8C3D541D64F44B00E6D47A /* ReferenceImages_IOS9_64 in Resources */ = {isa = PBXBuildFile; fileRef = 2D8C3D531D64F44B00E6D47A /* ReferenceImages_IOS9_64 */; };
@@ -873,6 +881,10 @@
 		18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStatefulViewReusePoolTests.mm; sourceTree = "<group>"; };
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
+		2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTransactionalComponentDataSourceChangesetVerification.h; sourceTree = "<group>"; };
+		2D7A98151DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetVerification.mm; sourceTree = "<group>"; };
+		2D7A98241DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetVerificationTests.mm; sourceTree = "<group>"; };
+		2D7A98271DB571700064FC6D /* CKBadChangesetOperationType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKBadChangesetOperationType.h; sourceTree = "<group>"; };
 		2D8C3D421D64F41E00E6D47A /* ReferenceImages_IOS10_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS10_64; sourceTree = "<group>"; };
 		2D8C3D501D64F43E00E6D47A /* ReferenceImages_IOS10_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS10_64; sourceTree = "<group>"; };
 		2D8C3D531D64F44B00E6D47A /* ReferenceImages_IOS9_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS9_64; sourceTree = "<group>"; };
@@ -1362,19 +1374,20 @@
 		A27436F51AE94FCA00832359 /* TransactionalDataSource */ = {
 			isa = PBXGroup;
 			children = (
+				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */,
+				B761C8B01CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm */,
 				A25C02D01AF0767700F4C864 /* CKTransactionalComponentDataSourceChangesetModificationTests.mm */,
+				B761C8AD1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm */,
+				2D7A98241DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm */,
+				B761C8AA1CB36AAE00CDD03F /* CKTransactionalComponentDataSourceConfigurationTests.mm */,
 				A27436F61AE94FE300832359 /* CKTransactionalComponentDataSourceReloadModificationTests.mm */,
-				A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */,
-				A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */,
-				A279EA9D1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm */,
-				A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */,
-				A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */,
 				A27436F81AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.h */,
 				A27436F91AE9589700832359 /* CKTransactionalComponentDataSourceStateTestHelpers.mm */,
-				497824741BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm */,
-				B761C8AA1CB36AAE00CDD03F /* CKTransactionalComponentDataSourceConfigurationTests.mm */,
-				B761C8AD1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm */,
-				B761C8B01CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm */,
+				A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */,
+				A22FE3021AF2CEB000EC30B8 /* CKTransactionalComponentDataSourceStateUpdateTests.mm */,
+				A279EA9D1AF087A70046B5AA /* CKTransactionalComponentDataSourceTests.mm */,
+				A2100E0C1AE9751500281861 /* CKTransactionalComponentDataSourceUpdateConfigurationModificationTests.mm */,
+				A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */,
 			);
 			path = TransactionalDataSource;
 			sourceTree = "<group>";
@@ -1828,6 +1841,8 @@
 				D0B47B781CBD926700BB33CE /* CKTransactionalComponentDataSourceChange.m */,
 				D0B47B791CBD926700BB33CE /* CKTransactionalComponentDataSourceChangesetModification.h */,
 				D0B47B7A1CBD926700BB33CE /* CKTransactionalComponentDataSourceChangesetModification.mm */,
+				2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */,
+				2D7A98151DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm */,
 				D0B47B7B1CBD926700BB33CE /* CKTransactionalComponentDataSourceReloadModification.h */,
 				D0B47B7C1CBD926700BB33CE /* CKTransactionalComponentDataSourceReloadModification.mm */,
 				D0B47B7D1CBD926700BB33CE /* CKTransactionalComponentDataSourceStateModifying.h */,
@@ -1845,6 +1860,7 @@
 				D0B47B831CBD926700BB33CE /* CKArrayControllerChangeset.h */,
 				D0B47B841CBD926700BB33CE /* CKArrayControllerChangeset.mm */,
 				D0B47B851CBD926700BB33CE /* CKArrayControllerChangeType.h */,
+				2D7A98271DB571700064FC6D /* CKBadChangesetOperationType.h */,
 				D0B47B861CBD926700BB33CE /* CKComponentAction.h */,
 				D0B47B871CBD926700BB33CE /* CKComponentAction.mm */,
 				D0B47B881CBD926700BB33CE /* CKComponentContext.h */,
@@ -2021,6 +2037,7 @@
 				A29D85791D80D37F00913E60 /* CKComponentContextHelper.h in Headers */,
 				03B8B4D01D2A346F00EDFF59 /* CKCollectionViewDataSource.h in Headers */,
 				03B8B4D11D2A346F00EDFF59 /* CKArrayControllerChangeset.h in Headers */,
+				2D7A98291DB571700064FC6D /* CKBadChangesetOperationType.h in Headers */,
 				03B8B4D21D2A346F00EDFF59 /* CKComponentRootView.h in Headers */,
 				03B8B4D31D2A346F00EDFF59 /* CKCollectionViewTransactionalDataSource.h in Headers */,
 				03B8B4D41D2A346F00EDFF59 /* CKWeakObjectContainer.h in Headers */,
@@ -2059,6 +2076,7 @@
 				03B8B4F41D2A346F00EDFF59 /* CKTextComponentView.h in Headers */,
 				03B8B4F51D2A346F00EDFF59 /* CKTransactionalComponentDataSourceReloadModification.h in Headers */,
 				03B8B4F61D2A346F00EDFF59 /* CKComponentAnnouncerBaseInternal.h in Headers */,
+				2D7A98171DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h in Headers */,
 				03B8B4F71D2A346F00EDFF59 /* CKTransactionalComponentDataSourceStateModifying.h in Headers */,
 				03B8B4F81D2A346F00EDFF59 /* CKArrayControllerChangeType.h in Headers */,
 				03B8B4F91D2A346F00EDFF59 /* CKStackPositionedLayout.h in Headers */,
@@ -2189,6 +2207,7 @@
 				D0B47D111CBD948E00BB33CE /* CKCollectionViewDataSource.h in Headers */,
 				A243B52E1D79A40800E6C393 /* CKComponentContextHelper.h in Headers */,
 				D0B47D501CBD948E00BB33CE /* CKArrayControllerChangeset.h in Headers */,
+				2D7A98281DB571700064FC6D /* CKBadChangesetOperationType.h in Headers */,
 				D0B47D2E1CBD948E00BB33CE /* CKComponentRootView.h in Headers */,
 				D0B47D131CBD948E00BB33CE /* CKCollectionViewTransactionalDataSource.h in Headers */,
 				D0B47D5F1CBD948E00BB33CE /* CKWeakObjectContainer.h in Headers */,
@@ -2285,6 +2304,7 @@
 				D0B47CEB1CBD948E00BB33CE /* CKButtonComponent.h in Headers */,
 				D0B47D561CBD948E00BB33CE /* CKComponentDelegateForwarder.h in Headers */,
 				D0B47D211CBD948E00BB33CE /* CKComponentDeciding.h in Headers */,
+				2D7A98161DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h in Headers */,
 				D0B47D331CBD948E00BB33CE /* CKInsetComponent.h in Headers */,
 				D0B47D041CBD948E00BB33CE /* CKUpdateMode.h in Headers */,
 				D0B47D181CBD948E00BB33CE /* CKComponentAnnouncerHelper.h in Headers */,
@@ -2860,6 +2880,7 @@
 				03B8B4B61D2A346F00EDFF59 /* CKOptimisticViewMutations.mm in Sources */,
 				03B8B4B71D2A346F00EDFF59 /* CKSectionedArrayController.mm in Sources */,
 				03B8B4B81D2A346F00EDFF59 /* CKWeakObjectContainer.m in Sources */,
+				2D7A98191DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm in Sources */,
 				03B8B4B91D2A346F00EDFF59 /* CKLabelComponent.mm in Sources */,
 				03B8B4BA1D2A346F00EDFF59 /* CKTextComponent.mm in Sources */,
 				03B8B4BB1D2A346F00EDFF59 /* CKTextComponentLayer.mm in Sources */,
@@ -2894,6 +2915,7 @@
 				03F1ABCA1D2B2A9B00867584 /* CKComponentBoundsAnimationTests.mm in Sources */,
 				03F1ABCB1D2B2A9B00867584 /* CKOptimisticViewMutationsTests.mm in Sources */,
 				03F1ABCC1D2B2A9B00867584 /* CKComponentActionTests.mm in Sources */,
+				2D7A98261DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm in Sources */,
 				03F1ABCD1D2B2A9B00867584 /* CKComponentAccessibilityTests.mm in Sources */,
 				03F1ABCE1D2B2A9B00867584 /* CKArrayControllerChangesetTests.mm in Sources */,
 				03F1ABCF1D2B2A9B00867584 /* CKTransactionalComponentDataSourceConfigurationTests.mm in Sources */,
@@ -2975,6 +2997,7 @@
 				39B090BF1B71645600A5470B /* CKComponentDataSourceAttachControllerTests.mm in Sources */,
 				B342DC741AC23EA900ACAC53 /* CKComponentHostingViewTestModel.mm in Sources */,
 				B342DC761AC23EA900ACAC53 /* CKComponentLifecycleManagerTests.mm in Sources */,
+				2D7A98251DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm in Sources */,
 				497824751BC570E000F29081 /* CKCollectionViewTransactionalDataSourceTests.mm in Sources */,
 				A22FE3061AF2CF0C00EC30B8 /* CKStateExposingComponent.mm in Sources */,
 				B342DC721AC23EA900ACAC53 /* CKComponentFlexibleSizeRangeProviderTests.mm in Sources */,
@@ -3127,6 +3150,7 @@
 				D0B47CCE1CBD943400BB33CE /* CKOptimisticViewMutations.mm in Sources */,
 				D0B47CCF1CBD943400BB33CE /* CKSectionedArrayController.mm in Sources */,
 				D0B47CD01CBD943400BB33CE /* CKWeakObjectContainer.m in Sources */,
+				2D7A98181DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm in Sources */,
 				D0B47CD11CBD943400BB33CE /* CKLabelComponent.mm in Sources */,
 				D0B47CD21CBD943400BB33CE /* CKTextComponent.mm in Sources */,
 				D0B47CD31CBD943400BB33CE /* CKTextComponentLayer.mm in Sources */,

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.h
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <ComponentKit/CKBadChangesetOperationType.h>
+
+@class CKTransactionalComponentDataSourceChangeset;
+@class CKTransactionalComponentDataSourceState;
+
+extern CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentDataSourceChangeset *changeset,
+                                                              CKTransactionalComponentDataSourceState *state);

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.mm
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "CKTransactionalComponentDataSourceChangesetVerification.h"
+
+#import <ComponentKit/CKTransactionalComponentDataSourceChangesetInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceStateInternal.h>
+
+static NSMutableArray<NSNumber *> *sectionCountsForState(CKTransactionalComponentDataSourceState *state);
+
+static NSArray<NSIndexPath *> *sortedIndexPaths(NSArray<NSIndexPath *> *indexPaths);
+
+CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentDataSourceChangeset *changeset,
+                                                       CKTransactionalComponentDataSourceState *state)
+{
+  NSMutableArray<NSNumber *> *sectionCounts = sectionCountsForState(state);
+  __block BOOL invalidChangeFound = NO;
+  // Updated items
+  [changeset.updatedItems enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull indexPath, id _Nonnull model, BOOL * _Nonnull stop) {
+    const NSInteger section = indexPath.section;
+    const NSInteger item = indexPath.item;
+    if (section >= sectionCounts.count
+        || item >= [sectionCounts[section] integerValue]
+        || section < 0
+        || item < 0) {
+      invalidChangeFound = YES;
+      *stop = YES;
+    }
+  }];
+  if (invalidChangeFound) {
+    return CKBadChangesetOperationTypeUpdate;
+  }
+  /*
+   Removed items
+   Section counts may not immediately reflect removals as order is not guaranteed and may result in a false positive.
+   As long as each item is located within the bounds of its section the changeset is valid.
+   */
+  NSMutableDictionary<NSNumber *, NSMutableIndexSet *> *itemsToRemove = [NSMutableDictionary new];
+  [changeset.removedItems enumerateObjectsUsingBlock:^(NSIndexPath *_Nonnull indexPath, BOOL * _Nonnull stop) {
+    const NSInteger section = indexPath.section;
+    const NSInteger item = indexPath.item;
+    if (section >= sectionCounts.count
+        || section < 0
+        || item >= [sectionCounts[section] integerValue]) {
+      invalidChangeFound = YES;
+      *stop = YES;
+    } else {
+      if (!itemsToRemove[@(section)]) {
+        itemsToRemove[@(section)] = [NSMutableIndexSet indexSet];
+      }
+      [itemsToRemove[@(section)] addIndex:item];
+    }
+  }];
+  if (invalidChangeFound) {
+    return CKBadChangesetOperationTypeRemoveRow;
+  } else {
+    [itemsToRemove enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull section, NSMutableIndexSet * _Nonnull indexSet, BOOL * _Nonnull stop) {
+      sectionCounts[[section integerValue]] = @([sectionCounts[[section integerValue]] integerValue] - [indexSet count]);
+    }];
+  }
+  /*
+   Removed sections
+   Section counts may not immediately reflect removals as order is not guaranteed and may result in a false positive.
+   As long as each section is located within the bounds of all sections the changeset is valid.
+   */
+  NSMutableIndexSet *sectionsToRemove = [NSMutableIndexSet indexSet];
+  [changeset.removedSections enumerateIndexesUsingBlock:^(NSUInteger section, BOOL * _Nonnull stop) {
+    if (section >= sectionCounts.count) {
+      invalidChangeFound = YES;
+      *stop = YES;
+    } else {
+      [sectionsToRemove addIndex:section];
+    }
+  }];
+  if (invalidChangeFound) {
+    return CKBadChangesetOperationTypeRemoveSection;
+  } else {
+    [sectionCounts removeObjectsAtIndexes:sectionsToRemove];
+  }
+  /*
+   Inserted sections
+   Section counts may immediately reflect insertions as they are guaranteed to be contiguous by virtue of NSIndexSet.
+   As long as each section is located within the bounds of all sections the changeset is valid.
+   */
+  [changeset.insertedSections enumerateIndexesUsingBlock:^(NSUInteger section, BOOL * _Nonnull stop) {
+    if (section > sectionCounts.count) {
+      invalidChangeFound = YES;
+      *stop = YES;
+    } else {
+      [sectionCounts insertObject:@0 atIndex:section];
+    }
+  }];
+  if (invalidChangeFound) {
+    return CKBadChangesetOperationTypeInsertSection;
+  }
+  /*
+   Inserted items
+   Section counts may immediately reflect insertions as they are guaranteed to be contiguous by virtue of sorting the index paths.
+   As long as each item is located within the bounds of its section the changeset is valid.
+   */
+  [sortedIndexPaths(changeset.insertedItems.allKeys) enumerateObjectsUsingBlock:^(NSIndexPath * _Nonnull indexPath, NSUInteger index, BOOL * _Nonnull stop) {
+    const NSInteger section = indexPath.section;
+    const NSInteger item = indexPath.item;
+    if (section >= sectionCounts.count
+        || section < 0
+        || item > [sectionCounts[section] integerValue]) {
+      invalidChangeFound = YES;
+      *stop = YES;
+    } else {
+      sectionCounts[section] = @([sectionCounts[section] integerValue] + 1);
+    }
+  }];
+  if (invalidChangeFound) {
+    return CKBadChangesetOperationTypeInsertRow;
+  }
+  // Moved items
+  [changeset.movedItems enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull fromIndexPath, NSIndexPath * _Nonnull toIndexPath, BOOL * _Nonnull stop) {
+    const BOOL fromIndexPathSectionInvalid = fromIndexPath.section >= sectionCounts.count;
+    const BOOL toIndexPathSectionInvalid = toIndexPath.section >= sectionCounts.count;
+    if (fromIndexPathSectionInvalid || toIndexPathSectionInvalid) {
+      invalidChangeFound = YES;
+      *stop = YES;
+    } else {
+      const BOOL fromIndexPathItemInvalid = fromIndexPath.item >= [sectionCounts[fromIndexPath.section] integerValue];
+      const BOOL toIndexPathItemInvalid = ((fromIndexPath.section == toIndexPath.section)
+                                           ? toIndexPath.item >= [sectionCounts[toIndexPath.section] integerValue]
+                                           : toIndexPath.item > [sectionCounts[toIndexPath.section] integerValue]);
+      if (fromIndexPathItemInvalid || toIndexPathItemInvalid) {
+        invalidChangeFound = YES;
+        *stop = YES;
+      } else {
+        sectionCounts[fromIndexPath.section] = @([sectionCounts[fromIndexPath.section] integerValue] - 1);
+        sectionCounts[toIndexPath.section] = @([sectionCounts[toIndexPath.section] integerValue] + 1);
+      }
+    }
+  }];
+  return invalidChangeFound ? CKBadChangesetOperationTypeMoveRow : CKBadChangesetOperationTypeNone;
+}
+
+static NSMutableArray<NSNumber *> *sectionCountsForState(CKTransactionalComponentDataSourceState *state)
+{
+  NSMutableArray *sectionCounts = [NSMutableArray new];
+  for (NSArray *section in state.sections) {
+    [sectionCounts addObject:@(section.count)];
+  }
+  return sectionCounts;
+}
+
+static NSArray<NSIndexPath *> *sortedIndexPaths(NSArray<NSIndexPath *> *indexPaths)
+{
+  return [indexPaths sortedArrayUsingSelector:@selector(compare:)];
+}

--- a/ComponentKit/Utilities/CKArrayControllerChangesetVerification.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangesetVerification.h
@@ -11,17 +11,7 @@
 #import <Foundation/Foundation.h>
 
 #import <ComponentKit/CKArrayControllerChangeset.h>
-
-typedef NS_ENUM(NSUInteger, CKBadChangesetOperationType) {
-  CKBadChangesetOperationTypeNone,
-  CKBadChangesetOperationTypeUpdate,
-  CKBadChangesetOperationTypeInsertSection,
-  CKBadChangesetOperationTypeInsertRow,
-  CKBadChangesetOperationTypeRemoveSection,
-  CKBadChangesetOperationTypeRemoveRow,
-  CKBadChangesetOperationTypeMoveSection,
-  CKBadChangesetOperationTypeMoveRow
-};
+#import <ComponentKit/CKBadChangesetOperationType.h>
 
 /**
  This function determines whether a given changeset is valid for a particular data source state.

--- a/ComponentKit/Utilities/CKBadChangesetOperationType.h
+++ b/ComponentKit/Utilities/CKBadChangesetOperationType.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, CKBadChangesetOperationType) {
+  CKBadChangesetOperationTypeNone,
+  CKBadChangesetOperationTypeUpdate,
+  CKBadChangesetOperationTypeInsertSection,
+  CKBadChangesetOperationTypeInsertRow,
+  CKBadChangesetOperationTypeRemoveSection,
+  CKBadChangesetOperationTypeRemoveRow,
+  CKBadChangesetOperationTypeMoveSection,
+  CKBadChangesetOperationTypeMoveRow
+};

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
@@ -1,0 +1,879 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <XCTest/XCTest.h>
+
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChangeset.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceItemInternal.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceStateInternal.h>
+
+#import "CKTransactionalComponentDataSourceChangesetVerification.h"
+
+@interface CKTransactionalComponentDataSourceChangesetVerificationTests : XCTestCase
+@end
+
+@implementation CKTransactionalComponentDataSourceChangesetVerificationTests
+
+#pragma mark - Valid changesets
+
+- (void)test_emptyChangesetEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_emptyChangesetNonEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"A"),
+                                                                             itemWithModel(@"B"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_nonEmptyChangesetEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+    withInsertedItems:@{
+                       [NSIndexPath indexPathForItem:0 inSection:0]: @"A",
+                       [NSIndexPath indexPathForItem:1 inSection:0]: @"B",
+                       }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionIntoEmptySection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:0 inSection:0]: @"A",
+                        [NSIndexPath indexPathForItem:1 inSection:0]: @"B",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionIntoBeginningOfNonEmptySection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:0 inSection:0]: @"A",
+                        [NSIndexPath indexPathForItem:1 inSection:0]: @"B",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionIntoMiddleOfNonEmptySection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:1 inSection:0]: @"A",
+                        [NSIndexPath indexPathForItem:2 inSection:0]: @"B",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionAtEndOfNonEmptySection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:2 inSection:0]: @"A",
+                        [NSIndexPath indexPathForItem:3 inSection:0]: @"B",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validRemovalAtBeginningOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             itemWithModel(@"E"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:0 inSection:0],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validRemovalAtMiddleOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             itemWithModel(@"E"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:1 inSection:0],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validRemovalAtEndOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             itemWithModel(@"E"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:2 inSection:0],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validRemovalOfAllItems
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             itemWithModel(@"E"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:2 inSection:0],
+                                           [NSIndexPath indexPathForItem:1 inSection:0],
+                                           [NSIndexPath indexPathForItem:0 inSection:0],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionOfSectionInEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionOfSectionAtBeginningOfNonEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionOfSectionInMiddleOfNonEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:1]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionOfSectionAtEndOfNonEmptySections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:2]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validInsertionOfMultipleSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 2)]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_removalOfSectionAtBeginningOfSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedSections:[NSIndexSet indexSetWithIndex:0]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_removalOfSectionAtMiddleOfSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedSections:[NSIndexSet indexSetWithIndex:1]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_removalOfSectionAtEndOfSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedSections:[NSIndexSet indexSetWithIndex:2]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_removeMultipleSectionsAtBeginningOfSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_removeMultipleSectionsAtEndOfSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 2)]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validUpdate
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{
+                       [NSIndexPath indexPathForItem:0 inSection:0]: @"A",
+                       }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validMoveForwardInsideOneSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:1 inSection:0],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validMoveBackwardInsideOneSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:1 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validMoveForwardBetweenSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:1],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+- (void)test_validMoveBackwardBetweenSections
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"E"),
+                                                                             itemWithModel(@"F"),
+                                                                             ],
+                                                                           @[
+                                                                             itemWithModel(@"G"),
+                                                                             itemWithModel(@"H"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:0 inSection:1]: [NSIndexPath indexPathForItem:2 inSection:0],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+#pragma mark - Invalid changesets
+
+- (void)test_invalidUpdateInNegativeSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{
+                       [NSIndexPath indexPathForItem:1 inSection:-1]: @"A",
+                       }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+}
+
+- (void)test_invalidUpdateInNegativeItem
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{
+                       [NSIndexPath indexPathForItem:-1 inSection:0]: @"A",
+                       }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+}
+
+- (void)test_invalidInsertionAtEndOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:3 inSection:0]: @"A",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertRow);
+}
+
+- (void)test_invalidMultipleInsertionAtEndOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:2 inSection:0]: @"A",
+                        [NSIndexPath indexPathForItem:4 inSection:0]: @"B",
+                        [NSIndexPath indexPathForItem:5 inSection:0]: @"E",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertRow);
+}
+
+- (void)test_invalidInsertionInNonExistentSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:0 inSection:1]: @"A",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertRow);
+}
+
+- (void)test_invalidRemovalInValidSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:2 inSection:0],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeRemoveRow);
+}
+
+- (void)test_invalidRemovalInNonExistentSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:0 inSection:1],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeRemoveRow);
+}
+
+- (void)test_invalidInsertionOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withInsertedSections:[NSIndexSet indexSetWithIndex:2]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertSection);
+}
+
+- (void)test_invalidRemovalOfSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withRemovedSections:[NSIndexSet indexSetWithIndex:2]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeRemoveSection);
+}
+
+- (void)test_invalidUpdateWithinExistingSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{
+                       [NSIndexPath indexPathForItem:2 inSection:0]: @"A",
+                       }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+}
+
+- (void)test_invalidUpdateWithinNonExistentSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withUpdatedItems:@{
+                       [NSIndexPath indexPathForItem:0 inSection:1]: @"A",
+                       }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+}
+
+- (void)test_moveWithInvalidOriginIndexPathInExistingSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:2 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+}
+
+- (void)test_moveWithInvalidDestinationIndexPathInExistingSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:0],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+}
+
+- (void)test_moveWithInvalidOriginSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:0 inSection:1]: [NSIndexPath indexPathForItem:0 inSection:0],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+}
+
+- (void)test_moveWithInvalidDestinationSection
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                           ]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+    withMovedItems:@{
+                     [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:1],
+                     }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+}
+
+#pragma mark - More complicated situations
+
+- (void)test_validSampleInitialInsertions
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[]];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withInsertedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]]
+    withInsertedItems:@{
+                        [NSIndexPath indexPathForItem:0 inSection:0]: @"A1",
+                        [NSIndexPath indexPathForItem:1 inSection:0]: @"B1",
+                        [NSIndexPath indexPathForItem:0 inSection:1]: @"A2",
+                        [NSIndexPath indexPathForItem:1 inSection:1]: @"B2",
+                        }]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+}
+
+static CKTransactionalComponentDataSourceItem *itemWithModel(id model)
+{
+  return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout()
+                                                                  model:model
+                                                              scopeRoot:nil];
+}
+
+@end


### PR DESCRIPTION
A `CKTransactionalComponentDataSourceChangeset` port of #599.