### PR TITLE
Lift memoization out of core

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -376,6 +376,8 @@
 		B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B167C70F1DD38E4200769084 /* CKMemoizingComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B167C7101DD38E4200769084 /* CKMemoizingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */; };
+		B1DC105F1DD480FB00CCBF2F /* CKMemoizingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */; };
+		B1DC106A1DD4810700CCBF2F /* CKMemoizingComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */; };
 		B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */; };
 		B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */; };
@@ -2070,6 +2072,7 @@
 				03B8B4D51D2A346F00EDFF59 /* CKTransactionalComponentDataSourceInternal.h in Headers */,
 				03B8B4D61D2A346F00EDFF59 /* CKTransactionalComponentDataSourceUpdateStateModification.h in Headers */,
 				03B8B4D71D2A346F00EDFF59 /* CKTransactionalComponentDataSourceChangeset.h in Headers */,
+				B1DC106A1DD4810700CCBF2F /* CKMemoizingComponent.h in Headers */,
 				03B8B4D81D2A346F00EDFF59 /* CKComponentProvider.h in Headers */,
 				03B8B4D91D2A346F00EDFF59 /* CKComponentAnnouncerBase.h in Headers */,
 				03B8B4DA1D2A346F00EDFF59 /* CKComponentLayout.h in Headers */,
@@ -2836,6 +2839,7 @@
 				03B8B46E1D2A346F00EDFF59 /* CKButtonComponent.mm in Sources */,
 				03B8B46F1D2A346F00EDFF59 /* CKImageComponent.mm in Sources */,
 				03B8B4701D2A346F00EDFF59 /* CKNetworkImageComponent.mm in Sources */,
+				B1DC105F1DD480FB00CCBF2F /* CKMemoizingComponent.mm in Sources */,
 				03B8B4711D2A346F00EDFF59 /* CKComponent.mm in Sources */,
 				03B8B4721D2A346F00EDFF59 /* CKComponentAnimation.mm in Sources */,
 				03B8B4731D2A346F00EDFF59 /* CKComponentBoundsAnimation.mm in Sources */,

--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -374,6 +374,8 @@
 		A2CD66321AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */; };
 		A2D20CF41B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */; };
 		B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B167C70F1DD38E4200769084 /* CKMemoizingComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B167C7101DD38E4200769084 /* CKMemoizingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */; };
 		B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */; };
 		B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */; };
 		B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */; };
@@ -929,6 +931,8 @@
 		A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateTests.mm; sourceTree = "<group>"; tabWidth = 2; };
 		A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentHostingViewAsyncStateUpdateTests.mm; sourceTree = "<group>"; };
 		B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKComponentActionInternal.h; sourceTree = "<group>"; };
+		B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKMemoizingComponent.h; sourceTree = "<group>"; };
+		B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKMemoizingComponent.mm; sourceTree = "<group>"; };
 		B342DC401AC23E8200ACAC53 /* ComponentKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComponentKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKArrayControllerChangesetTests.mm; sourceTree = "<group>"; };
 		B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentAccessibilityTests.mm; sourceTree = "<group>"; };
@@ -1618,6 +1622,8 @@
 				D0B47AD11CBD926700BB33CE /* CKNetworkImageComponent.h */,
 				D0B47AD21CBD926700BB33CE /* CKNetworkImageComponent.mm */,
 				D0B47AD31CBD926700BB33CE /* CKNetworkImageDownloading.h */,
+				B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */,
+				B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2225,6 +2231,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B167C70F1DD38E4200769084 /* CKMemoizingComponent.h in Headers */,
 				D0B47D111CBD948E00BB33CE /* CKCollectionViewDataSource.h in Headers */,
 				A243B52E1D79A40800E6C393 /* CKComponentContextHelper.h in Headers */,
 				D0B47D501CBD948E00BB33CE /* CKArrayControllerChangeset.h in Headers */,
