### PR TITLE
Verify transactional component data source changesets

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -325,6 +325,8 @@
 		2D03A6601D3869A800E4F890 /* CKDetectComponentScopeCollisions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */; };
 		2D03A6611D3869C700E4F890 /* CKDetectComponentScopeCollisions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D34A4AA1D777EB80020B11C /* CKArrayControllerChangesetVerification.mm in Sources */ = {isa = PBXBuildFile; fileRef = B797C03F1D49F701006461CC /* CKArrayControllerChangesetVerification.mm */; };
+		2D640D5D1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D640D5C1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm */; };
+		2D640D5E1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D640D5C1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm */; };
 		2D7A98161DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */; };
 		2D7A98171DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */; };
 		2D7A98181DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D7A98151DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm */; };
@@ -881,6 +883,7 @@
 		18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStatefulViewReusePoolTests.mm; sourceTree = "<group>"; };
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
+		2D640D5C1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKBadChangesetOperationType.mm; sourceTree = "<group>"; };
 		2D7A98141DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTransactionalComponentDataSourceChangesetVerification.h; sourceTree = "<group>"; };
 		2D7A98151DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetVerification.mm; sourceTree = "<group>"; };
 		2D7A98241DB56D8D0064FC6D /* CKTransactionalComponentDataSourceChangesetVerificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetVerificationTests.mm; sourceTree = "<group>"; };
@@ -1861,6 +1864,7 @@
 				D0B47B841CBD926700BB33CE /* CKArrayControllerChangeset.mm */,
 				D0B47B851CBD926700BB33CE /* CKArrayControllerChangeType.h */,
 				2D7A98271DB571700064FC6D /* CKBadChangesetOperationType.h */,
+				2D640D5C1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm */,
 				D0B47B861CBD926700BB33CE /* CKComponentAction.h */,
 				D0B47B871CBD926700BB33CE /* CKComponentAction.mm */,
 				D0B47B881CBD926700BB33CE /* CKComponentContext.h */,
@@ -2867,6 +2871,7 @@
 				03B8B4A91D2A346F00EDFF59 /* CKTransactionalComponentDataSourceState.mm in Sources */,
 				03B8B4AA1D2A346F00EDFF59 /* CKTransactionalComponentDataSourceChange.m in Sources */,
 				03B8B4AB1D2A346F00EDFF59 /* CKTransactionalComponentDataSourceChangesetModification.mm in Sources */,
+				2D640D5E1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm in Sources */,
 				03B8B4AC1D2A346F00EDFF59 /* CKTransactionalComponentDataSourceReloadModification.mm in Sources */,
 				03B8B4AD1D2A346F00EDFF59 /* CKTransactionalComponentDataSourceUpdateConfigurationModification.mm in Sources */,
 				03B8B4AE1D2A346F00EDFF59 /* CKTransactionalComponentDataSourceUpdateStateModification.mm in Sources */,
@@ -3137,6 +3142,7 @@
 				D0B47CC21CBD943400BB33CE /* CKTransactionalComponentDataSourceChange.m in Sources */,
 				D0B47CC31CBD943400BB33CE /* CKTransactionalComponentDataSourceChangesetModification.mm in Sources */,
 				D0B47CC41CBD943400BB33CE /* CKTransactionalComponentDataSourceReloadModification.mm in Sources */,
+				2D640D5D1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm in Sources */,
 				D0B47CC51CBD943400BB33CE /* CKTransactionalComponentDataSourceUpdateConfigurationModification.mm in Sources */,
 				D0B47CC61CBD943400BB33CE /* CKTransactionalComponentDataSourceUpdateStateModification.mm in Sources */,
 				D0B47CC71CBD943400BB33CE /* CKArrayControllerChangeset.mm in Sources */,

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -256,8 +256,11 @@ static void verifyChangeset(CKTransactionalComponentDataSourceChangeset *changes
                                                                                            state,
                                                                                            pendingAsynchronousModifications);
   CKCAssert(badChangesetOperationType == CKBadChangesetOperationTypeNone,
-            @"Bad operation: %@\nChangeset:\n************\n %@\n************\nCurrent data source state: %@",
-            CKHumanReadableBadChangesetOperationType(badChangesetOperationType), changeset, state);
+            @"Bad operation: %@\n*** Changeset:\n%@\n*** Data source state:\n%@\n*** Pending data source modifications:\n%@",
+            CKHumanReadableBadChangesetOperationType(badChangesetOperationType),
+            changeset,
+            state,
+            pendingAsynchronousModifications);
 #endif
 }
 

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -15,6 +15,7 @@
 #import "CKComponentScopeRoot.h"
 #import "CKTransactionalComponentDataSourceChange.h"
 #import "CKTransactionalComponentDataSourceChangesetModification.h"
