### PR TITLE
Revert "Merge pull request #469 from DeskConnect/transactional-bounds…

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -3420,6 +3420,10 @@
 		B342DC471AC23E8200ACAC53 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = "ComponentKitTests/ComponentKitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3430,6 +3434,10 @@
 		B342DC481AC23E8200ACAC53 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = "ComponentKitTests/ComponentKitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3440,6 +3448,10 @@
 		B342DC921AC23EC300ACAC53 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = "ComponentKitApplicationTests/ComponentKitApplicationTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -3451,6 +3463,10 @@
 		B342DC931AC23EC300ACAC53 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = "ComponentKitApplicationTests/ComponentKitApplicationTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.componentkit.$(PRODUCT_NAME:rfc1034identifier)";

--- a/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
+++ b/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
@@ -104,10 +104,6 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
   if (animation.duration == 0) {
     return;
   }
-  // Don't animate the collection view if it is not being displayed.
-  if (!_collectionView.window) {
-    return;
-  }
   // The documentation states that you must not use these functions with inserts or deletes. Let's be safe:
   if ([_collectionView numberOfSections] != _numberOfSections) {
     return;

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.h
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.h
@@ -41,7 +41,6 @@
  */
 - (void)attachComponentLayout:(CKComponentLayout)layout
           withScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier
-          withBoundsAnimation:(CKComponentBoundsAnimation)boundsAnimation
                        toView:(UIView *)view;
 /**
  Detaching a component tree will cause it to be unmounted from the view it is currently attached to and will mark the view as available to be

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
@@ -52,7 +52,6 @@
 
 - (void)attachComponentLayout:(CKComponentLayout)layout
           withScopeIdentifier:(CKComponentScopeRootIdentifier)scopeIdentifier
-          withBoundsAnimation:(CKComponentBoundsAnimation)boundsAnimation
                        toView:(UIView *)view
 {
   CKAssertMainThread();
@@ -68,7 +67,7 @@
   }
   
   // Mount the component tree on the view
-  CKComponentDataSourceAttachState *attachState = _mountComponentLayoutInView(layout, view, scopeIdentifier, boundsAnimation);
+  CKComponentDataSourceAttachState *attachState = _mountComponentLayoutInView(layout, view, scopeIdentifier);
   // Mark the view as attached and associates it to the right attach state
   _scopeIdentifierToAttachedViewMap[@(scopeIdentifier)] = view;
   view.ck_attachState = attachState;
@@ -102,15 +101,11 @@
 
 static CKComponentDataSourceAttachState *_mountComponentLayoutInView(CKComponentLayout layout,
                                                                      UIView *view,
-                                                                     CKComponentScopeRootIdentifier scopeIdentifier,
-                                                                     CKComponentBoundsAnimation boundsAnimation)
+                                                                     CKComponentScopeRootIdentifier scopeIdentifier)
 {
   CKCAssertNotNil(view, @"Impossible to mount a component layout on a nil view");
   NSSet *currentlyMountedComponents = view.ck_attachState.mountedComponents;
-  __block NSSet *newMountedComponents = nil;
-  CKComponentBoundsAnimationApply(boundsAnimation, ^{
-    newMountedComponents = CKMountComponentLayout(layout, view, currentlyMountedComponents, nil);
-  }, nil);
+  NSSet *newMountedComponents = CKMountComponentLayout(layout, view, currentlyMountedComponents, nil);
   return [[CKComponentDataSourceAttachState alloc] initWithScopeIdentifier:scopeIdentifier mountedComponents:newMountedComponents layout:layout];
 }
 

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.h
@@ -9,7 +9,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <ComponentKit/CKComponentBoundsAnimation.h>
 
 class CKComponentLayout;
 @class CKComponentScopeRoot;
@@ -23,8 +22,5 @@ class CKComponentLayout;
 
 /** The scope root for this item, which holds references to component controllers and state */
 @property (nonatomic, strong, readonly) CKComponentScopeRoot *scopeRoot;
-
-/** The bounds animation with which to apply the layout */
-@property (nonatomic, readonly) CKComponentBoundsAnimation boundsAnimation;
 
 @end

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItem.mm
@@ -23,13 +23,11 @@
 - (instancetype)initWithLayout:(const CKComponentLayout &)layout
                          model:(id)model
                      scopeRoot:(CKComponentScopeRoot *)scopeRoot
-               boundsAnimation:(CKComponentBoundsAnimation)boundsAnimation
 {
   if (self = [super init]) {
     _layout = layout;
     _model = model;
     _scopeRoot = scopeRoot;
-    _boundsAnimation = boundsAnimation;
   }
   return self;
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItemInternal.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceItemInternal.h
@@ -15,7 +15,6 @@
 
 - (instancetype)initWithLayout:(const CKComponentLayout &)layout
                          model:(id)model
-                     scopeRoot:(CKComponentScopeRoot *)scopeRoot
-               boundsAnimation:(CKComponentBoundsAnimation)boundsAnimation;
+                     scopeRoot:(CKComponentScopeRoot *)scopeRoot;
 
 @end

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceChangesetModification.mm
@@ -64,7 +64,7 @@
     const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
 
     [section replaceObjectAtIndex:indexPath.item withObject:
-     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot boundsAnimation:result.boundsAnimation]];
+     [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot]];
   }];
 
   __block std::unordered_map<NSUInteger, std::map<NSUInteger, CKTransactionalComponentDataSourceItem *>> insertedItemsBySection;
@@ -109,7 +109,7 @@
     });
     const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
     insertedItemsBySection[indexPath.section][indexPath.item] =
