### PR TITLE
Make actions typesafe through templated type

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		A29D85791D80D37F00913E60 /* CKComponentContextHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A243B52C1D79A40800E6C393 /* CKComponentContextHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2CD66321AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */; };
 		A2D20CF41B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */; };
+		B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */; };
 		B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */; };
 		B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */; };
@@ -927,6 +928,7 @@
 		A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateStateModificationTests.mm; sourceTree = "<group>"; };
 		A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateTests.mm; sourceTree = "<group>"; tabWidth = 2; };
 		A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentHostingViewAsyncStateUpdateTests.mm; sourceTree = "<group>"; };
+		B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKComponentActionInternal.h; sourceTree = "<group>"; };
 		B342DC401AC23E8200ACAC53 /* ComponentKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComponentKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKArrayControllerChangesetTests.mm; sourceTree = "<group>"; };
 		B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentAccessibilityTests.mm; sourceTree = "<group>"; };
@@ -1880,6 +1882,7 @@
 				2D640D5C1DB7FD7800271CB4 /* CKBadChangesetOperationType.mm */,
 				D0B47B861CBD926700BB33CE /* CKComponentAction.h */,
 				D0B47B871CBD926700BB33CE /* CKComponentAction.mm */,
+				B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */,
 				D0B47B881CBD926700BB33CE /* CKComponentContext.h */,
 				A243B52C1D79A40800E6C393 /* CKComponentContextHelper.h */,
 				A243B52D1D79A40800E6C393 /* CKComponentContextHelper.mm */,
@@ -2247,6 +2250,7 @@
 				D0B47D2D1CBD948E00BB33CE /* CKComponentHostingViewInternal.h in Headers */,
 				D0B47D241CBD948E00BB33CE /* CKComponentPreparationQueueListener.h in Headers */,
 				D0B47D371CBD948E00BB33CE /* CKStackLayoutComponentUtilities.h in Headers */,
+				B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */,
 				D0B47D1E1CBD948E00BB33CE /* CKComponentDataSourceInputItem.h in Headers */,
 				D0B47D391CBD948E00BB33CE /* CKStackUnpositionedLayout.h in Headers */,
 				D0B47D321CBD948E00BB33CE /* CKCenterLayoutComponent.h in Headers */,

--- a/ComponentKit/Components/CKButtonComponent.h
+++ b/ComponentKit/Components/CKButtonComponent.h
@@ -33,7 +33,7 @@ struct CKButtonComponentAccessibilityConfiguration {
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
-                       action:(const CKTypedComponentAction<UIEvent *> &)action
+                       action:(CKTypedComponentAction<UIEvent *>)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)attributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration;

--- a/ComponentKit/Components/CKButtonComponent.h
+++ b/ComponentKit/Components/CKButtonComponent.h
@@ -33,7 +33,7 @@ struct CKButtonComponentAccessibilityConfiguration {
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
-                       action:(const CKComponentAction &)action
+                       action:(const CKTypedComponentAction<UIEvent *> &)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)attributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration;

--- a/ComponentKit/Components/CKButtonComponent.h
+++ b/ComponentKit/Components/CKButtonComponent.h
@@ -33,7 +33,7 @@ struct CKButtonComponentAccessibilityConfiguration {
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
-                       action:(CKComponentAction)action
+                       action:(const CKComponentAction &)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)attributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration;

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -90,7 +90,7 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
-                       action:(const CKComponentAction &)action
+                       action:(const CKTypedComponentAction<UIEvent *> &)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration
@@ -161,7 +161,7 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                             std::move(attributes),
                             {
                               .accessibilityLabel = accessibilityConfiguration.accessibilityLabel,
-                              .accessibilityComponentAction = enabled ? action : NULL
+                              .accessibilityComponentAction = enabled ? CKComponentAction(action) : NULL
                             }
                           }
                           size:size];

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -90,7 +90,7 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
-                       action:(CKComponentAction)action
+                       action:(const CKComponentAction &)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -90,7 +90,7 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
-                       action:(const CKTypedComponentAction<UIEvent *> &)action
+                       action:(CKTypedComponentAction<UIEvent *>)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration

--- a/ComponentKit/Core/Scope/CKComponentScope.h
+++ b/ComponentKit/Core/Scope/CKComponentScope.h
@@ -65,6 +65,13 @@ public:
   */
   CKComponentStateUpdater stateUpdater(void) const;
 
+  /**
+   @return The scope handle associated with this scope.
+   @discussion This is exposed for use by the framework. You should almost certainly never call this for any reason
+               in your components.
+   */
+  CKComponentScopeHandle *scopeHandle(void) const;
+
 private:
   CKComponentScope(const CKComponentScope&) = delete;
   CKComponentScope &operator=(const CKComponentScope&) = delete;

--- a/ComponentKit/Core/Scope/CKComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKComponentScope.mm
@@ -48,3 +48,8 @@ CKComponentStateUpdater CKComponentScope::stateUpdater(void) const
   CKComponentScopeHandle *const scopeHandle = _scopeHandle;
   return ^(id (^update)(id), CKUpdateMode mode){ [scopeHandle updateState:update mode:mode]; };
 }
+
+CKComponentScopeHandle *CKComponentScope::scopeHandle(void) const
+{
+  return _scopeHandle;
+}

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -51,12 +51,15 @@
  return nil until `resolve` is called.
  */
 @property (nonatomic, strong, readonly) CKComponentController *controller;
-@property (nonatomic, weak, readonly) CKComponent *acquiredComponent;
-@property (nonatomic, assign, readonly) BOOL resolved;
 
 @property (nonatomic, assign, readonly) Class componentClass;
 
 @property (nonatomic, strong, readonly) id state;
 @property (nonatomic, readonly) CKComponentScopeHandleIdentifier globalIdentifier;
+
+/**
+ Provides a responder corresponding with this scope handle. The controller will assert if called before resolution.
+ */
+- (id)responder;
 
 @end

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -51,6 +51,11 @@
  return nil until `resolve` is called.
  */
 @property (nonatomic, strong, readonly) CKComponentController *controller;
+@property (nonatomic, weak, readonly) CKComponent *acquiredComponent;
+@property (nonatomic, assign, readonly) BOOL resolved;
+
+@property (nonatomic, assign, readonly) Class componentClass;
+
 @property (nonatomic, strong, readonly) id state;
 @property (nonatomic, readonly) CKComponentScopeHandleIdentifier globalIdentifier;
 

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -25,6 +25,8 @@
   CKComponentController *_controller;
   CKComponentScopeRootIdentifier _rootIdentifier;
   BOOL _acquired;
+  BOOL _resolved;
+  CKComponent *__weak _acquiredComponent;
 }
 
 + (CKComponentScopeHandle *)handleForComponent:(CKComponent *)component
@@ -162,6 +164,12 @@
     _controller = newController(_acquiredComponent, currentScope->newScopeRoot);
   }
   _resolved = YES;