@@ -3162,6 +3169,7 @@
 				D0B47CBF1CBD943400BB33CE /* CKTransactionalComponentDataSourceItem.mm in Sources */,
 				D0B47CC01CBD943400BB33CE /* CKTransactionalComponentDataSourceListenerAnnouncer.mm in Sources */,
 				D0B47CC11CBD943400BB33CE /* CKTransactionalComponentDataSourceState.mm in Sources */,
+				B167C7101DD38E4200769084 /* CKMemoizingComponent.mm in Sources */,
 				D0B47CC21CBD943400BB33CE /* CKTransactionalComponentDataSourceChange.m in Sources */,
 				D0B47CC31CBD943400BB33CE /* CKTransactionalComponentDataSourceChangesetModification.mm in Sources */,
 				D0B47CC41CBD943400BB33CE /* CKTransactionalComponentDataSourceReloadModification.mm in Sources */,

--- a/ComponentKit/Components/CKMemoizingComponent.h
+++ b/ComponentKit/Components/CKMemoizingComponent.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <ComponentKit/CKCompositeComponent.h>
+
+/**
+ A memoizing component should be present in the component hierarchy above components that wish to use memoization. It
+ configures thread-local state so that memoization of components and component layouts can be successful. If a
+ memoizing component is not present, memoization operations will silently fail and components will be rebuilt and
+ re-laid out on every call.
+ */
+@interface CKMemoizingComponent : CKComponent
+
++ (instancetype)newWithComponentBlock:(CKComponent *(^)())block;
+
+@end