+#import "CKTransactionalComponentDataSourceChangesetVerification.h"
 #import "CKTransactionalComponentDataSourceConfiguration.h"
 #import "CKTransactionalComponentDataSourceConfigurationInternal.h"
 #import "CKTransactionalComponentDataSourceListenerAnnouncer.h"
@@ -74,6 +75,7 @@
               userInfo:(NSDictionary *)userInfo
 {
   CKAssertMainThread();
+  verifyChangeset(changeset, _state);
   id<CKTransactionalComponentDataSourceStateModifying> modification =
   [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset stateListener:self userInfo:userInfo];
   switch (mode) {
@@ -243,6 +245,17 @@
       [self _startFirstAsynchronousModification];
     }
   });
+}
+
+static void verifyChangeset(CKTransactionalComponentDataSourceChangeset *changeset,
+                            CKTransactionalComponentDataSourceState *state)
+{
+#if CK_ASSERTIONS_ENABLED
+  const CKBadChangesetOperationType badChangesetOperationType = CKIsValidChangesetForState(changeset, state);
+  CKCAssert(badChangesetOperationType == CKBadChangesetOperationTypeNone,
+            @"Bad operation: %@\nChangeset:\n************\n %@\n************\nCurrent data source state: %@",
+            CKHumanReadableBadChangesetOperationType(badChangesetOperationType), changeset, state);
+#endif
 }
 
 @end

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.h
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.h
@@ -17,7 +17,11 @@
 @protocol CKComponentStateListener;
 
 @interface CKTransactionalComponentDataSourceChangesetModification : NSObject <CKTransactionalComponentDataSourceStateModifying>
+
 - (instancetype)initWithChangeset:(CKTransactionalComponentDataSourceChangeset *)changeset
                     stateListener:(id<CKComponentStateListener>)stateListener
                          userInfo:(NSDictionary *)userInfo;
+
+@property (nonatomic, readonly, strong) CKTransactionalComponentDataSourceChangeset *changeset;
+
 @end

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -140,6 +140,11 @@
                                                           appliedChanges:appliedChanges];
 }
 
+- (NSString *)description
+{
+  return [_changeset description];
+}
+
 static NSArray *emptyMutableArrays(NSUInteger count)
 {
   NSMutableArray *arrays = [NSMutableArray array];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -25,7 +25,6 @@
 
 @implementation CKTransactionalComponentDataSourceChangesetModification
 {
-  CKTransactionalComponentDataSourceChangeset *_changeset;
   id<CKComponentStateListener> _stateListener;
   NSDictionary *_userInfo;
 }

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.h
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.h
@@ -15,5 +15,8 @@
 @class CKTransactionalComponentDataSourceChangeset;
 @class CKTransactionalComponentDataSourceState;
 
-extern CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentDataSourceChangeset *changeset,
-                                                              CKTransactionalComponentDataSourceState *state);
+@protocol CKTransactionalComponentDataSourceStateModifying;
+
+CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentDataSourceChangeset *changeset,
+                                                       CKTransactionalComponentDataSourceState *state,
+                                                       NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *pendingAsynchronousModifications);

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.mm
@@ -10,24 +10,19 @@
 
 #import <UIKit/UIKit.h>
 
-#import <map>
-#import <unordered_map>
-
 #import "CKTransactionalComponentDataSourceChangesetVerification.h"
 
 #import <ComponentKit/CKTransactionalComponentDataSourceChangesetInternal.h>
 #import <ComponentKit/CKTransactionalComponentDataSourceChangesetModification.h>
 #import <ComponentKit/CKTransactionalComponentDataSourceStateInternal.h>
 