+}
+
+- (id)responder
+{
+  CKAssert(_resolved, @"Asking for responder from scope handle before resolution:%@", NSStringFromClass(_componentClass));
+  return _acquiredComponent;
 }
 
 #pragma mark Controllers

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -115,11 +115,8 @@ struct CKTypedComponentAction {
   CKTypedComponentAction(SEL selector) : _internal(CKTypedComponentActionVariantRawSelector, nil, nil, selector) { };
 
   /** We support promotion from actions that take no arguments. */
-  template <typename T1, typename... Ts>
-  CKTypedComponentAction<T1, Ts...>(const CKTypedComponentAction<> &action) : _internal(action._internal) { };
-
-  /** Const copy constructor to allow for block capture of the struct. */
-  CKTypedComponentAction<T...>(const CKTypedComponentAction<T...> &action) : _internal(action._internal) { };
+  template <typename... Ts>
+  CKTypedComponentAction<Ts...>(const CKTypedComponentAction<> &action) : _internal(action._internal) { };
 
   /**
    We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -16,11 +16,43 @@
 
 /**
  A component action is simply a selector. The selector may optionally take one argument: the sending component.
-
+ 
  Component actions provide a way for components to communicate to supercomponents using CKComponentActionSend. Since
  components are in the responder chain, the message will reach its supercomponents.
  */
-typedef SEL CKComponentAction;
+struct CKComponentAction {
+public:
+  CKComponentAction() : _selector(NULL) {};
+  
+  /**
+   TODO(ocrickard) Remove this. Implicit conversion from SEL is a temporary change to support refactoring these to
+   take the scope.
+   */
+  CKComponentAction(SEL selector) : _selector(selector) {};
+  
+  /** TODO(ocrickard) Remove this. To support implicit conversion/comparison to NULL. */
+  CKComponentAction(int s) : _selector(NULL) {};
+  CKComponentAction(long s) : _selector(NULL) {};
+  CKComponentAction(std::nullptr_t n) : _selector(NULL) {};
+  
+  SEL selector() const { return _selector; };
+  
+  bool operator==(const CKComponentAction& rhs) const { return _selector == rhs.selector(); };
+  explicit operator bool() const { return _selector != NULL; }
+  
+private:
+  SEL _selector;
+};
+
+/** TODO(ocrickard) Remove this. Present to support comparison with NULL during refactor. */
+inline bool operator==(const CKComponentAction &lhs, const std::nullptr_t &rhs){ return lhs.selector() == NULL; }
+inline bool operator!=(const CKComponentAction &lhs, const std::nullptr_t &rhs){ return !(lhs == rhs); }
+inline bool operator==(const std::nullptr_t &lhs, const CKComponentAction &rhs){ return rhs.selector() == NULL; }
+inline bool operator!=(const std::nullptr_t &lhs, const CKComponentAction &rhs){ return !(lhs == rhs); }
+inline bool operator==(const CKComponentAction &lhs, const long &rhs){ return lhs.selector() == NULL; }
+inline bool operator!=(const CKComponentAction &lhs, const long &rhs){ return !(lhs == rhs); }
+inline bool operator==(const CKComponentAction &lhs, const int &rhs){ return lhs.selector() == NULL; }
+inline bool operator!=(const CKComponentAction &lhs, const int &rhs){ return !(lhs == rhs); }
 
 typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   /** Starts searching at the sender's next responder. Usually this is what you want to prevent infinite loops. */
@@ -32,23 +64,23 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
 /**
  Sends a component action up the responder chain by crawling up the responder chain until it finds a responder that
  responds to the action's selector, then invokes it.
-
+ 
  @param action The action to send up the responder chain.
  @param sender The component sending the action. Traversal starts from the component itself, then its next responder.
  @param context An optional context-dependent second parameter to the component action. Defaults to nil.
  @param behavior @see CKComponentActionSendBehavior
  */
-void CKComponentActionSend(CKComponentAction action, CKComponent *sender, id context = nil,
+void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender,
+                           id context = nil,
                            CKComponentActionSendBehavior behavior = CKComponentActionSendBehaviorStartAtSenderNextResponder);
 
 /**
  Returns a view attribute that configures a component that creates a UIControl to send the given CKComponentAction.
  You can use this with e.g. CKButtonComponent.
-
+ 
  @param action Sent up the responder chain when an event occurs. Sender is the component that created the UIControl;
-        context is the UIEvent that triggered the action. May be NULL, in which case no action will be sent.
+ context is the UIEvent that triggered the action. May be NULL, in which case no action will be sent.
  @param controlEvents The events that should result in the action being sent. Default is touch up inside.
  */
-CKComponentViewAttributeValue CKComponentActionAttribute(CKComponentAction action,
+CKComponentViewAttributeValue CKComponentActionAttribute(const CKComponentAction &action,
                                                          UIControlEvents controlEvents = UIControlEventTouchUpInside);
-

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -22,10 +22,76 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   CKComponentActionSendBehaviorStartAtSender,
 };
 
+/**
+ CKTypedComponentAction is a struct that represents a method invocation that can be passed to a child component to
+ trigger a method invocation on a target.
+ 
+ We allow a typed specification of the parameters that will be provided as arguments to the component action at runtime
+ through the variadic templated arguments. You may specify an arbitrary number of arguments to your component action,
+ and you may use either object, or primitive arguments. You should not use C++ references as arguments because the block
+ API will likely result in corrupted memory access. Pass C++ structs by value as arguments to action sending.
+
+ Methods will always be provided the sender as the first argument.
+ 
+ Usage in your component header:
+ 
+ @interface MyComponent : CKComponent
+ + (instancetype)newWithAction:(const CKTypedComponentAction<NSString *, int> &)action;
+ @end
+ 
+ When creating the action:
+ 
+ Option 1 - Promoted raw-selector component action. Uses a raw selector which traverses upwards looking for a parent
+            that implements methodWithNoArguments, and calls that method without any arguments. The component responder
+            chain is only present while the component is mounted, so you should use a target/selector action or a
+            scope action if your action will be fired either before or after your component is mounted. We support
+            actions which accept fewer arguments than defined in the declaration of the action above. However, types of
+            received parameters should be the same as the declaration, if they're present.
+
+ [MyComponent newWithAction:{@selector(methodWithNoArguments)}];
+ ...
+ - (void)methodWithNoArguments {}
+
+ 
+ Option 2 - Exact raw-selector component action. Uses a raw selector which also traverses upwards using the responder
+            chain, but accepts the arguments defined in the interface.
+
+ [MyComponent newWithAction:{@selector(methodWithSender:string:integer:)}];
+ ...
+ - (void)methodWithSender:(CKComponent *)sender string:(NSString *)string integer:(int)integer {}
+
+ 
+ Option 3 - Target/selector action. Ensures that the target responds to the given selector. Target must directly
+            respond to the selector. Targets are captured weakly by the action. Promotion, as in option 2 above is also
+            supported for target/selector actions. This constructor is useful for triggering actions on objects outside
+            of the component hierarchy like view controllers. Does not depend on the mount-based responder chain to
+            call on the target.
+ 
+ [MyComponent newWithAction:{[SomeObject sharedInstance], @selector(methodWithNoArguments)}];
+ ...
+ on SomeObject: - (void)methodWithNoArguments {}
+ 
+
+ Option 4 - Scope action. Similar to target/selector action in that it skips the responder chain from the sender, and
+            directly invokes the selector on the component or controller corresponding with the scope. Promotion is also
+            supported for scope-based actions. Scope actions weakly capture the component or controller. Does not
+            depend on the mount-based responder chain to call on the component or controller. Action may be implemented
+            on either component or controller.
+ 
+ + (instancetype)new
+ {
+    CKComponentScope scope(self);
+    return [super
+            newWithComponent:
+             [MyComponent 
+              newWithAction:{scope, @selector(methodWithNoArguments)}]];
+ }
+ - (void)methodWithNoArguments {}
+ */
 template<typename... T>
 struct CKTypedComponentAction {
-  CKTypedComponentAction() : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
-  CKTypedComponentAction(id target, SEL selector) : _variant(CKTypedComponentActionVariantTargetSelector), _target(target), _selector(selector)
+  CKTypedComponentAction<T...>() : _variant(_CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  CKTypedComponentAction<T...>(id target, SEL selector) : _variant(_CKTypedComponentActionVariantTargetSelector), _target(target), _selector(selector)
   {
 #if DEBUG
     std::vector<const char *> typeEncodings;
@@ -33,9 +99,40 @@ struct CKTypedComponentAction {
     _CKTypedComponentDebugCheckTargetSelector(target, selector, typeEncodings);
 #endif
   }
+
+  CKTypedComponentAction<T...>(const CKComponentScope &scope, SEL selector) : _variant(_CKTypedComponentActionVariantComponentScope), _target(nil), _selector(selector), _scopeHandle(scope.scopeHandle())
+  {
+#if DEBUG
+    std::vector<const char *> typeEncodings;
+    _CKTypedComponentActionTypeVectorBuild(typeEncodings, _CKTypedComponentActionTypelist<T...>{});
+    _CKTypedComponentDebugCheckComponentScope(scope, selector, typeEncodings);
+#endif
+  }
   
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
-  CKTypedComponentAction(SEL selector) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(selector) { };
+  CKTypedComponentAction(SEL selector) : _variant(_CKTypedComponentActionVariantRawSelector), _target(nil), _selector(selector) { };
+
+  /** We support promotion from actions that take no arguments. */
+  template <typename T1, typename... Ts>
+  CKTypedComponentAction<T1, Ts...>(const CKTypedComponentAction<> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; }
+
+  /** Const copy constructor to allow for block capture of the struct. */
+  CKTypedComponentAction<T...>(const CKTypedComponentAction<T...> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; }
+
+  /**
+   We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the
+   method specified here will have nil values at runtime. Used for interoperation with older API's.
+   */
+  template<typename... Ts>
+  explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; }
+
+  /** Allows conversion from NULL actions. */
+  CKTypedComponentAction(int s) : _variant(_CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  CKTypedComponentAction(long s) : _variant(_CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  CKTypedComponentAction(std::nullptr_t n) : _variant(_CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
   
   explicit operator bool() const { return _selector != NULL; };
   bool operator==(const CKTypedComponentAction& rhs) const
@@ -46,47 +143,46 @@ struct CKTypedComponentAction {
   SEL selector() const { return _selector; };
   
   void send(CKComponent *sender, T... args) const
-  { this->send(sender, CKComponentActionSendBehaviorStartAtSenderNextResponder, args...); }
+  { this->send(sender, (_variant == _CKTypedComponentActionVariantRawSelector
+                        ? CKComponentActionSendBehaviorStartAtSenderNextResponder
+                        : CKComponentActionSendBehaviorStartAtSender), args...); }
   void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
   {
     if (_selector == NULL) {
       return;
     }
-    const id target = _variant == CKTypedComponentActionVariantRawSelector ? sender : _target;
+    const id target = _CKTypedComponentActionTarget(_variant, sender, _target, _scopeHandle);
     const id initialTarget = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];
     _CKComponentActionSendResponderChain(_selector, initialTarget, sender, args...);
   }
   
   /** Allows you to get a block that sends the action when executed. */
-  typedef void (^CKTypedComponentActionExecutionBlock)(id sender, T... args);
-  CKTypedComponentActionExecutionBlock block() const;
-  
-  /** We support promotion from actions that take no arguments. */
-  template <typename T1, typename... Ts>
-  CKTypedComponentAction<T1, Ts...>(const CKTypedComponentAction<> &action)
-  { _variant = action._variant; _target = action._target; _selector = action._selector; }
+  typedef void (^CKTypedComponentActionExecutionBlock)(id sender, CKComponentActionSendBehavior behavior, T... args);
+  CKTypedComponentActionExecutionBlock block() const
+  {
+    CKTypedComponentAction<T...> copy {*this};
+    return ^(id sender, CKComponentActionSendBehavior behavior, T... args) {
+      copy.send(sender, behavior, args...);
+    };
+  }
+  typedef void (^CKTypedComponentActionCurriedSenderExecutionBlock)(T... args);
+  CKTypedComponentActionCurriedSenderExecutionBlock curriedSenderBlock(id sender, CKComponentActionSendBehavior behavior) const
+  {
+    CKCAssertNotNil(sender, @"Must provide a sender to curry.");
+    __weak id weakSender = sender;
+    CKTypedComponentAction<T...> copy {*this};
+    return ^(T... args) {
+      id strongSender = weakSender;
+      CKCAssert(strongSender, @"Curried sender should be retained by caller.");
+      copy.send(strongSender, behavior, args...);
+    };
+  }
 
-  /** Const copy constructor to allow for block capture of the struct. */
-  CKTypedComponentAction<T...>(const CKTypedComponentAction<T...> &action)
-  { _variant = action._variant; _target = action._target; _selector = action._selector; }
-
-  /** 
-   We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the
-   method specified here will have nil values at runtime. Used for interoperation with older API's.
-   */
-  template<typename... Ts>
-  explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action)
-  { _variant = action._variant; _target = action._target; _selector = action._selector; }
-  
-  /** Allows conversion from NULL actions. */
-  CKTypedComponentAction(int s) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
-  CKTypedComponentAction(long s) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
-  CKTypedComponentAction(std::nullptr_t n) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
-  
   /** Private details, do not use. */
-  CKTypedComponentActionVariant _variant;
+  _CKTypedComponentActionVariant _variant;
   __weak id _target;
   SEL _selector;
+  __weak CKComponentScopeHandle *_scopeHandle;
 };
 
 typedef CKTypedComponentAction<> CKComponentAction;

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -61,9 +61,22 @@ struct CKTypedComponentAction {
   typedef void (^CKTypedComponentActionExecutionBlock)(id sender, T... args);
   CKTypedComponentActionExecutionBlock block() const;
   
-  /** We support promotion from actions that take no arguments, but we do not allow demotion. */
-  CKTypedComponentAction(const CKTypedComponentAction<> &action)
-  { _variant = action._variant; _target = action._target; _selector = action._selector; };
+  /** We support promotion from actions that take no arguments. */
+  template <typename T1, typename... Ts>
+  CKTypedComponentAction<T1, Ts...>(const CKTypedComponentAction<> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; }
+
+  /** Const copy constructor to allow for block capture of the struct. */
+  CKTypedComponentAction<T...>(const CKTypedComponentAction<T...> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; }
+
+  /** 
+   We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the
+   method specified here will have nil values at runtime. Used for interoperation with older API's.
+   */
+  template<typename... Ts>
+  explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; }
   
   /** Allows conversion from NULL actions. */
   CKTypedComponentAction(int s) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
@@ -100,5 +113,5 @@ void CKComponentActionSend(const CKTypedComponentAction<id> &action, CKComponent
  context is the UIEvent that triggered the action. May be NULL, in which case no action will be sent.
  @param controlEvents The events that should result in the action being sent. Default is touch up inside.
  */
-CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentAction<id> &action,
+CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentAction<UIEvent *> &action,
                                                          UIControlEvents controlEvents = UIControlEventTouchUpInside);

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -11,48 +11,9 @@
 #import <UIKit/UIKit.h>
 
 #import <ComponentKit/CKComponentViewAttribute.h>
+#import <ComponentKit/CKComponentActionInternal.h>
 
 @class CKComponent;
-
-/**
- A component action is simply a selector. The selector may optionally take one argument: the sending component.
- 
- Component actions provide a way for components to communicate to supercomponents using CKComponentActionSend. Since
- components are in the responder chain, the message will reach its supercomponents.
- */
-struct CKComponentAction {
-public:
-  CKComponentAction() : _selector(NULL) {};
-  
-  /**
-   TODO(ocrickard) Remove this. Implicit conversion from SEL is a temporary change to support refactoring these to
-   take the scope.
-   */
-  CKComponentAction(SEL selector) : _selector(selector) {};
-  
-  /** TODO(ocrickard) Remove this. To support implicit conversion/comparison to NULL. */
-  CKComponentAction(int s) : _selector(NULL) {};
-  CKComponentAction(long s) : _selector(NULL) {};
-  CKComponentAction(std::nullptr_t n) : _selector(NULL) {};
-  
-  SEL selector() const { return _selector; };
-  
-  bool operator==(const CKComponentAction& rhs) const { return _selector == rhs.selector(); };
-  explicit operator bool() const { return _selector != NULL; }
-  
-private:
-  SEL _selector;
-};
-
-/** TODO(ocrickard) Remove this. Present to support comparison with NULL during refactor. */
-inline bool operator==(const CKComponentAction &lhs, const std::nullptr_t &rhs){ return lhs.selector() == NULL; }
-inline bool operator!=(const CKComponentAction &lhs, const std::nullptr_t &rhs){ return !(lhs == rhs); }
-inline bool operator==(const std::nullptr_t &lhs, const CKComponentAction &rhs){ return rhs.selector() == NULL; }
-inline bool operator!=(const std::nullptr_t &lhs, const CKComponentAction &rhs){ return !(lhs == rhs); }
-inline bool operator==(const CKComponentAction &lhs, const long &rhs){ return lhs.selector() == NULL; }
-inline bool operator!=(const CKComponentAction &lhs, const long &rhs){ return !(lhs == rhs); }
-inline bool operator==(const CKComponentAction &lhs, const int &rhs){ return lhs.selector() == NULL; }
-inline bool operator!=(const CKComponentAction &lhs, const int &rhs){ return !(lhs == rhs); }
 
 typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   /** Starts searching at the sender's next responder. Usually this is what you want to prevent infinite loops. */
@@ -61,18 +22,75 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   CKComponentActionSendBehaviorStartAtSender,
 };
 
+template<typename... T>
+struct CKTypedComponentAction {
+  CKTypedComponentAction() : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  CKTypedComponentAction(id target, SEL selector) : _variant(CKTypedComponentActionVariantTargetSelector), _target(target), _selector(selector)
+  {
+#if DEBUG
+    std::vector<const char *> typeEncodings;
+    _CKTypedComponentActionTypeVectorBuild(typeEncodings, _CKTypedComponentActionTypelist<T...>{});
+    _CKTypedComponentDebugCheckTargetSelector(target, selector, typeEncodings);
+#endif
+  }
+  
+  /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
+  CKTypedComponentAction(SEL selector) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(selector) { };
+  
+  explicit operator bool() const { return _selector != NULL; };
+  bool operator==(const CKTypedComponentAction& rhs) const
+  {
+    return _selector == rhs._selector && CKObjectIsEqual(_target, rhs._target) && _variant == rhs._variant;
+  }
+  
+  SEL selector() const { return _selector; };
+  
+  void send(CKComponent *sender, T... args) const
+  { this->send(sender, CKComponentActionSendBehaviorStartAtSenderNextResponder, args...); }
+  void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
+  {
+    if (_selector == NULL) {
+      return;
+    }
+    const id target = _variant == CKTypedComponentActionVariantRawSelector ? sender : _target;
+    const id initialTarget = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];
+    _CKComponentActionSendResponderChain(_selector, initialTarget, sender, args...);
+  }
+  
+  /** Allows you to get a block that sends the action when executed. */
+  typedef void (^CKTypedComponentActionExecutionBlock)(id sender, T... args);
+  CKTypedComponentActionExecutionBlock block() const;
+  
+  /** We support promotion from actions that take no arguments, but we do not allow demotion. */
+  CKTypedComponentAction(const CKTypedComponentAction<> &action)
+  { _variant = action._variant; _target = action._target; _selector = action._selector; };
+  
+  /** Allows conversion from NULL actions. */
+  CKTypedComponentAction(int s) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  CKTypedComponentAction(long s) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  CKTypedComponentAction(std::nullptr_t n) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _selector(NULL) {};
+  
+  /** Private details, do not use. */
+  CKTypedComponentActionVariant _variant;
+  __weak id _target;
+  SEL _selector;
+};
+
+typedef CKTypedComponentAction<> CKComponentAction;
+
 /**
  Sends a component action up the responder chain by crawling up the responder chain until it finds a responder that
- responds to the action's selector, then invokes it.
+ responds to the action's selector, then invokes it. These remain for legacy reasons, and simply call action.send(...);
  
  @param action The action to send up the responder chain.
  @param sender The component sending the action. Traversal starts from the component itself, then its next responder.
- @param context An optional context-dependent second parameter to the component action. Defaults to nil.
+ @param context An optional context-dependent second parameter to the component action.
  @param behavior @see CKComponentActionSendBehavior
  */
-void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender,
-                           id context = nil,
-                           CKComponentActionSendBehavior behavior = CKComponentActionSendBehaviorStartAtSenderNextResponder);
+void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender);
+void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender, CKComponentActionSendBehavior behavior);
+void CKComponentActionSend(const CKTypedComponentAction<id> &action, CKComponent *sender, id context);
+void CKComponentActionSend(const CKTypedComponentAction<id> &action, CKComponent *sender, id context, CKComponentActionSendBehavior behavior);
 
 /**
  Returns a view attribute that configures a component that creates a UIControl to send the given CKComponentAction.
@@ -82,5 +100,5 @@ void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender,
  context is the UIEvent that triggered the action. May be NULL, in which case no action will be sent.
  @param controlEvents The events that should result in the action being sent. Default is touch up inside.
  */