-    [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot boundsAnimation:result.boundsAnimation];
+    [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
   }];
 
   for (const auto &sectionIt : insertedItemsBySection) {

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceReloadModification.mm
@@ -52,8 +52,7 @@
       const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
       [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                    model:[item model]
-                                                                               scopeRoot:result.scopeRoot
-                                                                         boundsAnimation:result.boundsAnimation]];
+                                                                               scopeRoot:result.scopeRoot]];
     }];
     [newSections addObject:newItems];
   }];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateConfigurationModification.mm
@@ -58,8 +58,7 @@
         const CKComponentLayout layout = CKComputeRootComponentLayout(item.layout.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
-                                                                       scopeRoot:[item scopeRoot]
-                                                                 boundsAnimation:[item boundsAnimation]];
+                                                                       scopeRoot:[item scopeRoot]];
       } else {
         const CKBuildComponentResult result = CKBuildComponent([item scopeRoot], {}, ^{
           return [componentProvider componentForModel:[item model] context:context];
@@ -67,8 +66,7 @@
         const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
         newItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                            model:[item model]
-                                                                       scopeRoot:result.scopeRoot
-                                                                 boundsAnimation:result.boundsAnimation];
+                                                                       scopeRoot:result.scopeRoot];
       }
 
       [newItems addObject:newItem];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKTransactionalComponentDataSourceUpdateStateModification.mm
@@ -56,8 +56,7 @@
         const CKComponentLayout layout = CKComputeRootComponentLayout(result.component, sizeRange);
         [newItems addObject:[[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout
                                                                                      model:[item model]
-                                                                                 scopeRoot:result.scopeRoot
-                                                                           boundsAnimation:result.boundsAnimation]];
+                                                                                 scopeRoot:result.scopeRoot]];
       }
     }];
     [newSections addObject:newItems];

--- a/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
@@ -36,7 +36,7 @@
   CKComponent *component = [CKComponent new];
   CKComponentScopeRootIdentifier scopeIdentifier = 0x5C09E;
 
-  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier withBoundsAnimation:{} toView:view];
+  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier toView:view];
   CKComponentDataSourceAttachState *attachState = [_attachController attachStateForScopeIdentifier:scopeIdentifier];
   XCTAssertEqualObjects(attachState.mountedComponents, [NSSet setWithObject:component]);
   XCTAssertEqual(attachState.scopeIdentifier, scopeIdentifier);
@@ -51,11 +51,11 @@
   UIView *view = [UIView new];
   CKComponent *component = [CKComponent new];
   CKComponentScopeRootIdentifier scopeIdentifier = 0x5C09E;
-  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier withBoundsAnimation:{} toView:view];
+  [_attachController attachComponentLayout:{component, {0, 0}} withScopeIdentifier:scopeIdentifier toView:view];
 
   CKComponent *component2 = [CKComponent new];
   CKComponentScopeRootIdentifier scopeIdentifier2 = 0x5C09E2;
-  [_attachController attachComponentLayout:{component2, {0, 0}} withScopeIdentifier:scopeIdentifier2 withBoundsAnimation:{} toView:view];
+  [_attachController attachComponentLayout:{component2, {0, 0}} withScopeIdentifier:scopeIdentifier2 toView:view];
 
   // the first component is now detached
   CKComponentDataSourceAttachState *attachState = [_attachController attachStateForScopeIdentifier:scopeIdentifier];

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
@@ -997,8 +997,7 @@ static CKTransactionalComponentDataSourceItem *itemWithModel(id model)
 {
   return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout()
                                                                   model:model
-                                                              scopeRoot:nil
-                                                        boundsAnimation:{}];
+                                                              scopeRoot:nil];
 }
 
 @end

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTestHelpers.mm
@@ -27,7 +27,7 @@ static CKTransactionalComponentDataSourceItem *item(CKTransactionalComponentData
     return [configuration.componentProvider componentForModel:model context:configuration.context];
   });
   const CKComponentLayout layout = [result.component layoutThatFits:configuration.sizeRange parentSize:configuration.sizeRange.max];
-  return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot boundsAnimation:result.boundsAnimation];
+  return [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:layout model:model scopeRoot:result.scopeRoot];
 }
 
 CKTransactionalComponentDataSourceState *CKTransactionalComponentDataSourceTestState(Class<CKComponentProvider> provider,

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceStateTests.mm
@@ -90,14 +90,14 @@
 
 - (void)testStateEquality
 {
-  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil boundsAnimation:{}];
+  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *firstConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"
                                                                            sizeRange:CKSizeRange()];
   CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[firstItem]]];
 
-  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil boundsAnimation:{}];
+  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *secondConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"
@@ -109,14 +109,14 @@
 
 - (void)testNonEqualStates
 {
-  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil boundsAnimation:{}];
+  CKTransactionalComponentDataSourceItem *firstItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *firstConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"
                                                                            sizeRange:CKSizeRange()];
   CKTransactionalComponentDataSourceState *firstState = [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:firstConfiguration sections:@[@[firstItem]]];
 
-  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model2" scopeRoot:nil boundsAnimation:{}];
+  CKTransactionalComponentDataSourceItem *secondItem = [[CKTransactionalComponentDataSourceItem alloc] initWithLayout:CKComponentLayout() model:@"model2" scopeRoot:nil];
   CKTransactionalComponentDataSourceConfiguration *secondConfiguration =
   [[CKTransactionalComponentDataSourceConfiguration alloc] initWithComponentProvider:[CKTransactionalComponentDataSourceStateTests class]
                                                                              context:@"context"


### PR DESCRIPTION
…-animation"

This reverts https://github.com/facebook/componentkit/pull/469 because it breaks animations in certain conditions. @eczarny is going to get to the bottom of why, and re-commit this, but for now we need to back it out.

This reverts commit e587533db470fef3884a371fb08b35ccb1a6c382, reversing
changes made to e61515a2ea3dea19c154fe86d7718123715e6d09.