-static CKTransactionalComponentDataSourceState *foldModificationsIntoState(CKTransactionalComponentDataSourceState *state,
-                                                                           NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *modifications);
+static NSArray<NSNumber *> *sectionCountsWithModificationsFoldedIntoState(CKTransactionalComponentDataSourceState *state,
+                                                                          NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *modifications);
 
-static CKTransactionalComponentDataSourceState *foldModificationIntoState(CKTransactionalComponentDataSourceState *state,
-                                                                          CKTransactionalComponentDataSourceChangesetModification *changesetModification);
+static NSArray<NSNumber *> *sectionCountsForState(CKTransactionalComponentDataSourceState *state);
 
-static NSArray *emptyMutableArrays(NSUInteger count);
-
-static NSMutableArray<NSNumber *> *sectionCountsForState(CKTransactionalComponentDataSourceState *state);
+static NSArray<NSNumber *> *updatedSectionCountsWithModification(NSArray<NSNumber *> *sectionCounts,
+                                                                 CKTransactionalComponentDataSourceChangesetModification *changesetModification);
 
 static NSArray<NSIndexPath *> *sortedIndexPaths(NSArray<NSIndexPath *> *indexPaths);
 
@@ -36,12 +31,10 @@ CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentD
                                                        NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *pendingAsynchronousModifications)
 {
   /*
-   "Fold" any pending asynchronous modifications into the supplied state.
-   This process ensures that the modified state represents the actual state the changeset will be applied to.
+   "Fold" any pending asynchronous modifications into the supplied state and compute the number of items in each section.
+   This process ensures that the modified state represents the state the changeset will be eventually applied to.
    */
-  CKTransactionalComponentDataSourceState *modifiedState = foldModificationsIntoState(state, pendingAsynchronousModifications);
-  // Compute the number of items in each section used to maintain a running tally as changeset modifications are "applied".
-  NSMutableArray<NSNumber *> *sectionCounts = sectionCountsForState(modifiedState);
+  NSMutableArray<NSNumber *> *sectionCounts = [sectionCountsWithModificationsFoldedIntoState(state, pendingAsynchronousModifications) mutableCopy];
   __block BOOL invalidChangeFound = NO;
   // Updated items
   [changeset.updatedItems enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull indexPath, id _Nonnull model, BOOL * _Nonnull stop) {
@@ -165,92 +158,56 @@ CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentD
   return invalidChangeFound ? CKBadChangesetOperationTypeMoveRow : CKBadChangesetOperationTypeNone;
 }
 
-static CKTransactionalComponentDataSourceState *foldModificationsIntoState(CKTransactionalComponentDataSourceState *state,
-                                                                           NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *modifications)
+static NSArray<NSNumber *> *sectionCountsWithModificationsFoldedIntoState(CKTransactionalComponentDataSourceState *state,
+                                                                          NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *modifications)
 {
-  CKTransactionalComponentDataSourceState *modifiedState = state;
+  NSArray<NSNumber *> *sectionCounts = sectionCountsForState(state);
   for (id<CKTransactionalComponentDataSourceStateModifying> modification in modifications) {
     if ([modification isKindOfClass:[CKTransactionalComponentDataSourceChangesetModification class]]) {
-      modifiedState = foldModificationIntoState(modifiedState, modification);
+      sectionCounts = updatedSectionCountsWithModification(sectionCounts, modification);
     }
   }
-  return modifiedState;
+  return sectionCounts;
 }
 
-static CKTransactionalComponentDataSourceState *foldModificationIntoState(CKTransactionalComponentDataSourceState *state,
-                                                                          CKTransactionalComponentDataSourceChangesetModification *changesetModification)
-{
-  CKTransactionalComponentDataSourceChangeset *changeset = changesetModification.changeset;
-  NSMutableArray *modifiedSections = [NSMutableArray new];
-  [state.sections enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger index, BOOL *sectionStop) {
-    [modifiedSections addObject:[items mutableCopy]];
-  }];
-  // Update items
-  [[changeset updatedItems] enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPath, id model, BOOL *stop) {
-    [modifiedSections[indexPath.section] replaceObjectAtIndex:indexPath.item withObject:model];
-  }];
-  __block std::unordered_map<NSUInteger, std::map<NSUInteger, id>> insertedItemsBySection;
-  __block std::unordered_map<NSUInteger, NSMutableIndexSet *> removedItemsBySection;
-  void (^addRemovedIndexPath)(NSIndexPath *) = ^(NSIndexPath *indexPath){
-    const auto &element = removedItemsBySection.find(indexPath.section);
-    if (element == removedItemsBySection.end()) {
-      removedItemsBySection.insert({indexPath.section, [NSMutableIndexSet indexSetWithIndex:indexPath.item]});
-    } else {
-      [element->second addIndex:indexPath.item];
-    }
-  };
-  // Move items
-  [[changeset movedItems] enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *fromIndexPath, NSIndexPath *toIndexPath, BOOL *stop) {
-    insertedItemsBySection[toIndexPath.section][toIndexPath.row] = modifiedSections[fromIndexPath.section][fromIndexPath.item];
-  }];
-  [[changeset movedItems] enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *fromIndexPath, NSIndexPath *toIndexPath, BOOL *stop) {
-    addRemovedIndexPath(fromIndexPath);
-  }];
-  // Remove items
-  for (NSIndexPath *removedItem in [changeset removedItems]) {
-    addRemovedIndexPath(removedItem);
-  }
-  for (const auto &removedItems : removedItemsBySection) {
-    [[modifiedSections objectAtIndex:removedItems.first] removeObjectsAtIndexes:removedItems.second];
-  }
-  // Remove sections
-  [modifiedSections removeObjectsAtIndexes:[changeset removedSections]];
-  // Insert sections
-  [modifiedSections insertObjects:emptyMutableArrays([[changeset insertedSections] count])
-                        atIndexes:[changeset insertedSections]];
-  // Insert items
-  [[changeset insertedItems] enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPath, id model, BOOL *stop) {
-    insertedItemsBySection[indexPath.section][indexPath.item] = model;
-  }];
-  for (const auto &section : insertedItemsBySection) {
-    NSMutableIndexSet *indexes = [NSMutableIndexSet indexSet];
-    NSMutableArray *items = [NSMutableArray array];
-    for (const auto &item : section.second) {
-      [indexes addIndex:item.first];
-      [items addObject:item.second];
-    }
-    [[modifiedSections objectAtIndex:section.first] insertObjects:items atIndexes:indexes];
-  }
-  return [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:state.configuration
-                                                                       sections:modifiedSections];
-}
-
-static NSArray *emptyMutableArrays(NSUInteger count)
-{
-  NSMutableArray *arrays = [NSMutableArray new];
-  for (NSUInteger i = 0; i < count; i++) {
-    [arrays addObject:[NSMutableArray new]];
-  }
-  return arrays;
-}
-
-static NSMutableArray<NSNumber *> *sectionCountsForState(CKTransactionalComponentDataSourceState *state)
+static NSArray<NSNumber *> *sectionCountsForState(CKTransactionalComponentDataSourceState *state)
 {
   NSMutableArray *sectionCounts = [NSMutableArray new];
   for (NSArray *section in state.sections) {
     [sectionCounts addObject:@(section.count)];
   }
   return sectionCounts;
+}
+
+static NSArray<NSNumber *> *updatedSectionCountsWithModification(NSArray<NSNumber *> *sectionCounts,
+                                                                 CKTransactionalComponentDataSourceChangesetModification *changesetModification)
+{
+  CKTransactionalComponentDataSourceChangeset *changeset = changesetModification.changeset;
+  NSMutableArray *updatedSectionCounts = [sectionCounts mutableCopy];
+  // Move items
+  [changeset.movedItems enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull fromIndexPath, NSIndexPath * _Nonnull toIndexPath, BOOL * _Nonnull stop) {
+    // "Remove" the item
+    updatedSectionCounts[fromIndexPath.section] = @([updatedSectionCounts[fromIndexPath.section] integerValue] - 1);
+    // "Insert" the item
+    updatedSectionCounts[toIndexPath.section] = @([updatedSectionCounts[toIndexPath.section] integerValue] + 1);
+  }];
+  // Remove items
+  [changeset.removedItems enumerateObjectsUsingBlock:^(NSIndexPath *_Nonnull indexPath, BOOL * _Nonnull stop) {
+    updatedSectionCounts[indexPath.section] = @([updatedSectionCounts[indexPath.section] integerValue] - 1);
+  }];
+  // Remove sections
+  [updatedSectionCounts removeObjectsAtIndexes:changeset.removedSections];
+  // Insert sections
+  NSMutableArray *emptySections = [NSMutableArray new];
+  for (NSUInteger i = 0; i < changeset.insertedSections.count; i++) {
+    [emptySections addObject:@0];
+  }
+  [updatedSectionCounts insertObjects:emptySections atIndexes:changeset.insertedSections];
+  // Insert items
+  [changeset.insertedItems enumerateKeysAndObjectsUsingBlock:^(NSIndexPath * _Nonnull indexPath, id _Nonnull model, BOOL * _Nonnull stop) {
+    updatedSectionCounts[indexPath.section] = @([updatedSectionCounts[indexPath.section] integerValue] + 1);
+  }];
+  return updatedSectionCounts;
 }
 
 static NSArray<NSIndexPath *> *sortedIndexPaths(NSArray<NSIndexPath *> *indexPaths)

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetVerification.mm
@@ -40,7 +40,7 @@ CKBadChangesetOperationType CKIsValidChangesetForState(CKTransactionalComponentD
    This process ensures that the modified state represents the actual state the changeset will be applied to.
    */
   CKTransactionalComponentDataSourceState *modifiedState = foldModificationsIntoState(state, pendingAsynchronousModifications);
-  // Compute the initial collection of section used, used to maintain a running tally of how many items are present in each section.
+  // Compute the number of items in each section used to maintain a running tally as changeset modifications are "applied".
   NSMutableArray<NSNumber *> *sectionCounts = sectionCountsForState(modifiedState);
   __block BOOL invalidChangeFound = NO;
   // Updated items
@@ -181,7 +181,7 @@ static CKTransactionalComponentDataSourceState *foldModificationIntoState(CKTran
                                                                           CKTransactionalComponentDataSourceChangesetModification *changesetModification)
 {
   CKTransactionalComponentDataSourceChangeset *changeset = changesetModification.changeset;
-  NSMutableArray *modifiedSections = [NSMutableArray array];
+  NSMutableArray *modifiedSections = [NSMutableArray new];
   [state.sections enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger index, BOOL *sectionStop) {
     [modifiedSections addObject:[items mutableCopy]];
   }];
@@ -237,9 +237,9 @@ static CKTransactionalComponentDataSourceState *foldModificationIntoState(CKTran
 
 static NSArray *emptyMutableArrays(NSUInteger count)
 {
-  NSMutableArray *arrays = [NSMutableArray array];
+  NSMutableArray *arrays = [NSMutableArray new];
   for (NSUInteger i = 0; i < count; i++) {
-    [arrays addObject:[NSMutableArray array]];
+    [arrays addObject:[NSMutableArray new]];
   }
   return arrays;
 }

--- a/ComponentKit/Utilities/CKArrayControllerChangesetVerification.h
+++ b/ComponentKit/Utilities/CKArrayControllerChangesetVerification.h
@@ -23,7 +23,5 @@
  @param sections the current sections (or state) of the data source
  @return which section is causing an issue, if any. If there's no issue, this function will return CKBadChangesetOperationTypeNone
  */
-CKBadChangesetOperationType CKIsValidChangesetForSections(CKArrayControllerInputChangeset changeset, NSArray<NSArray *> *sections);
-
-/** This function takes a CKBadChangesetOperationType and returns a human readable string for it */
-NSString *CKHumanReadableBadChangesetOperation(CKBadChangesetOperationType type);
+CKBadChangesetOperationType CKIsValidChangesetForSections(CKArrayControllerInputChangeset changeset,
+                                                          NSArray<NSArray *> *sections);

--- a/ComponentKit/Utilities/CKArrayControllerChangesetVerification.mm
+++ b/ComponentKit/Utilities/CKArrayControllerChangesetVerification.mm
@@ -150,25 +150,3 @@ CKBadChangesetOperationType CKIsValidChangesetForSections(CKArrayControllerInput
 
   return invalidChangeFound ? CKBadChangesetOperationTypeMoveRow : CKBadChangesetOperationTypeNone;
 }
-
-NSString *CKHumanReadableBadChangesetOperation(CKBadChangesetOperationType type)
-{
-  switch (type) {
-    case CKBadChangesetOperationTypeUpdate:
-      return @"Bad Update";
-    case CKBadChangesetOperationTypeRemoveRow:
-      return @"Bad Row Removal";
-    case CKBadChangesetOperationTypeRemoveSection:
-      return @"Bad Section Removal";
-    case CKBadChangesetOperationTypeInsertSection:
-      return @"Bad Section Insertion";
-    case CKBadChangesetOperationTypeMoveSection:
-      return @"Bad Section Move";
-    case CKBadChangesetOperationTypeInsertRow:
-      return @"Bad Row Insertion";
-    case CKBadChangesetOperationTypeMoveRow:
-      return @"Bad Row Move";
-    case CKBadChangesetOperationTypeNone:
-      return @"No Issue";
-  }
-}

--- a/ComponentKit/Utilities/CKBadChangesetOperationType.h
+++ b/ComponentKit/Utilities/CKBadChangesetOperationType.h
@@ -20,3 +20,6 @@ typedef NS_ENUM(NSUInteger, CKBadChangesetOperationType) {
   CKBadChangesetOperationTypeMoveSection,
   CKBadChangesetOperationTypeMoveRow
 };
+
+/** Returns a human readable translation of the given CKBadChangesetOperationType. */
+NSString *CKHumanReadableBadChangesetOperationType(CKBadChangesetOperationType type);

--- a/ComponentKit/Utilities/CKBadChangesetOperationType.mm
+++ b/ComponentKit/Utilities/CKBadChangesetOperationType.mm
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKBadChangesetOperationType.h"
+
+NSString *CKHumanReadableBadChangesetOperationType(CKBadChangesetOperationType type)
+{
+  switch (type) {
+    case CKBadChangesetOperationTypeUpdate:
+      return @"Bad Update";
+    case CKBadChangesetOperationTypeRemoveRow:
+      return @"Bad Row Removal";
+    case CKBadChangesetOperationTypeRemoveSection:
+      return @"Bad Section Removal";
+    case CKBadChangesetOperationTypeInsertSection:
+      return @"Bad Section Insertion";
+    case CKBadChangesetOperationTypeMoveSection:
+      return @"Bad Section Move";
+    case CKBadChangesetOperationTypeInsertRow:
+      return @"Bad Row Insertion";
+    case CKBadChangesetOperationTypeMoveRow:
+      return @"Bad Row Move";
+    case CKBadChangesetOperationTypeNone:
+      return @"No Issue";
+  }
+}

--- a/ComponentKit/Utilities/CKSectionedArrayController.mm
+++ b/ComponentKit/Utilities/CKSectionedArrayController.mm
@@ -236,7 +236,7 @@ static void verifyChangeset(CKArrayControllerInputChangeset changeset, NSArray<N
 {
 #if CK_ASSERTIONS_ENABLED
   CKBadChangesetOperationType badChangesetOperationType = CKIsValidChangesetForSections(changeset, sections);
-  CKCAssert(badChangesetOperationType == CKBadChangesetOperationTypeNone, @"Bad operation: %@\nChangeset:\n************\n %@\n************\nCurrent data source state: %@", CKHumanReadableBadChangesetOperation(badChangesetOperationType), changeset.description(), sections);
+  CKCAssert(badChangesetOperationType == CKBadChangesetOperationTypeNone, @"Bad operation: %@\nChangeset:\n************\n %@\n************\nCurrent data source state: %@", CKHumanReadableBadChangesetOperationType(badChangesetOperationType), changeset.description(), sections);
 #endif
 }
 

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
@@ -34,7 +34,7 @@
   CKTransactionalComponentDataSourceChangeset *changeset =
   [[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_emptyChangesetNonEmptySections
@@ -54,7 +54,7 @@
   CKTransactionalComponentDataSourceChangeset *changeset =
   [[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_nonEmptyChangesetEmptySections
@@ -70,7 +70,7 @@
                        [NSIndexPath indexPathForItem:1 inSection:0]: @"B",
                        }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionIntoEmptySection
@@ -87,7 +87,7 @@
                         [NSIndexPath indexPathForItem:1 inSection:0]: @"B",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionIntoBeginningOfNonEmptySection
@@ -107,7 +107,7 @@
                         [NSIndexPath indexPathForItem:1 inSection:0]: @"B",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionIntoMiddleOfNonEmptySection
@@ -127,7 +127,7 @@
                         [NSIndexPath indexPathForItem:2 inSection:0]: @"B",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionAtEndOfNonEmptySection
@@ -147,7 +147,7 @@
                         [NSIndexPath indexPathForItem:3 inSection:0]: @"B",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validRemovalAtBeginningOfSection
@@ -167,7 +167,7 @@
                                            [NSIndexPath indexPathForItem:0 inSection:0],
                                            ]]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validRemovalAtMiddleOfSection
@@ -187,7 +187,7 @@
                                            [NSIndexPath indexPathForItem:1 inSection:0],
                                            ]]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validRemovalAtEndOfSection
@@ -207,7 +207,7 @@
                                            [NSIndexPath indexPathForItem:2 inSection:0],
                                            ]]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validRemovalOfAllItems
