### PR TITLE
Fix forwarded selectors not respected

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -70,9 +70,7 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
   while (!signature) {
     // From https://www.mikeash.com/pyblog/friday-qa-2009-03-27-objective-c-message-forwarding.html
     // 1. Lazy method resolution
-    BOOL resolved = [[responder class] resolveInstanceMethod:selector];
-    
-    if (resolved) {
+    if ( [[responder class] resolveInstanceMethod:selector]) {
       signature = [responder methodSignatureForSelector:selector];
       // The responder resolved its instance method, we now have a valid responder/signature
       break;

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -70,9 +70,10 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
   while (!signature) {
     // From https://www.mikeash.com/pyblog/friday-qa-2009-03-27-objective-c-message-forwarding.html
     // 1. Lazy method resolution
-    [[responder class] resolveInstanceMethod:selector];
-    signature = [responder methodSignatureForSelector:selector];
-    if (signature) {
+    BOOL resolved = [[responder class] resolveInstanceMethod:selector];
+    
+    if (resolved) {
+      signature = [responder methodSignatureForSelector:selector];
       // The responder resolved its instance method, we now have a valid responder/signature
       break;
     }


### PR DESCRIPTION
According to https://www.mikeash.com/pyblog/friday-qa-2009-03-27-objective-c-message-forwarding.html we missed a step in doing our invocation here. The performSelector:withObject: we were using before looks for a fast-forwarding path if the object doesn't respond to the selector.

We have to make sure that once we get to the responder in the chain that wants the action, we give it the opportunity to forward that selector.