### PR TITLE
Fix build for certain device and dylib builds

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -129,7 +129,9 @@ struct CKTypedComponentAction {
   CKTypedComponentAction(int s) : _internal({}) {};
   CKTypedComponentAction(long s) : _internal({}) {};
   CKTypedComponentAction(std::nullptr_t n) : _internal({}) {};
-  
+
+  ~CKTypedComponentAction() {};
+
   explicit operator bool() const { return bool(_internal); };
   bool operator==(const CKTypedComponentAction& rhs) const { return _internal == rhs._internal; }
   


### PR DESCRIPTION
This already landed internally to fix dylib builds for certain device configurations. I'm unclear on why certain architectures require this explicit destructor.