-CKComponentViewAttributeValue CKComponentActionAttribute(const CKComponentAction &action,
+CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentAction<id> &action,
                                                          UIControlEvents controlEvents = UIControlEventTouchUpInside);

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -44,21 +44,21 @@ void CKComponentActionSend(const CKTypedComponentAction<id> &action, CKComponent
 }
 
 @interface CKComponentActionControlForwarder : NSObject
-- (instancetype)initWithAction:(const CKTypedComponentAction<id> &)action;
+- (instancetype)initWithAction:(const CKTypedComponentAction<UIEvent *> &)action;
 - (void)handleControlEventFromSender:(UIControl *)sender withEvent:(UIEvent *)event;
 @end
 
 struct CKComponentActionHasher
 {
-  std::size_t operator()(const CKTypedComponentAction<id>& k) const
+  std::size_t operator()(const CKTypedComponentAction<UIEvent *>& k) const
   {
     return std::hash<void *>()(k.selector());
   }
 };
 
-typedef std::unordered_map<CKTypedComponentAction<id>, CKComponentActionControlForwarder *, CKComponentActionHasher> ForwarderMap;
+typedef std::unordered_map<CKTypedComponentAction<UIEvent *>, CKComponentActionControlForwarder *, CKComponentActionHasher> ForwarderMap;
 
-CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentAction<id> &action,
+CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentAction<UIEvent *> &action,
                                                          UIControlEvents controlEvents)
 {
   static ForwarderMap *map = new ForwarderMap(); // never destructed to avoid static destruction fiasco
@@ -117,10 +117,10 @@ CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentA
 
 @implementation CKComponentActionControlForwarder
 {
-  CKTypedComponentAction<id> _action;
+  CKTypedComponentAction<UIEvent *> _action;
 }
 
-- (instancetype)initWithAction:(const CKTypedComponentAction<id> &)action
+- (instancetype)initWithAction:(const CKTypedComponentAction<UIEvent *> &)action
 {
   if (self = [super init]) {
     _action = action;
@@ -131,7 +131,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentA
 - (void)handleControlEventFromSender:(UIControl *)sender withEvent:(UIEvent *)event
 {
   // If the action can be handled by the sender itself, send it there instead of looking up the chain.
-  CKComponentActionSend(_action, sender.ck_component, event, CKComponentActionSendBehaviorStartAtSender);
+  _action.send(sender.ck_component, CKComponentActionSendBehaviorStartAtSender, event);
 }
 
 #pragma mark - Debug Helpers

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -185,7 +185,7 @@ static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSigna
     const char *methodEncoding = [signature getArgumentTypeAtIndex:i + 3];
     const char *typeEncoding = typeEncodings[i];
 
-    CKCAssert(strcmp(methodEncoding, typeEncoding) == 0, @"Implementation of %@ does not match expected types.\nExpected type %s, got %s", NSStringFromSelector(selector), typeEncoding, methodEncoding);
+    CKCAssert(methodEncoding == NULL || typeEncoding == NULL || strcmp(methodEncoding, typeEncoding) == 0, @"Implementation of %@ does not match expected types.\nExpected type %s, got %s", NSStringFromSelector(selector), typeEncoding, methodEncoding);
   }
 }
 

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -35,6 +35,14 @@ id CKTypedComponentActionValue::initialTarget(CKComponent *sender) const {
   }
 }
 