--- a/ComponentKit/Components/CKMemoizingComponent.mm
+++ b/ComponentKit/Components/CKMemoizingComponent.mm
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKMemoizingComponent.h"
+
+#import <mutex>
+
+#import "CKComponentMemoizer.h"
+#import "CKComponentScope.h"
+#import "CKComponentSubclass.h"
+
+/**
+ Memoizers work by preparing a thread-local stack. We want to be able to preserve this state between component tree
+ creation and layout. We do this through the state associated with this component's scope. This is a "best attempt"
+ approach at memoization. For instance, it's possible that a memoizable hierarchy is being built or laid out on two
+ threads simultaneously. This state wrapper can therefore be used by multiple threads simultaneously. We protect the
+ memoization state (which cannot be safely used by multiple threads simultaneously) by forcing the calling threads
+ to take "ownership" over that state during the execution of its block. If any other threads attempt to access the
+ memoization state while a block execution is ongoing, it will fail to access the memoization state that was already
+ granted to the first calling thread, and memoization will fail there (that's OK, we just have to try our best at
+ memoizing the results). Since this should be very rare, this isn't a big deal so long as the operation is safe.
+ 
+ This is somewhat antithetical to the design of Components, in that we're storing a mutable value into our state without
+ using the updateState: mechanism. Sadly, updateState: won't work here, since we would end up in an infinite loop of
+ updates. We would receive an update from something, which would cause us to update our memoization state after
+ computing the memoized hierarchy, then this would trigger another state update.
+ */
+@interface CKMemoizingComponentStateWrapper : NSObject
+
+- (void)executeBlockWithMemoizationState:(id (^)(id memoizationState))block;
+
+@end
+
+@implementation CKMemoizingComponentStateWrapper
+{
+  id _memoizationState;
+  std::mutex _mutex;
+}
+
+- (void)executeBlockWithMemoizationState:(id (^)(id))block
+{
+  // We have to avoid calling the block while we are locked. Components can be created or laid out on multiple threads
+  // simultaneously, and this state wrapper may be shared between multiple threads simultaneously. If we were to just
+  // lock for the block (even though that would be a little scary, it'd still be hard to deadlock), then we could
+  // easily introduce a priority inversion as the main thread is stuck waiting on a bg thread component creation.
+  id memoizationState = nil;
+  {
+    std::lock_guard<std::mutex> l(_mutex);
+    memoizationState = _memoizationState;
+    // Un-set it here within the protection of the lock, so any other threads accessing while we execute the block get
+    // a nil memoization state.
+    _memoizationState = nil;
+  }
+
+  const id newMemoizationState = block(memoizationState);
+
+  {
+    std::lock_guard<std::mutex> l(_mutex);
+    _memoizationState = newMemoizationState;
+  }
+}
+
+@end
+
+@implementation CKMemoizingComponent
+{
+  CKMemoizingComponentStateWrapper *_wrapper;
+  CKComponent *_component;
+}
+
++ (id)initialState
+{
+  return [CKMemoizingComponentStateWrapper new];
+}
+
++ (instancetype)newWithComponentBlock:(CKComponent *(^)())block
+{
+  CKComponentScope scope(self);
+
+  CKMemoizingComponentStateWrapper *wrapper = scope.state();
+
+  __block CKComponent *result = nil;
+
+  [wrapper executeBlockWithMemoizationState:^id(id memoizationState) {
+    CKComponentMemoizer memoizer(memoizationState);
+
+    result = block();
+
+    return memoizer.nextMemoizerState();
+  }];
+
+  CKMemoizingComponent *c = [super newWithView:{} size:{}];
+  if (c) {
+    c->_wrapper = wrapper;
+    c->_component = result;
+  }
+  return c;
+}
+
+- (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize
+                          restrictedToSize:(const CKComponentSize &)size
+                      relativeToParentSize:(CGSize)parentSize
+{
+  __block CKComponentLayout l;
+  [_wrapper executeBlockWithMemoizationState:^id(id memoizationState) {
+    CKComponentMemoizer memoizer(memoizationState);
+    l = [_component layoutThatFits:constrainedSize parentSize:parentSize];
+    return memoizer.nextMemoizerState();
+  }];
+  return {self, l.size, {{{0,0}, l}}};
+}
+
+@end

--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -11,7 +11,6 @@
 #import "CKComponent.h"
 #import "CKComponentControllerInternal.h"
 #import "CKComponentInternal.h"
-#import "CKComponentMemoizer.h"
 #import "CKComponentSubclass.h"
 
 #import <ComponentKit/CKArgumentPrecondition.h>
@@ -221,7 +220,9 @@ struct CKComponentMountInfo {
 {
   CK::Component::LayoutContext context(self, constrainedSize);
 
-  CKComponentLayout layout = CKMemoizeOrComputeLayout(self, constrainedSize, _size, parentSize);
+  CKComponentLayout layout = [self computeLayoutThatFits:constrainedSize
+                                        restrictedToSize:_size
+                                    relativeToParentSize:parentSize];
 
   CKAssert(layout.component == self, @"Layout computed by %@ should return self as component, but returned %@",
            [self class], [layout.component class]);
@@ -247,11 +248,6 @@ struct CKComponentMountInfo {
 - (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize
 {
   return {self, constrainedSize.min};
-}
-
-- (BOOL)shouldMemoizeLayout
-{
-  return NO;
 }
 
 #pragma mark - Responder

--- a/ComponentKit/Core/CKComponentInternal.h
+++ b/ComponentKit/Core/CKComponentInternal.h
@@ -71,6 +71,3 @@
 @property (nonatomic, assign, readonly) CKComponentSize size;
 
 @end
-
-// Internal, for CKComponent
-CKComponentLayout CKMemoizeOrComputeLayout(CKComponent *component, CKSizeRange constrainedSize, const CKComponentSize& size, CGSize parentSize);

--- a/ComponentKit/Core/CKComponentLifecycleManager.h
+++ b/ComponentKit/Core/CKComponentLifecycleManager.h
@@ -25,7 +25,6 @@ struct CKComponentLifecycleManagerState {
   CKSizeRange constrainedSize;
   CKComponentLayout layout;
   CKComponentScopeRoot *root;
-  id memoizerState;
   CKComponentBoundsAnimation boundsAnimation;
 };
 

--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -18,7 +18,6 @@
 #import "CKComponentInternal.h"
 #import "CKComponentLayout.h"
 #import "CKComponentLifecycleManagerAsynchronousUpdateHandler.h"
-#import "CKComponentMemoizer.h"
 #import "CKComponentProvider.h"
 #import "CKComponentScope.h"
 #import "CKComponentScopeFrame.h"
@@ -87,9 +86,6 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
 
   CKComponentScopeRoot *previousRoot = _previousRoot ?: [CKComponentScopeRoot rootWithListener:self];
 
-  // Vend components from the current layout to be available in the new state and layout calculations
-  CKComponentMemoizer memoizer(_state.memoizerState);
-
   CKBuildComponentResult result = CKBuildComponent(previousRoot, _pendingStateUpdates, ^{
     return [_componentProvider componentForModel:model context:context];
   });
@@ -104,7 +100,6 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
     .context = context,
     .constrainedSize = constrainedSize,
     .layout = layout,
-    .memoizerState = memoizer.nextMemoizerState(),
     .root = result.scopeRoot,
     .boundsAnimation = result.boundsAnimation,
   };

--- a/ComponentKit/Core/CKComponentMemoizer.mm
+++ b/ComponentKit/Core/CKComponentMemoizer.mm
@@ -173,14 +173,16 @@ id CKComponentMemoizer::nextMemoizerState()
 
 CKComponentLayout CKMemoizeLayout(CKComponent *component, CKSizeRange constrainedSize, const CKComponentSize& size, CGSize parentSize, CKComponentLayout (^block)())
 {
-  _CKComponentMemoizerImpl *impl = [_CKComponentMemoizerImpl currentMemoizer];
-  CKCAssertNotNil(impl, @"There is no current memoizer, cannot memoize layout. You probably forgot to add a CKMemoizingComponent in the hierarchy above %@", component);
-  if (impl) { // If component wants layout memoization but there isn't a current memoizer, fall down to compute case
-    return [impl cachedLayout:component
-                     thatFits:constrainedSize
-             restrictedToSize:size
-                   parentSize:parentSize
-                        block:block];
+  if (component != nil) {
+    _CKComponentMemoizerImpl *impl = [_CKComponentMemoizerImpl currentMemoizer];
+    CKCAssertNotNil(impl, @"There is no current memoizer, cannot memoize layout. You probably forgot to add a CKMemoizingComponent in the hierarchy above %@", component);
+    if (impl) { // If component wants layout memoization but there isn't a current memoizer, fall down to compute case
+      return [impl cachedLayout:component
+                       thatFits:constrainedSize
+               restrictedToSize:size
+                     parentSize:parentSize
+                          block:block];
+    }
   }
   return block();
 }

--- a/ComponentKit/Core/CKComponentSubclass.h
+++ b/ComponentKit/Core/CKComponentSubclass.h
@@ -79,15 +79,6 @@ extern CGSize const kCKComponentParentSizeUndefined;
                       relativeToParentSize:(CGSize)parentSize;
 
 /**
- Override this in a subclass to opt-in to layout memoization.
-
- Calls to -layoutThatFits:constrainedSize: will then be transparently memoized across re-layouts
- for a given component instance, constrained size, and parent size, as long as there is a CKComponentMemoizer
- active in the given scope (see CKComponentMemoizer.h for details).
- */
-- (BOOL)shouldMemoizeLayout;
-
-/**
  Enqueue a change to the state.
 
  @param updateBlock A block that takes the current state as a parameter and returns an instance of the new state.


### PR DESCRIPTION
My goal here is to reduce the need for customizations to the build and layout calls in every rendering context that wants memoization. Here's an example of what I'm trying to avoid:

https://github.com/facebook/componentkit/pull/675

If your component hierarchy needs memoization, it should work regardless of how you configure your components, and ideally we wouldn't have to do this type of change to every place that builds components.

In this diff I introduce CKMemoizingComponent which prepares the thread-local state for component and layout memoization for its children. This component stores its memoization state into its scope's state.

Due to the nature of the thread-local stack that memoizers are built with, it should be fine to have multiple memoization components in the hierarchy with little cost, and everything "just works". This is important, since if you embed a sub-hierarchy that adds one of these so it can memoize in a different context, you don't want it to conflict with a higher-level memoizing component wrapper.

I'd like to land this first, then look at fixing up the scopes/states as in https://github.com/facebook/componentkit/pull/348 after this is in master. Looking at that diff, we can apply basically the same process here.
