### PR TITLE
Try to reduce some of the code in the headers of component actions

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -139,24 +139,9 @@ struct CKTypedComponentAction {
   { this->send(sender, _internal.defaultBehavior(), args...); }
   void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
   {
-    if (!_internal) {
-      return;
-    }
     const id target = _internal.initialTarget(sender);
     const id responder = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];
     CKComponentActionSendResponderChain(_internal.selector(), responder, sender, args...);
-  }
-  
-  /** Allows you to get a block that sends the action when executed. */
-  typedef void (^CKTypedComponentActionCurriedSenderExecutionBlock)(T... args);
-  CKTypedComponentActionCurriedSenderExecutionBlock curriedSenderBlock(id sender, CKComponentActionSendBehavior behavior) const
-  {
-    __weak id weakSender = sender;
-    CKTypedComponentAction<T...> copy {*this};
-    return ^(T... args) {
-      id strongSender = weakSender;
-      copy.send(strongSender, behavior, args...);
-    };
   }
 
   CKTypedComponentActionValue _internal;

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -195,7 +195,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
 
 static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSignature *signature, const std::vector<const char *> &typeEncodings)
 {
-#ifdef DEBUG
+#if DEBUG
   CKCAssert(typeEncodings.size() + 3 >= signature.numberOfArguments, @"Expected action method %@ to take less than %lu arguments, but it suppoorts %lu", NSStringFromSelector(selector), typeEncodings.size(), (unsigned long)signature.numberOfArguments - 3);
 
   CKCAssert(signature.methodReturnLength == 0, @"Component action methods should not have any return value. Any objects returned from this method will be leaked.");
@@ -211,7 +211,7 @@ static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSigna
 
 void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings)
 {
-#ifdef DEBUG
+#if DEBUG
   // In DEBUG mode, we want to do the minimum of type-checking for the action that's possible in Objective-C. We
   // can't do exact type checking, but we can ensure that you're passing the right type of primitives to the right
   // argument indices.
@@ -228,7 +228,7 @@ void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SE
 
 void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings)
 {
-#ifdef DEBUG
+#if DEBUG
   // In DEBUG mode, we want to do the minimum of type-checking for the action that's possible in Objective-C. We
   // can't do exact type checking, but we can ensure that you're passing the right type of primitives to the right
   // argument indices.

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -107,19 +107,11 @@ NSString *_CKComponentResponderChainDebugResponderChain(id responder);
 
 #pragma mark - Sending
 
+NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender);
+
 template<typename... T>
 static void CKComponentActionSendResponderChain(SEL selector, id target, CKComponent *sender, T... args) {
-  id responder = [target targetForAction:selector withSender:target];
-  CKCAssertNotNil(responder, @"Unhandled component action %@ following responder chain %@",
-                  NSStringFromSelector(selector), _CKComponentResponderChainDebugResponderChain(target));
-  // This is not performance-sensitive, so we can just use an invocation here.
-  NSMethodSignature *signature = [responder methodSignatureForSelector:selector];
-  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
-  invocation.selector = selector;
-  invocation.target = responder;
-  if (signature.numberOfArguments >= 3) {
-    [invocation setArgument:&sender atIndex:2];
-  }
+  NSInvocation *invocation = CKComponentActionSendResponderInvocationPrepare(selector, target, sender);
   // We use a recursive argument unpack to unwrap the variadic arguments in-order on the invocation in a type-safe
   // manner.
   CKConfigureInvocationWithArguments(invocation, 3, args...);

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -355,25 +355,6 @@
   XCTAssertTrue(calledBlock, @"Outer component should have received the action, even though the components are not mounted.");
 }
 
-- (void)testTargetSelectorActionCallsOnTargetWhenExecutionBlockInvokedWithCurriedSender
-{
-  __block id actionSender = nil;
-
-  CKComponent *innerComponent = [CKComponent new];
-  CKTestActionComponent *outerComponent =
-  [CKTestActionComponent
-   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionSender = sender; }
-   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
-   primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
-   component:innerComponent];
-
-  CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
-  action.curriedSenderBlock(innerComponent, CKComponentActionSendBehaviorStartAtSender)(@"hello");
-
-  XCTAssertTrue(actionSender == innerComponent, @"Sender should be the inner component.");
-}
-
 - (void)testScopeActionCallsMethodOnScopedComponent
 {
   __block BOOL calledAction = NO;


### PR DESCRIPTION
Pulling in the templated struct action, we saw an inflation of the binary. Let's try moving some stuff our of the headers to try and reduce some of the bloat.

The curried block function can be implemented fully by users, doesn't need to be present on every template instantiation. Also, move invocation creation and initial configuration to an extern function.