+#pragma mark - CKTypedComponentActionValue
+
+CKTypedComponentActionValue::CKTypedComponentActionValue() : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _scopeHandle(nil), _selector(NULL) {}
+
+CKTypedComponentActionValue::CKTypedComponentActionValue(const CKTypedComponentActionValue &value) : _variant(value._variant), _target(value._target), _scopeHandle(value._scopeHandle), _selector(value._selector) {};
+
+CKTypedComponentActionValue::CKTypedComponentActionValue(CKTypedComponentActionVariant variant, __unsafe_unretained id target, __unsafe_unretained CKComponentScopeHandle *scopeHandle, SEL selector) : _variant(variant), _target(target), _scopeHandle(scopeHandle), _selector(selector) {};
+
 bool CKTypedComponentActionValue::operator==(const CKTypedComponentActionValue& rhs) const
 {
   return (_variant == rhs._variant
@@ -49,6 +57,8 @@ CKComponentActionSendBehavior CKTypedComponentActionValue::defaultBehavior() con
           ? CKComponentActionSendBehaviorStartAtSenderNextResponder
           : CKComponentActionSendBehaviorStartAtSender);
 };
+
+#pragma mark - Legacy Send Functions
 
 void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender)
 {
@@ -69,6 +79,8 @@ void CKComponentActionSend(CKTypedComponentAction<id> action, CKComponent *sende
 {
   action.send(sender, behavior, context);
 }
+
+#pragma mark - Control Actions
 
 @interface CKComponentActionControlForwarder : NSObject
 - (instancetype)initWithAction:(CKTypedComponentAction<UIEvent *>)action;

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -37,9 +37,9 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
 };
 
 struct CKTypedComponentActionValue {
-  CKTypedComponentActionValue() : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _scopeHandle(nil), _selector(NULL) {}
-  CKTypedComponentActionValue(const CKTypedComponentActionValue &value) : _variant(value._variant), _target(value._target), _scopeHandle(value._scopeHandle), _selector(value._selector) {};
-  CKTypedComponentActionValue(CKTypedComponentActionVariant variant, __unsafe_unretained id target, __unsafe_unretained CKComponentScopeHandle *scopeHandle, SEL selector) : _variant(variant), _target(target), _scopeHandle(scopeHandle), _selector(selector) {};
+  CKTypedComponentActionValue();
+  CKTypedComponentActionValue(const CKTypedComponentActionValue &value);
+  CKTypedComponentActionValue(CKTypedComponentActionVariant variant, __unsafe_unretained id target, __unsafe_unretained CKComponentScopeHandle *scopeHandle, SEL selector);
 
   id initialTarget(CKComponent *sender) const;
   SEL selector() const { return _selector; };

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -15,6 +15,8 @@
 #import <ComponentKit/CKAssert.h>
 #import <ComponentKit/CKComponentScope.h>
 
+#import <type_traits>
+
 @class CKComponent;
 
 /**
@@ -56,6 +58,12 @@ private:
 #pragma mark - Typed Helpers
 
 template <typename... Ts> struct CKTypedComponentActionTypelist { };
+
+template <bool... b>
+struct CKTypedComponentActionBoolPack {};
+
+template <typename... TS>
+struct CKTypedComponentActionDenyType : std::true_type {};
 
 /** Base case, recursion should stop here. */
 void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list);

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <vector>
+
+#import <ComponentKit/CKAssert.h>
+
+@class CKComponent;
+
+/**
+ We support several different types of action variants. You don't need to use this value anywhere, it's set for you
+ by whatever initializer you end up using.
+ */
+typedef NS_ENUM(NSUInteger, CKTypedComponentActionVariant) {
+  CKTypedComponentActionVariantRawSelector = 0,
+  CKTypedComponentActionVariantTargetSelector
+};
+
+#pragma mark - Typed Helpers
+
+template <typename... Ts> struct _CKTypedComponentActionTypelist { };
+
+/** Base case, recursion should stop here. */
+void _CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const _CKTypedComponentActionTypelist<> &list);
+
+/** 
+ Recursion through variadic argument type unpacking. This allows us to build a vector of encoded const char * before
+ any actual arguments have been provided. All of this is done at compile-time.
+ */
+template<typename T, typename... Ts>
+void _CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const _CKTypedComponentActionTypelist<T, Ts...> &list)
+{
+  typeVector.push_back(@encode(T));
+  _CKTypedComponentActionTypeVectorBuild(typeVector, _CKTypedComponentActionTypelist<Ts...>{});
+}
+
+/** Base case, recursion should stop here. */
+void _CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index);
+
+/**
+ Recursion here is through normal variadic argument list unpacking. Unlike above, we have the arguments, so we don't
+ require the intermediary struct.
+ */
+template <typename T, typename... Ts>
+void _CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index, T t, Ts... args)
+{
+  // We have to be able to handle methods that take less than the provided number of arguments, since that will cause
+  // an exception to be thrown.
+  if (index < invocation.methodSignature.numberOfArguments) {
+    [invocation setArgument:&t atIndex:index];
+    _CKConfigureInvocationWithArguments(invocation, index + 1, args...);
+  }
+}
+
+#pragma mark - Debug Helpers
+
+void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings);
+
+NSString *_CKComponentResponderChainDebugResponderChain(id responder);
+
+#pragma mark - Sending
+
+template<typename... T>
+static void _CKComponentActionSendResponderChain(SEL selector, id target, CKComponent *sender, T... args) {
+  id responder = [target targetForAction:selector withSender:target];
+  CKCAssertNotNil(responder, @"Unhandled component action %@ following responder chain %@",
+                  NSStringFromSelector(selector), _CKComponentResponderChainDebugResponderChain(target));
+  // This is not performance-sensitive, so we can just use an invocation here.
+  NSMethodSignature *signature = [responder methodSignatureForSelector:selector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+  invocation.selector = selector;
+  invocation.target = responder;
+  if (signature.numberOfArguments >= 3) {
+    [invocation setArgument:&sender atIndex:2];
+  }
+  // We use a recursive argument unpack to unwrap the variadic arguments in-order on the invocation in a type-safe
+  // manner.
+  _CKConfigureInvocationWithArguments(invocation, 3, args...);
+  [invocation invoke];
+}

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -13,6 +13,7 @@
 #import <vector>
 
 #import <ComponentKit/CKAssert.h>
+#import <ComponentKit/CKComponentScope.h>
 
 @class CKComponent;
 
@@ -20,9 +21,10 @@
  We support several different types of action variants. You don't need to use this value anywhere, it's set for you
  by whatever initializer you end up using.
  */
-typedef NS_ENUM(NSUInteger, CKTypedComponentActionVariant) {
-  CKTypedComponentActionVariantRawSelector = 0,
-  CKTypedComponentActionVariantTargetSelector
+typedef NS_ENUM(NSUInteger, _CKTypedComponentActionVariant) {
+  _CKTypedComponentActionVariantRawSelector = 0,
+  _CKTypedComponentActionVariantTargetSelector,
+  _CKTypedComponentActionVariantComponentScope
 };
 
 #pragma mark - Typed Helpers
@@ -61,7 +63,11 @@ void _CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger ind
   }
 }
 
+id _CKTypedComponentActionTarget(_CKTypedComponentActionVariant variant, CKComponent *sender, id target, CKComponentScopeHandle *scopeHandle);
+
 #pragma mark - Debug Helpers
+
+void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings);
 
 void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings);
 

--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -21,7 +21,7 @@ typedef void (*CKComponentGestureRecognizerSetupFunction)(UIGestureRecognizer *)
  @param action Sent up the responder chain when a tap occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKComponentAction &action);
+CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedComponentAction<id> &action);
 
 /**
  Returns a view attribute that creates and configures a pan gesture recognizer to send the given CKComponentAction.
@@ -29,7 +29,7 @@ CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKComponentAc
  @param action Sent up the responder chain when a pan occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKComponentAction &action);
+CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedComponentAction<id> &action);
 
 /**
  Returns a view attribute that creates and configures a long press gesture recognizer to send the given CKComponentAction.
@@ -37,7 +37,7 @@ CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKComponentAc
  @param action Sent up the responder chain when a long press occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKComponentAction &action);
+CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTypedComponentAction<id> &action);
 
 /**
  Returns a view attribute that creates and configures a gesture recognizer.
@@ -50,11 +50,11 @@ CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKCompo
  */
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          const CKComponentAction &action,
+                                                          const CKTypedComponentAction<id> &action,
                                                           CKComponentForwardedSelectors delegateSelectors = {});
 
 /**
  Allows mapping a UIGestureRecognizer back to the original CKComponentAction selector,
  since ComponentKit internally changes the selector to be able send to the component responder chain.
  */
-CKComponentAction CKComponentGestureGetAction(UIGestureRecognizer *gesture);
+CKTypedComponentAction<id> CKComponentGestureGetAction(UIGestureRecognizer *gesture);

--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -21,7 +21,7 @@ typedef void (*CKComponentGestureRecognizerSetupFunction)(UIGestureRecognizer *)
  @param action Sent up the responder chain when a tap occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action);
+CKComponentViewAttributeValue CKComponentTapGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *> action);
 
 /**
  Returns a view attribute that creates and configures a pan gesture recognizer to send the given CKComponentAction.
@@ -29,7 +29,7 @@ CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedCompon
  @param action Sent up the responder chain when a pan occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action);
+CKComponentViewAttributeValue CKComponentPanGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *> action);
 
 /**
  Returns a view attribute that creates and configures a long press gesture recognizer to send the given CKComponentAction.
@@ -37,7 +37,7 @@ CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedCompon
  @param action Sent up the responder chain when a long press occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action);
+CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *> action);
 
 /**
  Returns a view attribute that creates and configures a gesture recognizer.
@@ -50,7 +50,7 @@ CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTyped
  */
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          const CKTypedComponentAction<UIGestureRecognizer *> &action,
+                                                          CKTypedComponentAction<UIGestureRecognizer *> action,
                                                           CKComponentForwardedSelectors delegateSelectors = {});
 
 /**

--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -21,7 +21,7 @@ typedef void (*CKComponentGestureRecognizerSetupFunction)(UIGestureRecognizer *)
  @param action Sent up the responder chain when a tap occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedComponentAction<id> &action);
+CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action);
 
 /**
  Returns a view attribute that creates and configures a pan gesture recognizer to send the given CKComponentAction.
@@ -29,7 +29,7 @@ CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedCompon
  @param action Sent up the responder chain when a pan occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedComponentAction<id> &action);
+CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action);
 
 /**
  Returns a view attribute that creates and configures a long press gesture recognizer to send the given CKComponentAction.
@@ -37,7 +37,7 @@ CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedCompon
  @param action Sent up the responder chain when a long press occurs. Sender is the component that created the view.
  Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTypedComponentAction<id> &action);
+CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action);
 
 /**
  Returns a view attribute that creates and configures a gesture recognizer.
@@ -50,11 +50,11 @@ CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTyped
  */
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          const CKTypedComponentAction<id> &action,
+                                                          const CKTypedComponentAction<UIGestureRecognizer *> &action,
                                                           CKComponentForwardedSelectors delegateSelectors = {});
 
 /**
  Allows mapping a UIGestureRecognizer back to the original CKComponentAction selector,
  since ComponentKit internally changes the selector to be able send to the component responder chain.
  */
-CKTypedComponentAction<id> CKComponentGestureGetAction(UIGestureRecognizer *gesture);
+CKTypedComponentAction<UIGestureRecognizer *> CKComponentGestureGetAction(UIGestureRecognizer *gesture);

--- a/ComponentKit/Utilities/CKComponentGestureActions.h
+++ b/ComponentKit/Utilities/CKComponentGestureActions.h
@@ -17,40 +17,40 @@ typedef void (*CKComponentGestureRecognizerSetupFunction)(UIGestureRecognizer *)
 
 /**
  Returns a view attribute that creates and configures a tap gesture recognizer to send the given CKComponentAction.
-
+ 
  @param action Sent up the responder chain when a tap occurs. Sender is the component that created the view.
-        Context is the gesture recognizer. May be NULL, in which case no action will be sent.
+ Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentTapGestureAttribute(CKComponentAction action);
+CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKComponentAction &action);
 
 /**
  Returns a view attribute that creates and configures a pan gesture recognizer to send the given CKComponentAction.
-
+ 
  @param action Sent up the responder chain when a pan occurs. Sender is the component that created the view.
-        Context is the gesture recognizer. May be NULL, in which case no action will be sent.
+ Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentPanGestureAttribute(CKComponentAction action);
+CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKComponentAction &action);
 
 /**
  Returns a view attribute that creates and configures a long press gesture recognizer to send the given CKComponentAction.
-
+ 
  @param action Sent up the responder chain when a long press occurs. Sender is the component that created the view.
-        Context is the gesture recognizer. May be NULL, in which case no action will be sent.
+ Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
-CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(CKComponentAction action);
+CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKComponentAction &action);
 
 /**
  Returns a view attribute that creates and configures a gesture recognizer.
-
+ 
  @param gestureRecognizerClass Must be a subclass of UIGestureRecognizer. Instantiated with -initWithTarget:action:.
  @param setupFunction Optional; pass nullptr if not needed. Called once for each new gesture recognizer; you may use
-        this function to configure the new gesture recognizer.
+ this function to configure the new gesture recognizer.
  @param action Sent up the responder chain when the gesture recognizer recognizes a gesture. Sender is the component
-        that created the view. Context is the gesture recognizer. May be NULL, in which case no action will be sent.
+ that created the view. Context is the gesture recognizer. May be NULL, in which case no action will be sent.
  */
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          CKComponentAction action,
+                                                          const CKComponentAction &action,
                                                           CKComponentForwardedSelectors delegateSelectors = {});
 
 /**

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -20,7 +20,7 @@
 #import "CKComponentViewInterface.h"
 
 /** Find a UIGestureRecognizer attached to a view that has a given ck_componentAction. */
-static UIGestureRecognizer *recognizerForAction(UIView *view, const CKComponentAction &action)
+static UIGestureRecognizer *recognizerForAction(UIView *view, const CKTypedComponentAction<id> &action)
 {
   for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
     if (sel_isEqual([recognizer ck_componentAction].selector(), action.selector())) {
@@ -63,17 +63,17 @@ private:
   std::vector<UIGestureRecognizer *> _reusePool;
 };
 
-CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKComponentAction &action)
+CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedComponentAction<id> &action)
 {
   return CKComponentGestureAttribute([UITapGestureRecognizer class], nullptr, action);
 }
 
-CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKComponentAction &action)
+CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedComponentAction<id> &action)
 {
   return CKComponentGestureAttribute([UIPanGestureRecognizer class], nullptr, action);
 }
 
-CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKComponentAction &action)
+CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTypedComponentAction<id> &action)
 {
   return CKComponentGestureAttribute([UILongPressGestureRecognizer class], nullptr, action);
 }
