### PR TITLE
Use a base-class for CKTypedComponentAction to reduce size

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -100,7 +100,7 @@ public:
     _CKTypedComponentDebugCheckTargetSelector(target, selector, typeEncodings);
 #endif
   }
-  
+
   CKTypedComponentAction<T...>(const CKComponentScope &scope, SEL selector) : CKTypedComponentActionBase(scope, selector)
   {
 #if DEBUG
@@ -109,36 +109,40 @@ public:
     _CKTypedComponentDebugCheckComponentScope(scope, selector, typeEncodings);
 #endif
   }
-  
-  // Legacy constructor for raw selector actions. Traverse up the mount responder chain.
+
+  /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
   CKTypedComponentAction(SEL selector) : CKTypedComponentActionBase(selector) {};
-  
-  // Allows conversion from NULL actions.
+
+  /** Allows conversion from NULL actions. */
   CKTypedComponentAction(int s) : CKTypedComponentActionBase() {};
   CKTypedComponentAction(long s) : CKTypedComponentActionBase() {};
   CKTypedComponentAction(std::nullptr_t n) : CKTypedComponentActionBase() {};
-  
+
   /** We support promotion from actions that take no arguments. */
   template <typename... Ts>
   CKTypedComponentAction<Ts...>(const CKTypedComponentAction<> &action) : CKTypedComponentActionBase(action) { };
-  
+
   /**
    We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the
    method specified here will have nil values at runtime. Used for interoperation with older API's.
    */
   template<typename... Ts>
   explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action) : CKTypedComponentActionBase(action) { };
-  
+
   ~CKTypedComponentAction() {};
-  
+
   void send(CKComponent *sender, T... args) const
-  { this->send(sender, _internal.defaultBehavior(), args...); }
+  { this->send(sender, _internal.defaultBehavior(), args...); };
   void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
   {
     const id target = _internal.initialTarget(sender);
     const id responder = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];
     CKComponentActionSendResponderChain(_internal.selector(), responder, sender, args...);
-  }
+  };
+
+  bool operator==(const CKTypedComponentAction<T...> &rhs) const {
+    return isEqual(rhs);
+  };
 };
 
 typedef CKTypedComponentAction<> CKComponentAction;
@@ -150,7 +154,7 @@ extern template class CKTypedComponentAction<id>;
 /**
  Sends a component action up the responder chain by crawling up the responder chain until it finds a responder that
  responds to the action's selector, then invokes it. These remain for legacy reasons, and simply call action.send(...);
- 
+
  @param action The action to send up the responder chain.
  @param sender The component sending the action. Traversal starts from the component itself, then its next responder.
  @param context An optional context-dependent second parameter to the component action.
@@ -164,7 +168,7 @@ void CKComponentActionSend(CKTypedComponentAction<id> action, CKComponent *sende
 /**
  Returns a view attribute that configures a component that creates a UIControl to send the given CKComponentAction.
  You can use this with e.g. CKButtonComponent.
- 
+
  @param action Sent up the responder chain when an event occurs. Sender is the component that created the UIControl;
  context is the UIEvent that triggered the action. May be NULL, in which case no action will be sent.
  @param controlEvents The events that should result in the action being sent. Default is touch up inside.

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -269,3 +269,8 @@ NSString *_CKComponentResponderChainDebugResponderChain(id responder) {
 }
 
 @end
+
+#pragma mark - Template instantiations
+
+template class CKTypedComponentAction<>;
+template class CKTypedComponentAction<id>;

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -55,6 +55,34 @@ private:
   SEL _selector;
 };
 
+#pragma mark - Action Base
+
+/** A base-class for typed components that doesn't use templates to avoid template bloat. */
+class CKTypedComponentActionBase {
+protected:
+  CKTypedComponentActionBase() = default;
+  CKTypedComponentActionBase(id target, SEL selector) : _internal({CKTypedComponentActionVariantTargetSelector, target, nil, selector}) {};
+  
+  CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) : _internal({CKTypedComponentActionVariantComponentScope, nil, scope.scopeHandle(), selector}) {};
+  
+  /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
+  CKTypedComponentActionBase(SEL selector) : _internal(CKTypedComponentActionVariantRawSelector, nil, nil, selector) {};
+  
+  /** Allows conversion from NULL actions. */
+  CKTypedComponentActionBase(int s) : _internal({}) {};
+  CKTypedComponentActionBase(long s) : _internal({}) {};
+  CKTypedComponentActionBase(std::nullptr_t n) : _internal({}) {};
+  
+  ~CKTypedComponentActionBase() {};
+  
+  CKTypedComponentActionValue _internal;
+public:
+  explicit operator bool() const { return bool(_internal); };
+  bool operator==(const CKTypedComponentActionBase &rhs) const { return _internal == rhs._internal; }
+  
+  SEL selector() const { return _internal.selector(); };
+};
+
 #pragma mark - Typed Helpers
 
 template <typename... Ts> struct CKTypedComponentActionTypelist { };

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -61,26 +61,25 @@ private:
 class CKTypedComponentActionBase {
 protected:
   CKTypedComponentActionBase() = default;
-  CKTypedComponentActionBase(id target, SEL selector) : _internal({CKTypedComponentActionVariantTargetSelector, target, nil, selector}) {};
-  
-  CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) : _internal({CKTypedComponentActionVariantComponentScope, nil, scope.scopeHandle(), selector}) {};
-  
+  CKTypedComponentActionBase(id target, SEL selector);
+
+  CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector);
+
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
-  CKTypedComponentActionBase(SEL selector) : _internal(CKTypedComponentActionVariantRawSelector, nil, nil, selector) {};
-  
+  CKTypedComponentActionBase(SEL selector);
+
   /** Allows conversion from NULL actions. */
-  CKTypedComponentActionBase(int s) : _internal({}) {};
-  CKTypedComponentActionBase(long s) : _internal({}) {};
-  CKTypedComponentActionBase(std::nullptr_t n) : _internal({}) {};
-  
+  CKTypedComponentActionBase(int s);
+  CKTypedComponentActionBase(long s);
+  CKTypedComponentActionBase(std::nullptr_t n);
+
   ~CKTypedComponentActionBase() {};
-  
+
   CKTypedComponentActionValue _internal;
 public:
-  explicit operator bool() const { return bool(_internal); };
-  bool operator==(const CKTypedComponentActionBase &rhs) const { return _internal == rhs._internal; }
-  
-  SEL selector() const { return _internal.selector(); };
+  explicit operator bool() const;
+  bool isEqual(const CKTypedComponentActionBase &rhs) const;
+  SEL selector() const;
 };
 
 #pragma mark - Typed Helpers


### PR DESCRIPTION
I met with @craffert0 this morning to go over strategies to reduce the size of the component action struct because we caused a lot of template bloat due to the tens of thousands of callsites we inflated with the initial templated struct approach. We move the bulk of the implementations to a non-templated base class, and moved the internal struct to be protected, so no more direct access to the value struct! Yay!

We also moved for an explicit external template instantiation for <> and <id> since these are the most common uses, and we can force the compiler to use the out-of-line definition instead of inlining the method bodies. This should make all the callsites just call the same functions in the binary instead of spreading our implementations all over the place.

This shouldn't change any client code. Interface remains identical.