### PR TITLE
Raise exceptions that include the name of the offending component during mount

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -340,6 +340,10 @@
 		2D8C3D441D64F41E00E6D47A /* ReferenceImages_IOS10_64 in Resources */ = {isa = PBXBuildFile; fileRef = 2D8C3D421D64F41E00E6D47A /* ReferenceImages_IOS10_64 */; };
 		2D8C3D521D64F43E00E6D47A /* ReferenceImages_IOS10_64 in Resources */ = {isa = PBXBuildFile; fileRef = 2D8C3D501D64F43E00E6D47A /* ReferenceImages_IOS10_64 */; };
 		2D8C3D541D64F44B00E6D47A /* ReferenceImages_IOS9_64 in Resources */ = {isa = PBXBuildFile; fileRef = 2D8C3D531D64F44B00E6D47A /* ReferenceImages_IOS9_64 */; };
+		2DA523981DCA8CA0007EF261 /* CKComponentBacktraceDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DA523961DCA8CA0007EF261 /* CKComponentBacktraceDescription.h */; };
+		2DA523991DCA8CA0007EF261 /* CKComponentBacktraceDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DA523961DCA8CA0007EF261 /* CKComponentBacktraceDescription.h */; };
+		2DA5239A1DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DA523971DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm */; };
+		2DA5239B1DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DA523971DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm */; };
 		2DBF1D7A1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DBF1D7B1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */; };
 		2DCA4E721D889D0300AAB2B3 /* CKTransactionalComponentDataSourceConfigurationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DCA4E711D889B8500AAB2B3 /* CKTransactionalComponentDataSourceConfigurationInternal.h */; };
@@ -894,6 +898,8 @@
 		2D8C3D421D64F41E00E6D47A /* ReferenceImages_IOS10_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS10_64; sourceTree = "<group>"; };
 		2D8C3D501D64F43E00E6D47A /* ReferenceImages_IOS10_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS10_64; sourceTree = "<group>"; };
 		2D8C3D531D64F44B00E6D47A /* ReferenceImages_IOS9_64 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ReferenceImages_IOS9_64; sourceTree = "<group>"; };
+		2DA523961DCA8CA0007EF261 /* CKComponentBacktraceDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKComponentBacktraceDescription.h; sourceTree = "<group>"; };
+		2DA523971DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentBacktraceDescription.mm; sourceTree = "<group>"; };
 		2DBF1D781D3425ED004F28E8 /* CKDetectComponentScopeCollisions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKDetectComponentScopeCollisions.h; sourceTree = "<group>"; };
 		2DBF1D791D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKDetectComponentScopeCollisions.mm; sourceTree = "<group>"; };
 		2DCA4E711D889B8500AAB2B3 /* CKTransactionalComponentDataSourceConfigurationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKTransactionalComponentDataSourceConfigurationInternal.h; sourceTree = "<group>"; };
@@ -1622,6 +1628,8 @@
 				D0B47AD71CBD926700BB33CE /* CKComponentAnimation.h */,
 				D0B47AD81CBD926700BB33CE /* CKComponentAnimation.mm */,
 				D0B47AD91CBD926700BB33CE /* CKComponentAnimationHooks.h */,
+				2DA523961DCA8CA0007EF261 /* CKComponentBacktraceDescription.h */,
+				2DA523971DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm */,
 				D0B47ADA1CBD926700BB33CE /* CKComponentBoundsAnimation.h */,
 				D0B47ADB1CBD926700BB33CE /* CKComponentBoundsAnimation.mm */,
 				D0B47ADC1CBD926700BB33CE /* CKComponentController.h */,
@@ -2067,6 +2075,7 @@
 				03B8B4E31D2A346F00EDFF59 /* CKComponentAccessibility.h in Headers */,
 				03B8B4E41D2A346F00EDFF59 /* CKComponentHostingViewInternal.h in Headers */,
 				03B8B4E51D2A346F00EDFF59 /* CKComponentPreparationQueueListener.h in Headers */,
+				2DA523991DCA8CA0007EF261 /* CKComponentBacktraceDescription.h in Headers */,
 				03B8B4E61D2A346F00EDFF59 /* CKStackLayoutComponentUtilities.h in Headers */,
 				03B8B4E71D2A346F00EDFF59 /* CKComponentDataSourceInputItem.h in Headers */,
 				03B8B4E81D2A346F00EDFF59 /* CKStackUnpositionedLayout.h in Headers */,