@@ -229,7 +229,7 @@
                                            [NSIndexPath indexPathForItem:0 inSection:0],
                                            ]]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionOfSectionInEmptySections
@@ -241,7 +241,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionOfSectionAtBeginningOfNonEmptySections
@@ -262,7 +262,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionOfSectionInMiddleOfNonEmptySections
@@ -283,7 +283,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:1]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionOfSectionAtEndOfNonEmptySections
@@ -304,7 +304,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:2]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validInsertionOfMultipleSections
@@ -325,7 +325,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 2)]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_removalOfSectionAtBeginningOfSections
@@ -350,7 +350,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withRemovedSections:[NSIndexSet indexSetWithIndex:0]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_removalOfSectionAtMiddleOfSections
@@ -375,7 +375,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withRemovedSections:[NSIndexSet indexSetWithIndex:1]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_removalOfSectionAtEndOfSections
@@ -400,7 +400,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withRemovedSections:[NSIndexSet indexSetWithIndex:2]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_removeMultipleSectionsAtBeginningOfSections
@@ -425,7 +425,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withRemovedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, 2)]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_removeMultipleSectionsAtEndOfSections
@@ -450,7 +450,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withRemovedSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 2)]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validUpdate
@@ -469,7 +469,7 @@
                        [NSIndexPath indexPathForItem:0 inSection:0]: @"A",
                        }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validMoveForwardInsideOneSection