@@ -100,7 +100,7 @@ namespace std {
 
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          const CKComponentAction &action,
+                                                          const CKTypedComponentAction<id> &action,
                                                           CKComponentForwardedSelectors delegateSelectors)
 {
   if (!action) {
@@ -185,7 +185,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
 
 @end
 
-CKComponentAction CKComponentGestureGetAction(UIGestureRecognizer *gesture)
+CKTypedComponentAction<id> CKComponentGestureGetAction(UIGestureRecognizer *gesture)
 {
   return [gesture ck_componentAction];
 };
@@ -194,7 +194,7 @@ CKComponentAction CKComponentGestureGetAction(UIGestureRecognizer *gesture)
 
 static const char kCKComponentActionGestureRecognizerKey = ' ';
 
-- (CKComponentAction)ck_componentAction
+- (CKTypedComponentAction<id>)ck_componentAction
 {
   NSString *action = objc_getAssociatedObject(self, &kCKComponentActionGestureRecognizerKey);
   if (action) {
@@ -204,7 +204,7 @@ static const char kCKComponentActionGestureRecognizerKey = ' ';
   }
 }
 
-- (void)ck_setComponentAction:(const CKComponentAction &)action
+- (void)ck_setComponentAction:(const CKTypedComponentAction<id> &)action
 {
   NSString *actionString = action ? NSStringFromSelector(action.selector()) : nil;
   objc_setAssociatedObject(self, &kCKComponentActionGestureRecognizerKey, actionString, OBJC_ASSOCIATION_COPY_NONATOMIC);

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -20,7 +20,7 @@
 #import "CKComponentViewInterface.h"
 
 /** Find a UIGestureRecognizer attached to a view that has a given ck_componentAction. */
-static UIGestureRecognizer *recognizerForAction(UIView *view, const CKTypedComponentAction<UIGestureRecognizer *> &action)
+static UIGestureRecognizer *recognizerForAction(UIView *view, CKTypedComponentAction<UIGestureRecognizer *> action)
 {
   for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
     if (sel_isEqual([recognizer ck_componentAction].selector(), action.selector())) {
@@ -63,17 +63,17 @@ private:
   std::vector<UIGestureRecognizer *> _reusePool;
 };
 
-CKComponentViewAttributeValue CKComponentTapGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action)
+CKComponentViewAttributeValue CKComponentTapGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *> action)
 {
   return CKComponentGestureAttribute([UITapGestureRecognizer class], nullptr, action);
 }
 
-CKComponentViewAttributeValue CKComponentPanGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action)
+CKComponentViewAttributeValue CKComponentPanGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *> action)
 {
   return CKComponentGestureAttribute([UIPanGestureRecognizer class], nullptr, action);
 }
 
-CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(const CKTypedComponentAction<UIGestureRecognizer *> &action)
+CKComponentViewAttributeValue CKComponentLongPressGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *> action)
 {
   return CKComponentGestureAttribute([UILongPressGestureRecognizer class], nullptr, action);
 }
