### PR TITLE
Reduce type bloat by removing sub-struct

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -132,12 +132,12 @@ public:
   ~CKTypedComponentAction() {};
 
   void send(CKComponent *sender, T... args) const
-  { this->send(sender, _internal.defaultBehavior(), args...); };
+  { this->send(sender, defaultBehavior(), args...); };
   void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
   {
-    const id target = _internal.initialTarget(sender);
+    const id target = initialTarget(sender);
     const id responder = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];
-    CKComponentActionSendResponderChain(_internal.selector(), responder, sender, args...);
+    CKComponentActionSendResponderChain(selector(), responder, sender, args...);
   };
 
   bool operator==(const CKTypedComponentAction<T...> &rhs) const {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -94,7 +94,7 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
       // The responder resolved its instance method, we now have a valid responder/signature
       break;
     }
-    
+
     // 2. Fast-forwarding path
     id forwardingTarget = [responder forwardingTargetForSelector:selector];
     if (!forwardingTarget || forwardingTarget == responder) {
@@ -102,7 +102,7 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
       CKCFailAssert(@"Forwarding target failed for action:%@ %@", target, NSStringFromSelector(selector));
       return nil;
     }
-    
+
     responder = forwardingTarget;
     signature = [responder methodSignatureForSelector:selector];
   }
@@ -159,7 +159,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
 {
   static ForwarderMap *map = new ForwarderMap(); // never destructed to avoid static destruction fiasco
   static CK::StaticMutex lock = CK_MUTEX_INITIALIZER;   // protects map
-  
+
   if (!action) {
     return {
       {"CKComponentActionAttribute-no-op", ^(UIControl *control, id value) {}, ^(UIControl *control, id value) {}},
@@ -167,7 +167,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
       @YES
     };
   }
-  
+
   // We need a target for the control event. (We can't use the responder chain because we need to jump in and change the
   // sender from the UIControl to the CKComponent.)
   // Control event targets are __unsafe_unretained. We can't rely on the block to keep the target alive, since the block
@@ -188,7 +188,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
       forwarder = it->second;
     }
   }
-  
+
   std::string identifier = std::string("CKComponentActionAttribute-")
   + std::string(sel_getName(action.selector()))
   + "-" + std::to_string(controlEvents);
@@ -236,13 +236,13 @@ static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSigna
 {
 #if DEBUG
   CKCAssert(typeEncodings.size() + 3 >= signature.numberOfArguments, @"Expected action method %@ to take less than %lu arguments, but it suppoorts %lu", NSStringFromSelector(selector), typeEncodings.size(), (unsigned long)signature.numberOfArguments - 3);
-  
+
   CKCAssert(signature.methodReturnLength == 0, @"Component action methods should not have any return value. Any objects returned from this method will be leaked.");
-  
+
   for (int i = 0; i + 3 < signature.numberOfArguments; i++) {
     const char *methodEncoding = [signature getArgumentTypeAtIndex:i + 3];
     const char *typeEncoding = typeEncodings[i];
-    
+
     CKCAssert(methodEncoding == NULL || typeEncoding == NULL || strcmp(methodEncoding, typeEncoding) == 0, @"Implementation of %@ does not match expected types.\nExpected type %s, got %s", NSStringFromSelector(selector), typeEncoding, methodEncoding);
   }
 #endif
@@ -258,9 +258,9 @@ void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SE
   // We allow component actions to be implemented either in the component, or its controller.
   const Class controllerKlass = CKComponentControllerClassFromComponentClass(klass);
   CKCAssert([klass instancesRespondToSelector:selector] || [controllerKlass instancesRespondToSelector:selector], @"Target does not respond to selector for component action. -[%@ %@]", klass, NSStringFromSelector(selector));
-  
+
   NSMethodSignature *signature = [klass instanceMethodSignatureForSelector:selector] ?: [controllerKlass instanceMethodSignatureForSelector:selector];
-  
+
   checkMethodSignatureAgainstTypeEncodings(selector, signature, typeEncodings);
 #endif
 }
@@ -272,9 +272,9 @@ void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const st
   // can't do exact type checking, but we can ensure that you're passing the right type of primitives to the right
   // argument indices.
   CKCAssert([target respondsToSelector:selector], @"Target does not respond to selector for component action. -[%@ %@]", [target class], NSStringFromSelector(selector));
-  
+
   NSMethodSignature *signature = [target methodSignatureForSelector:selector];
-  
+
   checkMethodSignatureAgainstTypeEncodings(selector, signature, typeEncodings);
 #endif
 }

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -36,46 +36,36 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   CKComponentActionSendBehaviorStartAtSender,
 };
 
-struct CKTypedComponentActionValue {
-  CKTypedComponentActionValue();
-  CKTypedComponentActionValue(const CKTypedComponentActionValue &value);
-  CKTypedComponentActionValue(CKTypedComponentActionVariant variant, __unsafe_unretained id target, __unsafe_unretained CKComponentScopeHandle *scopeHandle, SEL selector);
-
-  id initialTarget(CKComponent *sender) const;
-  SEL selector() const { return _selector; };
-  CKComponentActionSendBehavior defaultBehavior() const;
-
-  explicit operator bool() const { return _selector != NULL; };
-  bool operator==(const CKTypedComponentActionValue& rhs) const;
-
-private:
-  CKTypedComponentActionVariant _variant;
-  __weak id _target;
-  __weak CKComponentScopeHandle *_scopeHandle;
-  SEL _selector;
-};
-
 #pragma mark - Action Base
 
 /** A base-class for typed components that doesn't use templates to avoid template bloat. */
 class CKTypedComponentActionBase {
 protected:
-  CKTypedComponentActionBase() = default;
+  CKTypedComponentActionBase();
   CKTypedComponentActionBase(id target, SEL selector);
-
+  
   CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector);
-
+  
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
   CKTypedComponentActionBase(SEL selector);
-
+  
   /** Allows conversion from NULL actions. */
   CKTypedComponentActionBase(int s);
   CKTypedComponentActionBase(long s);
   CKTypedComponentActionBase(std::nullptr_t n);
-
+  
   ~CKTypedComponentActionBase() {};
-
-  CKTypedComponentActionValue _internal;
+  
+  id initialTarget(CKComponent *sender) const;
+  CKComponentActionSendBehavior defaultBehavior() const;
+  
+  bool operator==(const CKTypedComponentActionBase& rhs) const;
+  
+  CKTypedComponentActionVariant _variant;
+  __weak id _target;
+  __weak CKComponentScopeHandle *_scopeHandle;
+  SEL _selector;
+  
 public:
   explicit operator bool() const;
   bool isEqual(const CKTypedComponentActionBase &rhs) const;
@@ -95,7 +85,7 @@ struct CKTypedComponentActionDenyType : std::true_type {};
 /** Base case, recursion should stop here. */
 void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list);
 
-/** 
+/**
  Recursion through variadic argument type unpacking. This allows us to build a vector of encoded const char * before
  any actual arguments have been provided. All of this is done at compile-time.
  */


### PR DESCRIPTION
In inspecting the type encodings of these classes inside the compiled binaries I noted that we're seeing both the CKTypedComponentAction<...> signature AND its sub-struct the CKTypedComponentActionValue struct in the type encoded strings when stored as ivars or passed to obj-c methods. This indirection was made unnecessary by the move to a non-templated base-class, so let's move all this to directly use members of the base-class.

This should change no client code, but should reduce binary bloat a little bit.