@@ -2278,6 +2287,7 @@
 				D0B47D301CBD948E00BB33CE /* CKComponentSizeRangeProviding.h in Headers */,
 				D0B47D031CBD948E00BB33CE /* CKSizeRange.h in Headers */,
 				D0B47D0A1CBD948E00BB33CE /* CKComponentScope.h in Headers */,
+				2DA523981DCA8CA0007EF261 /* CKComponentBacktraceDescription.h in Headers */,
 				D0B47D411CBD948E00BB33CE /* CKTransactionalComponentDataSourceChangesetInternal.h in Headers */,
 				D0B47CFE1CBD948E00BB33CE /* CKComponentViewAttribute.h in Headers */,
 				D0B47D4A1CBD948E00BB33CE /* CKTransactionalComponentDataSourceChange.h in Headers */,
@@ -2900,6 +2910,7 @@
 				03B8B4BF1D2A346F00EDFF59 /* CKTextKitAttributes.mm in Sources */,
 				03B8B4C01D2A346F00EDFF59 /* CKTextKitContext.mm in Sources */,
 				03B8B4C11D2A346F00EDFF59 /* CKTextKitEntityAttribute.m in Sources */,
+				2DA5239B1DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm in Sources */,
 				03B8B4C21D2A346F00EDFF59 /* CKTextKitRenderer+Positioning.mm in Sources */,
 				03B8B4C31D2A346F00EDFF59 /* CKTextKitRenderer+TextChecking.mm in Sources */,
 				03B8B4C41D2A346F00EDFF59 /* CKTextKitRenderer.mm in Sources */,
@@ -3174,6 +3185,7 @@
 				D0B47CD71CBD943400BB33CE /* CKTextKitAttributes.mm in Sources */,
 				D0B47CD81CBD943400BB33CE /* CKTextKitContext.mm in Sources */,
 				D0B47CD91CBD943400BB33CE /* CKTextKitEntityAttribute.m in Sources */,
+				2DA5239A1DCA8CA0007EF261 /* CKComponentBacktraceDescription.mm in Sources */,
 				D0B47CDA1CBD943400BB33CE /* CKTextKitRenderer+Positioning.mm in Sources */,
 				D0B47CDB1CBD943400BB33CE /* CKTextKitRenderer+TextChecking.mm in Sources */,
 				D0B47CDC1CBD943400BB33CE /* CKTextKitRenderer.mm in Sources */,

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -146,13 +146,8 @@ struct CKComponentMountInfo {
       [v setCenter:effectiveContext.position + CGPoint({size.width * anchorPoint.x, size.height * anchorPoint.y})];
       [v setBounds:{v.bounds.origin, size}];
     } @catch (NSException *exception) {
-      NSMutableArray<CKComponent *> *const componentBacktrace = [NSMutableArray arrayWithObject:supercomponent];
-      while ([componentBacktrace lastObject]
-             && [componentBacktrace lastObject]->_mountInfo
-             && [componentBacktrace lastObject]->_mountInfo->supercomponent) {
-        [componentBacktrace addObject:[componentBacktrace lastObject]->_mountInfo->supercomponent];
-      }
-      NSString *const componentBacktraceDescription = CKComponentBacktraceDescription(componentBacktrace);
+      NSString *const componentBacktraceDescription =
+      CKComponentBacktraceDescription(generateComponentBacktrace(supercomponent));
       [NSException raise:exception.name
                   format:@"%@ raised %@ during mount: %@\n%@", [self class], exception.name, exception.reason, componentBacktraceDescription];
     }