@@ -100,7 +100,7 @@ namespace std {
 
 CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognizerClass,
                                                           CKComponentGestureRecognizerSetupFunction setupFunction,
-                                                          const CKTypedComponentAction<UIGestureRecognizer *> &action,
+                                                          CKTypedComponentAction<UIGestureRecognizer *> action,
                                                           CKComponentForwardedSelectors delegateSelectors)
 {
   if (!action) {
@@ -187,7 +187,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
 
 @interface _CKGestureActionWrapper : NSObject <NSCopying>
 
-- (instancetype)initWithGestureAction:(const CKTypedComponentAction<UIGestureRecognizer *> &)action;
+- (instancetype)initWithGestureAction:(CKTypedComponentAction<UIGestureRecognizer *>)action;
 
 - (CKTypedComponentAction<UIGestureRecognizer *>)action;
 
@@ -198,7 +198,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
   CKTypedComponentAction<UIGestureRecognizer *> _action;
 }
 
-- (instancetype)initWithGestureAction:(const CKTypedComponentAction<UIGestureRecognizer *> &)action
+- (instancetype)initWithGestureAction:(CKTypedComponentAction<UIGestureRecognizer *>)action
 {
   if (self = [super init]) {
     _action = action;
@@ -233,7 +233,7 @@ static const char kCKComponentActionGestureRecognizerKey = ' ';
   }
 }
 
-- (void)ck_setComponentAction:(const CKTypedComponentAction<UIGestureRecognizer *> &)action
+- (void)ck_setComponentAction:(CKTypedComponentAction<UIGestureRecognizer *>)action
 {
   _CKGestureActionWrapper *wrapper = [[_CKGestureActionWrapper alloc] initWithGestureAction:action];
   objc_setAssociatedObject(self, &kCKComponentActionGestureRecognizerKey, wrapper, OBJC_ASSOCIATION_COPY_NONATOMIC);

--- a/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
+++ b/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
@@ -19,5 +19,5 @@
 /** Exposed only for testing. Do not touch this directly. */
 @interface UIGestureRecognizer (CKComponent)
 - (CKTypedComponentAction<UIGestureRecognizer *>)ck_componentAction;
-- (void)ck_setComponentAction:(const CKTypedComponentAction<UIGestureRecognizer *> &)action;
+- (void)ck_setComponentAction:(CKTypedComponentAction<UIGestureRecognizer *>)action;
 @end

--- a/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
+++ b/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
@@ -18,6 +18,6 @@
 
 /** Exposed only for testing. Do not touch this directly. */
 @interface UIGestureRecognizer (CKComponent)
-- (CKTypedComponentAction<id>)ck_componentAction;
-- (void)ck_setComponentAction:(const CKTypedComponentAction<id> &)action;
+- (CKTypedComponentAction<UIGestureRecognizer *>)ck_componentAction;
+- (void)ck_setComponentAction:(const CKTypedComponentAction<UIGestureRecognizer *> &)action;
 @end

--- a/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
+++ b/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
@@ -18,6 +18,6 @@
 
 /** Exposed only for testing. Do not touch this directly. */
 @interface UIGestureRecognizer (CKComponent)
-- (CKComponentAction)ck_componentAction;
-- (void)ck_setComponentAction:(const CKComponentAction &)action;
+- (CKTypedComponentAction<id>)ck_componentAction;
+- (void)ck_setComponentAction:(const CKTypedComponentAction<id> &)action;
 @end

--- a/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
+++ b/ComponentKit/Utilities/CKComponentGestureActionsInternal.h
@@ -19,5 +19,5 @@
 /** Exposed only for testing. Do not touch this directly. */
 @interface UIGestureRecognizer (CKComponent)
 - (CKComponentAction)ck_componentAction;
-- (void)ck_setComponentAction:(CKComponentAction)action;
+- (void)ck_setComponentAction:(const CKComponentAction &)action;
 @end

--- a/ComponentKit/Utilities/CKInternalHelpers.h
+++ b/ComponentKit/Utilities/CKInternalHelpers.h
@@ -14,6 +14,8 @@
 
 BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector);
 
+Class CKComponentControllerClassFromComponentClass(Class componentClass);
+
 std::string CKStringFromPointer(const void *ptr);
 
 CGFloat CKScreenScale();

--- a/ComponentKit/Utilities/CKInternalHelpers.mm
+++ b/ComponentKit/Utilities/CKInternalHelpers.mm
@@ -14,6 +14,12 @@
 #import <objc/runtime.h>
 #import <stdio.h>
 #import <string>
+#import <unordered_map>
+
+#import "CKComponent.h"
+#import "CKComponentController.h"
+#import "CKComponentSubclass.h"
+#import "CKMutex.h"
 
 BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
 {
@@ -22,6 +28,33 @@ BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
   IMP superclassIMP = superclassMethod ? method_getImplementation(superclassMethod) : NULL;
   IMP subclassIMP = subclassMethod ? method_getImplementation(subclassMethod) : NULL;
   return (superclassIMP != subclassIMP);
+}
+
+Class CKComponentControllerClassFromComponentClass(Class componentClass)
+{
+  if (componentClass == [CKComponent class]) {
+    return Nil; // Don't create root CKComponentControllers as it does nothing interesting.
+  }
+
+  static CK::StaticMutex mutex = CK_MUTEX_INITIALIZER; // protects cache
+  CK::StaticMutexLocker l(mutex);
+
+  static std::unordered_map<Class, Class> *cache = new std::unordered_map<Class, Class>();
+  const auto &it = cache->find(componentClass);
+  if (it == cache->end()) {
+    Class c = NSClassFromString([NSStringFromClass(componentClass) stringByAppendingString:@"Controller"]);
+
+    // If you override animationsFromPreviousComponent: or animationsOnInitialMount then we need a controller.
+    if (c == nil &&
+        (CKSubclassOverridesSelector([CKComponent class], componentClass, @selector(animationsFromPreviousComponent:)) ||
+         CKSubclassOverridesSelector([CKComponent class], componentClass, @selector(animationsOnInitialMount)))) {
+          c = [CKComponentController class];
+        }
+
+    cache->insert({componentClass, c});
+    return c;
+  }
+  return it->second;
 }
 
 std::string CKStringFromPointer(const void *ptr)

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -39,7 +39,10 @@
 
   CKTestActionComponent *outerComponent =
   [CKTestActionComponent
-   newWithBlock:^(CKComponent *sender, id context){ actionSender = sender; }
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
+   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
+   primitiveArgumentBlock:^(CKComponent *sender, int value) { }
+   noArgumentBlock:^{ }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -66,7 +69,10 @@
 
   CKTestActionComponent *outerComponent =
   [CKTestActionComponent
-   newWithBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
+   primitiveArgumentBlock:^(CKComponent *sender, int value) { }
+   noArgumentBlock:^{ }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -93,7 +99,10 @@
 
   CKTestActionComponent *outerComponent =
   [CKTestActionComponent
-   newWithBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
+   primitiveArgumentBlock:^(CKComponent *sender, int value) { }
+   noArgumentBlock:^{ }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -120,7 +129,10 @@
 
   CKTestActionComponent *outerComponent =
   [CKTestActionComponent
-   newWithBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
+   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
+   primitiveArgumentBlock:^(CKComponent *sender, int value) { }
+   noArgumentBlock:^{ }
    component:controlComponent];
 
   // Must be mounted to send actions:

--- a/ComponentKitTestHelpers/CKTestActionComponent.h
+++ b/ComponentKitTestHelpers/CKTestActionComponent.h
@@ -12,7 +12,13 @@
 
 @interface CKTestActionComponent : CKCompositeComponent
 /** @param block Executed when "testAction:context:" is invoked on the component */
-+ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block
-                   component:(CKComponent *)component;
++ (instancetype)newWithSingleArgumentBlock:(void (^)(CKComponent *sender, id context))singleArgumentBlock
+                       secondArgumentBlock:(void (^)(CKComponent *sender, id obj1, id obj2))secondArgumentBlock
+                    primitiveArgumentBlock:(void (^)(CKComponent *sender, int value))primitiveArgumentBlock
+                           noArgumentBlock:(void (^)(void))noArgumentBlock
+                                 component:(CKComponent *)component;
 - (void)testAction:(CKComponent *)sender context:(id)context;
+- (void)testAction2:(CKComponent *)sender context1:(id)context1 context2:(id)context2;
+- (void)testPrimitive:(CKComponent *)sender integer:(int)integer;
+- (void)testNoArgumentAction;
 @end

--- a/ComponentKitTestHelpers/CKTestActionComponent.mm
+++ b/ComponentKitTestHelpers/CKTestActionComponent.mm
@@ -13,13 +13,23 @@
 @implementation CKTestActionComponent
 {
   void (^_block)(CKComponent *, id);
+  void (^_secondBlock)(CKComponent *, id, id);
+  void (^_primitiveArgumentBlock)(CKComponent *, int);
+  void (^_noArgumentBlock)(void);
 }
 
-+ (instancetype)newWithBlock:(void (^)(CKComponent *sender, id context))block component:(CKComponent *)component
++ (instancetype)newWithSingleArgumentBlock:(void (^)(CKComponent *sender, id context))singleArgumentBlock
+                       secondArgumentBlock:(void (^)(CKComponent *sender, id obj1, id obj2))secondArgumentBlock
+                    primitiveArgumentBlock:(void (^)(CKComponent *sender, int value))primitiveArgumentBlock
+                           noArgumentBlock:(void (^)(void))noArgumentBlock
+                                 component:(CKComponent *)component
 {
   CKTestActionComponent *c = [super newWithComponent:component];
   if (c) {
-    c->_block = block;
+    c->_block = singleArgumentBlock;
+    c->_secondBlock = secondArgumentBlock;
+    c->_primitiveArgumentBlock = primitiveArgumentBlock;
+    c->_noArgumentBlock = noArgumentBlock;
   }
   return c;
 }
@@ -27,6 +37,21 @@
 - (void)testAction:(CKComponent *)sender context:(id)context
 {
   _block(sender, context);
+}
+
+- (void)testAction2:(CKComponent *)sender context1:(id)context1 context2:(id)context2
+{
+  _secondBlock(sender, context1, context2);
+}
+
+- (void)testPrimitive:(CKComponent *)sender integer:(int)integer
+{
+  _primitiveArgumentBlock(sender, integer);
+}
+
+- (void)testNoArgumentAction
+{
+  _noArgumentBlock();
 }
 
 @end

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -355,44 +355,6 @@
   XCTAssertTrue(calledBlock, @"Outer component should have received the action, even though the components are not mounted.");
 }
 
-- (void)testTargetSelectorActionCallsOnTargetWhenExecutionBlockInvoked
-{
-  __block BOOL calledBlock = NO;
-
-  CKComponent *innerComponent = [CKComponent new];
-  CKTestActionComponent *outerComponent =
-  [CKTestActionComponent
-   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ calledBlock = YES; }
-   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
-   primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
-   component:innerComponent];
-
-  CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
-  action.block()(innerComponent, CKComponentActionSendBehaviorStartAtSender, @"hello");
-
-  XCTAssertTrue(calledBlock, @"Outer component should have received the action, even though the components are not mounted.");
-}
-
-- (void)testTargetSelectorActionCallsOnTargetWhenExecutionBlockInvokedWithCorrectSender
-{
-  __block id actionSender = nil;
-
-  CKComponent *innerComponent = [CKComponent new];
-  CKTestActionComponent *outerComponent =
-  [CKTestActionComponent
-   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionSender = sender; }
-   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
-   primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
-   component:innerComponent];
-
-  CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
-  action.block()(innerComponent, CKComponentActionSendBehaviorStartAtSender, @"hello");
-
-  XCTAssertTrue(actionSender == innerComponent, @"Sender should be the inner component.");
-}
-
 - (void)testTargetSelectorActionCallsOnTargetWhenExecutionBlockInvokedWithCurriedSender
 {
   __block id actionSender = nil;

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -50,7 +50,7 @@
 
   attr.first.applicator(view, attr.second);
   UITapGestureRecognizer *recognizer = [view.gestureRecognizers firstObject];
-  XCTAssertEqual([recognizer ck_componentAction], @selector(test), @"Expected ck_componentAction to be set on the GR");
+  XCTAssertEqual([recognizer ck_componentAction].selector(), @selector(test), @"Expected ck_componentAction to be set on the GR");
 
   attr.first.unapplicator(view, attr.second);
 }


### PR DESCRIPTION
This one is a doozey, and will break some current code written with ComponentKit, though I've tried my best to make the conversion path simple. Please review thoroughly.

This PR is attempting to make the CKComponentAction declaration a little bit clearer. We're providing a few new facilities:

1. CKComponentActions can now take arbitrary target/selector pairs instead of necessarily using the responder chain.
2. CKComponentAction now has a typed variant which allows specification of the arguments to the action method.
3. An execution block can be created from an action which can simply be executed with the arguments defined in the variadic types. This allows simple interop with systems that expect raw blocks as inputs for their actions (like JSC). (I haven't implemented this yet, tomorrow... should be simple).
4. Component actions may now take an arbitrary number of arguments instead of just 2.
5. Component actions may now take primitives or other non-NSObject types. You can pass things like C++ structs using this system.

The use of actions is currently ad-hoc and only documented in headers. It is a little tough to understand looking at the header for a component what arguments are available for your action method.

On top of that, the status quo uses the responder chain, which was a natural way to build it for the obj-c roots we come from, but ultimately has turned out to be a dangerous and annoying pattern in terms of debuggability. We'd prefer for targets/actions to be captured explicitly, which will allow us to do runtime and/or compile-time checking that the method is implemented at the level that the action was created. I have some changes coming tomorrow to support full integration with component scopes in actions.