@@ -488,7 +488,7 @@
                      [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:1 inSection:0],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validMoveBackwardInsideOneSection
@@ -507,7 +507,7 @@
                      [NSIndexPath indexPathForItem:1 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validMoveForwardBetweenSections
@@ -534,7 +534,7 @@
                      [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:1],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 - (void)test_validMoveBackwardBetweenSections
@@ -561,7 +561,7 @@
                      [NSIndexPath indexPathForItem:0 inSection:1]: [NSIndexPath indexPathForItem:2 inSection:0],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 #pragma mark - Invalid changesets
@@ -582,7 +582,7 @@
                        [NSIndexPath indexPathForItem:1 inSection:-1]: @"A",
                        }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeUpdate);
 }
 
 - (void)test_invalidUpdateInNegativeItem
@@ -601,7 +601,7 @@
                        [NSIndexPath indexPathForItem:-1 inSection:0]: @"A",
                        }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeUpdate);
 }
 
 - (void)test_invalidInsertionAtEndOfSection
@@ -620,7 +620,7 @@
                         [NSIndexPath indexPathForItem:3 inSection:0]: @"A",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeInsertRow);
 }
 
 - (void)test_invalidMultipleInsertionAtEndOfSection
@@ -641,7 +641,7 @@
                         [NSIndexPath indexPathForItem:5 inSection:0]: @"E",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeInsertRow);
 }
 
 - (void)test_invalidInsertionInNonExistentSection
