### PR TITLE
Add call operator

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -132,12 +132,12 @@ public:
   ~CKTypedComponentAction() {};
 
   void send(CKComponent *sender, T... args) const
-  { this->send(sender, _internal.defaultBehavior(), args...); };
+  { this->send(sender, defaultBehavior(), args...); };
   void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
   {
-    const id target = _internal.initialTarget(sender);
+    const id target = initialTarget(sender);
     const id responder = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];
-    CKComponentActionSendResponderChain(_internal.selector(), responder, sender, args...);
+    CKComponentActionSendResponderChain(selector(), responder, sender, args...);
   };
 
   bool operator==(const CKTypedComponentAction<T...> &rhs) const {

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -131,9 +131,9 @@ public:
 
   ~CKTypedComponentAction() {};
 
-  void send(CKComponent *sender, T... args) const
-  { this->send(sender, defaultBehavior(), args...); };
-  void send(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
+  void operator()(CKComponent *sender, T... args) const
+  { (*this)(sender, defaultBehavior(), args...); };
+  void operator()(CKComponent *sender, CKComponentActionSendBehavior behavior, T... args) const
   {
     const id target = initialTarget(sender);
     const id responder = behavior == CKComponentActionSendBehaviorStartAtSender ? target : [target nextResponder];

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -119,22 +119,22 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
 
 void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender)
 {
-  action.send(sender);
+  action(sender);
 }
 
 void CKComponentActionSend(const CKComponentAction &action, CKComponent *sender, CKComponentActionSendBehavior behavior)
 {
-  action.send(sender, behavior);
+  action(sender, behavior);
 }
 
 void CKComponentActionSend(CKTypedComponentAction<id> action, CKComponent *sender, id context)
 {
-  action.send(sender, CKComponentActionSendBehaviorStartAtSenderNextResponder, context);
+  action(sender, CKComponentActionSendBehaviorStartAtSenderNextResponder, context);
 }
 
 void CKComponentActionSend(CKTypedComponentAction<id> action, CKComponent *sender, id context, CKComponentActionSendBehavior behavior)
 {
-  action.send(sender, behavior, context);
+  action(sender, behavior, context);
 }
 
 #pragma mark - Control Actions
@@ -227,7 +227,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
 - (void)handleControlEventFromSender:(UIControl *)sender withEvent:(UIEvent *)event
 {
   // If the action can be handled by the sender itself, send it there instead of looking up the chain.
-  _action.send(sender.ck_component, CKComponentActionSendBehaviorStartAtSender, event);
+  _action(sender.ck_component, CKComponentActionSendBehaviorStartAtSender, event);
 }
 
 #pragma mark - Debug Helpers

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -36,46 +36,36 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   CKComponentActionSendBehaviorStartAtSender,
 };
 
-struct CKTypedComponentActionValue {
-  CKTypedComponentActionValue();
-  CKTypedComponentActionValue(const CKTypedComponentActionValue &value);
-  CKTypedComponentActionValue(CKTypedComponentActionVariant variant, __unsafe_unretained id target, __unsafe_unretained CKComponentScopeHandle *scopeHandle, SEL selector);
-
-  id initialTarget(CKComponent *sender) const;
-  SEL selector() const { return _selector; };
-  CKComponentActionSendBehavior defaultBehavior() const;
-
-  explicit operator bool() const { return _selector != NULL; };
-  bool operator==(const CKTypedComponentActionValue& rhs) const;
-
-private:
-  CKTypedComponentActionVariant _variant;
-  __weak id _target;
-  __weak CKComponentScopeHandle *_scopeHandle;
-  SEL _selector;
-};
-
 #pragma mark - Action Base
 
 /** A base-class for typed components that doesn't use templates to avoid template bloat. */
 class CKTypedComponentActionBase {
 protected:
-  CKTypedComponentActionBase() = default;
+  CKTypedComponentActionBase();
   CKTypedComponentActionBase(id target, SEL selector);
-
+  
   CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector);
-
+  
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
   CKTypedComponentActionBase(SEL selector);
-
+  
   /** Allows conversion from NULL actions. */
   CKTypedComponentActionBase(int s);
   CKTypedComponentActionBase(long s);
   CKTypedComponentActionBase(std::nullptr_t n);
-
+  
   ~CKTypedComponentActionBase() {};
-
-  CKTypedComponentActionValue _internal;
+  
+  id initialTarget(CKComponent *sender) const;
+  CKComponentActionSendBehavior defaultBehavior() const;
+  
+  bool operator==(const CKTypedComponentActionBase& rhs) const;
+  
+  CKTypedComponentActionVariant _variant;
+  __weak id _target;
+  __weak CKComponentScopeHandle *_scopeHandle;
+  SEL _selector;
+  
 public:
   explicit operator bool() const;
   bool isEqual(const CKTypedComponentActionBase &rhs) const;
@@ -95,7 +85,7 @@ struct CKTypedComponentActionDenyType : std::true_type {};
 /** Base case, recursion should stop here. */
 void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list);
 