@@ -319,6 +314,17 @@ static void *kRootComponentMountedViewKey = &kRootComponentMountedViewKey;
 - (id<NSObject>)scopeFrameToken
 {
   return _scopeHandle ? @(_scopeHandle.globalIdentifier) : nil;
+}
+
+static NSArray<CKComponent *> *generateComponentBacktrace(CKComponent *component)
+{
+  NSMutableArray<CKComponent *> *const componentBacktrace = [NSMutableArray arrayWithObject:component];
+  while ([componentBacktrace lastObject]
+         && [componentBacktrace lastObject]->_mountInfo
+         && [componentBacktrace lastObject]->_mountInfo->supercomponent) {
+    [componentBacktrace addObject:[componentBacktrace lastObject]->_mountInfo->supercomponent];
+  }
+  return componentBacktrace;
 }
 
 @end

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -151,7 +151,6 @@ struct CKComponentMountInfo {
              && [componentBacktrace lastObject]->_mountInfo
              && [componentBacktrace lastObject]->_mountInfo->supercomponent) {
         [componentBacktrace addObject:[componentBacktrace lastObject]->_mountInfo->supercomponent];
-
       }
       NSString *const componentBacktraceDescription = CKComponentBacktraceDescription(componentBacktrace);
       [NSException raise:exception.name

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -140,9 +140,14 @@ struct CKComponentMountInfo {
       CKAssert(v.ck_component == self, @"");
     }
 
-    const CGPoint anchorPoint = v.layer.anchorPoint;
-    [v setCenter:effectiveContext.position + CGPoint({size.width * anchorPoint.x, size.height * anchorPoint.y})];
-    [v setBounds:{v.bounds.origin, size}];
+    @try {
+      const CGPoint anchorPoint = v.layer.anchorPoint;
+      [v setCenter:effectiveContext.position + CGPoint({size.width * anchorPoint.x, size.height * anchorPoint.y})];
+      [v setBounds:{v.bounds.origin, size}];
+    } @catch (NSException *exception) {
+      [NSException raise:exception.name
+                  format:@"%@ raised %@ during mount: %@", [self class], exception.name, exception.reason];
+    }
 
     _mountInfo->viewContext = {v, {{0,0}, v.bounds.size}};
     return {.mountChildren = YES, .contextForChildren = effectiveContext.childContextForSubview(v, g.didBlockAnimations)};

--- a/ComponentKit/Core/CKComponentBacktraceDescription.h
+++ b/ComponentKit/Core/CKComponentBacktraceDescription.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@class CKComponent;
+
+NSString *CKComponentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace);

--- a/ComponentKit/Core/CKComponentBacktraceDescription.mm
+++ b/ComponentKit/Core/CKComponentBacktraceDescription.mm
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKComponentBacktraceDescription.h"
+
+#import "CKComponent.h"
+
+NSString *CKComponentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace)
+{
+  NSMutableString *const description = [NSMutableString string];
+  [componentBacktrace enumerateObjectsWithOptions:NSEnumerationReverse
+                                       usingBlock:^(CKComponent * _Nonnull component, NSUInteger index, BOOL * _Nonnull stop) {
+                                         const NSInteger depth = componentBacktrace.count - index - 1;
+                                         if (depth != 0) {
+                                           [description appendString:@"\n"];
+                                         }
+                                         [description appendString:[@"" stringByPaddingToLength:depth withString:@" " startingAtIndex:0]];
+                                         [description appendString:NSStringFromClass([component class])];
+                                         [description appendString:@": "];
+                                         [description appendString:[component description]];
+                                       }];
+  return description;
+}

--- a/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
+++ b/ComponentKit/Core/Scope/CKDetectComponentScopeCollisions.mm
@@ -13,6 +13,7 @@
 #import <queue>
 
 #import "CKAssert.h"
+#import "CKComponentBacktraceDescription.h"
 #import "CKComponentInternal.h"
 
 #pragma clang diagnostic push
@@ -27,23 +28,6 @@ static NSArray<CKComponent *> *generateComponentBacktrace(CKComponent *component
     parentComponent = [componentsToParentComponents objectForKey:parentComponent];
   }
   return componentBacktrace;
-}
-
-static NSString *componentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace)
-{
-  NSMutableString *const description = [NSMutableString string];
-  [componentBacktrace enumerateObjectsWithOptions:NSEnumerationReverse
-                                       usingBlock:^(CKComponent * _Nonnull component, NSUInteger index, BOOL * _Nonnull stop) {
-                                         const NSInteger depth = componentBacktrace.count - index - 1;
-                                         if (depth != 0) {
-                                           [description appendString:@"\n"];
-                                         }
-                                         [description appendString:[@"" stringByPaddingToLength:depth withString:@" " startingAtIndex:0]];
-                                         [description appendString:NSStringFromClass([component class])];
-                                         [description appendString:@": "];
-                                         [description appendString:[component description]];
-                                       }];
-  return description;
 }
 #pragma clang diagnostic pop
 