@@ -660,7 +660,7 @@
                         [NSIndexPath indexPathForItem:0 inSection:1]: @"A",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeInsertRow);
 }
 
 - (void)test_invalidRemovalInValidSection
@@ -679,7 +679,7 @@
                                            [NSIndexPath indexPathForItem:2 inSection:0],
                                            ]]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeRemoveRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeRemoveRow);
 }
 
 - (void)test_invalidRemovalInNonExistentSection
@@ -698,7 +698,7 @@
                                            [NSIndexPath indexPathForItem:0 inSection:1],
                                            ]]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeRemoveRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeRemoveRow);
 }
 
 - (void)test_invalidInsertionOfSection
@@ -715,7 +715,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:2]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeInsertSection);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeInsertSection);
 }
 
 - (void)test_invalidRemovalOfSection
@@ -732,7 +732,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withRemovedSections:[NSIndexSet indexSetWithIndex:2]]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeRemoveSection);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeRemoveSection);
 }
 
 - (void)test_invalidUpdateWithinExistingSection
@@ -751,7 +751,7 @@
                        [NSIndexPath indexPathForItem:2 inSection:0]: @"A",
                        }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeUpdate);
 }
 
 - (void)test_invalidUpdateWithinNonExistentSection
@@ -770,7 +770,7 @@
                        [NSIndexPath indexPathForItem:0 inSection:1]: @"A",
                        }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeUpdate);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeUpdate);
 }
 
 - (void)test_moveWithInvalidOriginIndexPathInExistingSection