-/** 
+/**
  Recursion through variadic argument type unpacking. This allows us to build a vector of encoded const char * before
  any actual arguments have been provided. All of this is done at compile-time.
  */

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -180,7 +180,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
   // If the action can be handled by the sender itself, send it there instead of looking up the chain.
-  [recognizer ck_componentAction].send(recognizer.view.ck_component, CKComponentActionSendBehaviorStartAtSender, recognizer);
+  [recognizer ck_componentAction](recognizer.view.ck_component, CKComponentActionSendBehaviorStartAtSender, recognizer);
 }
 
 @end

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -54,7 +54,7 @@
 
 - (void)triggerAction:(id)context
 {
-  _action.send(self, context);
+  _action(self, context);
 }
 
 @end
@@ -94,7 +94,7 @@
 
 - (void)triggerAction:(id)context
 {
-  _action.send(self, context);
+  _action(self, context);
 }
 
 @end
@@ -186,7 +186,7 @@
   id context2 = @"context2";
 
   CKTypedComponentAction<id, id> action = { @selector(testAction2:context1:context2:) };
-  action.send(innerComponent, context, context2);
+  action(innerComponent, context, context2);
 
   XCTAssert(actionContext == context && actionContext2 == context2, @"Contexts should match what was passed to CKComponentActionSend");
 
@@ -213,7 +213,7 @@
   int integer = 1337;
 
   CKTypedComponentAction<int> action = { @selector(testPrimitive:integer:) };
-  action.send(innerComponent, integer);
+  action(innerComponent, integer);
 
   XCTAssert(actionInteger == integer, @"Contexts should match what was passed to CKComponentActionSend");
 
@@ -238,7 +238,7 @@
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
   CKTypedComponentAction<> action = { @selector(testNoArgumentAction) };
-  action.send(innerComponent);
+  action(innerComponent);
 
   XCTAssert(calledNoArgumentBlock, @"Contexts should match what was passed to CKComponentActionSend");
 
@@ -263,7 +263,7 @@
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
   CKTypedComponentAction<id> action = { @selector(testNoArgumentAction) };
-  action.send(innerComponent, @"hello");
+  action(innerComponent, @"hello");
 
   XCTAssert(calledNoArgumentBlock, @"Contexts should match what was passed to CKComponentActionSend");
 
@@ -350,7 +350,7 @@
    component:innerComponent];
 
   CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
-  action.send(innerComponent, CKComponentActionSendBehaviorStartAtSender, @"hello");
+  action(innerComponent, CKComponentActionSendBehaviorStartAtSender, @"hello");
 
   XCTAssertTrue(calledBlock, @"Outer component should have received the action, even though the components are not mounted.");
 }


### PR DESCRIPTION
Based on https://github.com/facebook/componentkit/pull/683

I think it makes sense to add a call operator for component actions instead of using the send() function. This makes them feel like functions...