@@ -62,7 +46,7 @@ void CKDetectComponentScopeCollisions(const CKComponentLayout &layout)
     if (scopeFrameToken && [previouslySeenScopeFrameTokens containsObject:scopeFrameToken]) {
       CKCFailAssert(@"Scope collision. Attempting to create duplicate scope for component: %@\n%@",
                     [component class],
-                    componentBacktraceDescription(generateComponentBacktrace(component, componentsToParentComponents)));
+                    CKComponentBacktraceDescription(generateComponentBacktrace(component, componentsToParentComponents)));
     }
     if (scopeFrameToken) {
       [previouslySeenScopeFrameTokens addObject:scopeFrameToken];


### PR DESCRIPTION
Annotate `CALayerInvalidGeometry` exceptions raised during mount with the name of the offending component.

Test Plan:

Artificially trigger the exception by inserting a `NAN` when computing the view's center:

```
[v setCenter:effectiveContext.position + CGPoint({size.width * anchorPoint.x, size.height * anchorPoint.y + NAN})];
```

Run the snapshot tests and verify the exception is raised with the updated reason:

```
"CALayerInvalidGeometry", "CKTextComponent raised CALayerInvalidGeometry during mount: CALayer position contains NaN: [50.5 nan]"
(
	0   CoreFoundation                      0x00000001054c434b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x0000000104f2521e objc_exception_throw + 48
	2   CoreFoundation                      0x000000010552d265 +[NSException raise:format:] + 197
	3   ComponentKit                        0x0000000104719776 -[CKComponent mountInContext:size:children:supercomponent:] + 4246
	4   ComponentKit                        0x00000001048464c8 -[CKTextComponent mountInContext:size:children:supercomponent:] + 296
	5   ComponentKit                        0x000000010472b1ca _Z22CKMountComponentLayoutRK17CKComponentLayoutP6UIViewP5NSSetP11CKComponent + 1562
	6   ComponentKit                        0x0000000104732574 -[CKComponentLifecycleManager _mountLayout] + 68
	7   ComponentKit                        0x0000000104732748 -[CKComponentLifecycleManager attachToView:] + 344
	8   ComponentTextKitApplicationTests    0x00000001111edcc9 -[CKComponentSnapshotTestCase compareSnapshotOfComponent:sizeRange:referenceImagesDirectory:identifier:error:] + 873
	9   ComponentTextKitApplicationTests    0x00000001111b7df2 -[CKTextComponentTests testSimpleString] + 1778
	10  CoreFoundation                      0x000000010544b05c __invoking___ + 140
	11  CoreFoundation                      0x000000010544aee1 -[NSInvocation invoke] + 289
	12  XCTest                              0x0000000110de1210 __24-[XCTestCase invokeTest]_block_invoke_2 + 481
	13  XCTest                              0x0000000110e199d4 -[XCTestContext performInScope:] + 190
	14  XCTest                              0x0000000110de101c -[XCTestCase invokeTest] + 255
	15  XCTest                              0x0000000110de1835 -[XCTestCase performTest:] + 457
	16  XCTest                              0x0000000110dde8fd -[XCTestSuite performTest:] + 491
	17  XCTest                              0x0000000110dde8fd -[XCTestSuite performTest:] + 491
	18  XCTest                              0x0000000110dde8fd -[XCTestSuite performTest:] + 491
	19  XCTest                              0x0000000110dcab0c __25-[XCTestDriver _runSuite]_block_invoke + 51
	20  XCTest                              0x0000000110debfc3 -[XCTestObservationCenter _observeTestExecutionForBlock:] + 602
	21  XCTest                              0x0000000110dca9a9 -[XCTestDriver _runSuite] + 436
	22  XCTest                              0x0000000110dcb7a2 -[XCTestDriver _checkForTestManager] + 287
	23  XCTest                              0x0000000110e1af5c _XCTestMain + 628
	24  CoreFoundation                      0x000000010546925c __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
	25  CoreFoundation                      0x000000010544e304 __CFRunLoopDoBlocks + 356
	26  CoreFoundation                      0x000000010544da75 __CFRunLoopRun + 901
	27  CoreFoundation                      0x000000010544d494 CFRunLoopRunSpecific + 420
	28  GraphicsServices                    0x000000010a9bda6f GSEventRunModal + 161
	29  UIKit                               0x00000001058e7f34 UIApplicationMain + 159
	30  ComponentKitApplicationsTestsHost   0x0000000104668b0f main + 111
	31  libdyld.dylib                       0x0000000108e0c68d start + 1
)
```

/cc @adamjernst