@@ -789,7 +789,7 @@
                      [NSIndexPath indexPathForItem:2 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:0],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeMoveRow);
 }
 
 - (void)test_moveWithInvalidDestinationIndexPathInExistingSection
@@ -808,7 +808,7 @@
                      [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:2 inSection:0],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeMoveRow);
 }
 
 - (void)test_moveWithInvalidOriginSection
@@ -827,7 +827,7 @@
                      [NSIndexPath indexPathForItem:0 inSection:1]: [NSIndexPath indexPathForItem:0 inSection:0],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeMoveRow);
 }
 
 - (void)test_moveWithInvalidDestinationSection
@@ -846,7 +846,7 @@
                      [NSIndexPath indexPathForItem:0 inSection:0]: [NSIndexPath indexPathForItem:0 inSection:1],
                      }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeMoveRow);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeMoveRow);
 }
 
 #pragma mark - More complicated situations
@@ -866,7 +866,7 @@
                         [NSIndexPath indexPathForItem:1 inSection:1]: @"B2",
                         }]
    build];
-  XCTAssertEqual(CKIsValidChangesetForState(changeset, state), CKBadChangesetOperationTypeNone);
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
 static CKTransactionalComponentDataSourceItem *itemWithModel(id model)

--- a/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
+++ b/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
@@ -68,7 +68,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
    build];
-  [_dataSource applyChangeset:initialChangeset mode:CKUpdateModeAsynchronous userInfo:nil];
+  [_dataSource applyChangeset:initialChangeset mode:CKUpdateModeSynchronous userInfo:nil];
   [self _enqueuePage:[_quoteModelController fetchNewQuotesPageWithCount:4]];
 }
 

--- a/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
+++ b/Examples/WildeGuess/WildeGuess/WildeGuessCollectionViewController.mm
@@ -68,7 +68,7 @@
   [[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
    build];
-  [_dataSource applyChangeset:initialChangeset mode:CKUpdateModeSynchronous userInfo:nil];
+  [_dataSource applyChangeset:initialChangeset mode:CKUpdateModeAsynchronous userInfo:nil];
   [self _enqueuePage:[_quoteModelController fetchNewQuotesPageWithCount:4]];
 }
 


### PR DESCRIPTION
Adds an assertion to `CKTransactionalComponentDataSource` as changesets are applied.

Test Plan:

Trigger bad changesets in WildeGuess and verify assertions are raised.