### PR TITLE
RFC: Typed Props Component

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -373,6 +373,14 @@
 		A29D85791D80D37F00913E60 /* CKComponentContextHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A243B52C1D79A40800E6C393 /* CKComponentContextHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2CD66321AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */; };
 		A2D20CF41B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */; };
+		B183A2C11DE51EA7002C7727 /* CKTypedPropsComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B183A2BF1DE51EA7002C7727 /* CKTypedPropsComponent.h */; };
+		B183A2C21DE51EA7002C7727 /* CKTypedPropsComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B183A2C01DE51EA7002C7727 /* CKTypedPropsComponent.mm */; };
+		B183A2DC1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = B183A2DB1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h */; };
+		B183A2DD1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h in Headers */ = {isa = PBXBuildFile; fileRef = B183A2DB1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h */; };
+		B183A2E01DE5D6ED002C7727 /* CKTestTypedPropsComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B183A2DE1DE5D6ED002C7727 /* CKTestTypedPropsComponent.h */; };
+		B183A2E11DE5D6ED002C7727 /* CKTestTypedPropsComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B183A2DE1DE5D6ED002C7727 /* CKTestTypedPropsComponent.h */; };
+		B183A2E21DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B183A2DF1DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm */; };
+		B183A2E31DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B183A2DF1DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm */; };
 		B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */; };
 		B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */; };
@@ -928,6 +936,11 @@
 		A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateStateModificationTests.mm; sourceTree = "<group>"; };
 		A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateTests.mm; sourceTree = "<group>"; tabWidth = 2; };
 		A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentHostingViewAsyncStateUpdateTests.mm; sourceTree = "<group>"; };
+		B183A2BF1DE51EA7002C7727 /* CKTypedPropsComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTypedPropsComponent.h; sourceTree = "<group>"; };
+		B183A2C01DE51EA7002C7727 /* CKTypedPropsComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTypedPropsComponent.mm; sourceTree = "<group>"; };
+		B183A2DB1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTypedPropsComponentSubclass.h; sourceTree = "<group>"; };
+		B183A2DE1DE5D6ED002C7727 /* CKTestTypedPropsComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestTypedPropsComponent.h; sourceTree = "<group>"; };
+		B183A2DF1DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestTypedPropsComponent.mm; sourceTree = "<group>"; };
 		B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKComponentActionInternal.h; sourceTree = "<group>"; };
 		B342DC401AC23E8200ACAC53 /* ComponentKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComponentKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKArrayControllerChangesetTests.mm; sourceTree = "<group>"; };
@@ -1618,6 +1631,11 @@
 				D0B47AD11CBD926700BB33CE /* CKNetworkImageComponent.h */,
 				D0B47AD21CBD926700BB33CE /* CKNetworkImageComponent.mm */,
 				D0B47AD31CBD926700BB33CE /* CKNetworkImageDownloading.h */,
+				B183A2BF1DE51EA7002C7727 /* CKTypedPropsComponent.h */,
+				B183A2DB1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h */,
+				B183A2C01DE51EA7002C7727 /* CKTypedPropsComponent.mm */,
+				B183A2DE1DE5D6ED002C7727 /* CKTestTypedPropsComponent.h */,
+				B183A2DF1DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2112,6 +2130,7 @@
 				03B8B5031D2A346F00EDFF59 /* CKOverlayLayoutComponent.h in Headers */,
 				03B8B5041D2A346F00EDFF59 /* CKComponentGestureActions.h in Headers */,
 				03B8B5051D2A346F00EDFF59 /* CKOptimisticViewMutations.h in Headers */,
+				B183A2E11DE5D6ED002C7727 /* CKTestTypedPropsComponent.h in Headers */,
 				03B8B5061D2A346F00EDFF59 /* CKComponentAction.h in Headers */,
 				03B8B5071D2A346F00EDFF59 /* CKTransactionalComponentDataSourceUpdateConfigurationModification.h in Headers */,
 				03B8B5081D2A346F00EDFF59 /* CKComponentDelegateAttribute.h in Headers */,
@@ -2187,6 +2206,7 @@
 				03B8B54C1D2A346F00EDFF59 /* CKComponentMemoizer.h in Headers */,
 				03B8B54D1D2A346F00EDFF59 /* CKMutex.h in Headers */,
 				03B8B54E1D2A346F00EDFF59 /* CKHighlightOverlayLayer.h in Headers */,
+				B183A2DD1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h in Headers */,
 				03B8B54F1D2A346F00EDFF59 /* CKTextKitContext.h in Headers */,
 				03B8B5501D2A346F00EDFF59 /* CKComponentScopeHandle.h in Headers */,
 				03B8B5511D2A346F00EDFF59 /* CKAsyncTransaction.h in Headers */,
@@ -2264,6 +2284,7 @@
 				D0B47D361CBD948E00BB33CE /* CKStackLayoutComponent.h in Headers */,
 				D0B47D421CBD948E00BB33CE /* CKTransactionalComponentDataSourceConfiguration.h in Headers */,
 				D0B47D2C1CBD948E00BB33CE /* CKComponentHostingViewDelegate.h in Headers */,
+				B183A2DC1DE5D31E002C7727 /* CKTypedPropsComponentSubclass.h in Headers */,
 				D0B47D641CBD948E00BB33CE /* CKTextComponentView.h in Headers */,
 				D0B47D4C1CBD948E00BB33CE /* CKTransactionalComponentDataSourceReloadModification.h in Headers */,
 				D0B47D171CBD948E00BB33CE /* CKComponentAnnouncerBaseInternal.h in Headers */,
@@ -2283,6 +2304,7 @@
 				D0B47D571CBD948E00BB33CE /* CKComponentGestureActions.h in Headers */,
 				D0B47D5D1CBD948E00BB33CE /* CKOptimisticViewMutations.h in Headers */,
 				D0B47D521CBD948E00BB33CE /* CKComponentAction.h in Headers */,
+				B183A2E01DE5D6ED002C7727 /* CKTestTypedPropsComponent.h in Headers */,
 				D0B47D4E1CBD948E00BB33CE /* CKTransactionalComponentDataSourceUpdateConfigurationModification.h in Headers */,
 				D0B47D551CBD948E00BB33CE /* CKComponentDelegateAttribute.h in Headers */,
 				D0B47D201CBD948E00BB33CE /* CKComponentDataSourceOutputItem.h in Headers */,
@@ -2322,6 +2344,7 @@
 				D0B47D3A1CBD948E00BB33CE /* CKStaticLayoutComponent.h in Headers */,
 				D0B47CE61CBD948E00BB33CE /* CKComponentAccessibility_Private.h in Headers */,
 				D0B47CF21CBD948E00BB33CE /* CKComponentBoundsAnimation.h in Headers */,
+				B183A2C11DE51EA7002C7727 /* CKTypedPropsComponent.h in Headers */,
 				D0B47D121CBD948E00BB33CE /* CKCollectionViewDataSourceCell.h in Headers */,
 				D0B47D1B1CBD948E00BB33CE /* CKComponentDataSourceAttachController.h in Headers */,
 				D0B47CEB1CBD948E00BB33CE /* CKButtonComponent.h in Headers */,
@@ -2927,6 +2950,7 @@
 				03B8B4CB1D2A346F00EDFF59 /* CKAsyncTransactionContainer.m in Sources */,
 				03B8B4CC1D2A346F00EDFF59 /* CKAsyncTransactionGroup.m in Sources */,
 				03B8B4CD1D2A346F00EDFF59 /* CKHighlightOverlayLayer.mm in Sources */,
+				B183A2E31DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3114,6 +3138,7 @@
 				D0B47C921CBD943400BB33CE /* CKComponentViewConfiguration.mm in Sources */,
 				D0B47C931CBD943400BB33CE /* CKComponentViewInterface.mm in Sources */,
 				D0B47C941CBD943400BB33CE /* CKCompositeComponent.mm in Sources */,
+				B183A2C21DE51EA7002C7727 /* CKTypedPropsComponent.mm in Sources */,
 				B797C0411D49F701006461CC /* CKArrayControllerChangesetVerification.mm in Sources */,
 				D0B47C951CBD943400BB33CE /* CKDimension.mm in Sources */,
 				D0B47C961CBD943400BB33CE /* CKSizeRange.mm in Sources */,
@@ -3156,6 +3181,7 @@
 				2DBF1D7B1D3425ED004F28E8 /* CKDetectComponentScopeCollisions.mm in Sources */,
 				D0B47CBA1CBD943400BB33CE /* CKStatefulViewReusePool.mm in Sources */,
 				D0B47CBB1CBD943400BB33CE /* CKTransactionalComponentDataSource.mm in Sources */,
+				B183A2E21DE5D6ED002C7727 /* CKTestTypedPropsComponent.mm in Sources */,
 				D0B47CBC1CBD943400BB33CE /* CKTransactionalComponentDataSourceAppliedChanges.mm in Sources */,
 				D0B47CBD1CBD943400BB33CE /* CKTransactionalComponentDataSourceChangeset.mm in Sources */,
 				D0B47CBE1CBD943400BB33CE /* CKTransactionalComponentDataSourceConfiguration.mm in Sources */,

--- a/ComponentKit/Components/CKTestTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.h
@@ -15,4 +15,6 @@ struct CKTestTypedPropsComponentProps {
 
 @interface CKTestTypedPropsComponent : CKTypedPropsComponent
 
+CKTypedPropsComponentConstructor(CKTestTypedPropsComponentProps);
+
 @end

--- a/ComponentKit/Components/CKTestTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.h
@@ -1,0 +1,18 @@
+//
+//  CKTestTypedPropsComponent.h
+//  ComponentKit
+//
+//  Created by Oliver Rickard on 11/23/16.
+//
+//
+
+#import <ComponentKit/CKTypedPropsComponent.h>
+
+struct CKTestTypedPropsComponentProps {
+  NSString *string;
+  UIFont *font;
+};
+
+@interface CKTestTypedPropsComponent : CKTypedPropsComponent
+
+@end

--- a/ComponentKit/Components/CKTestTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.h
@@ -15,6 +15,8 @@ struct CKTestTypedPropsComponentProps {
 
 @interface CKTestTypedPropsComponent : CKTypedPropsComponent
 
-CKTypedPropsComponentConstructor(CKTestTypedPropsComponentProps);
++ (instancetype)newWithProps:(const CKTestTypedPropsComponentProps &)props
+                        view:(const CKComponentViewConfiguration &)view
+                        size:(const CKComponentSize &)size;
 
 @end

--- a/ComponentKit/Components/CKTestTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.h
@@ -1,10 +1,12 @@
-//
-//  CKTestTypedPropsComponent.h
-//  ComponentKit
-//
-//  Created by Oliver Rickard on 11/23/16.
-//
-//
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #import <ComponentKit/CKTypedPropsComponent.h>
 

--- a/ComponentKit/Components/CKTestTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.h
@@ -9,7 +9,7 @@
 #import <ComponentKit/CKTypedPropsComponent.h>
 
 struct CKTestTypedPropsComponentProps {
-  NSString *string;
+  CKRequiredProp<NSString *> string;
   UIFont *font;
 };
 

--- a/ComponentKit/Components/CKTestTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.mm
@@ -13,13 +13,21 @@
 
 @implementation CKTestTypedPropsComponent
 
-CKTypedPropsComponentConstructorImpl(CKTestTypedPropsComponentProps);
++ (instancetype)newWithProps:(const CKTestTypedPropsComponentProps &)props
+                        view:(const CKComponentViewConfiguration &)view
+                        size:(const CKComponentSize &)size
+{
+  return [self newWithPropsStruct:props
+                             view:view
+                             size:size];
+}
 
-+ (CKComponent *)renderWithProps:(const CKTestTypedPropsComponentProps &)props
++ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)p
                            state:(id)state
                             view:(const CKComponentViewConfiguration &)view
                             size:(const CKComponentSize &)size
 {
+  const CKTestTypedPropsComponentProps props = p;
   return [CKLabelComponent
           newWithLabelAttributes:{
             .string = props.string,

--- a/ComponentKit/Components/CKTestTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.mm
@@ -1,0 +1,31 @@
+//
+//  CKTestTypedPropsComponent.m
+//  ComponentKit
+//
+//  Created by Oliver Rickard on 11/23/16.
+//
+//
+
+#import "CKTestTypedPropsComponent.h"
+
+#import "CKTypedPropsComponentSubclass.h"
+#import "CKLabelComponent.h"
+
+@implementation CKTestTypedPropsComponent
+
++ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
+                           state:(id)state
+                            view:(const CKComponentViewConfiguration &)view
+                            size:(const CKComponentSize &)size
+{
+  const CKTestTypedPropsComponentProps p = props;
+  return [CKLabelComponent
+          newWithLabelAttributes:{
+            .string = p.string,
+            .font = p.font
+          }
+          viewAttributes:*view.attributes()
+          size:size];
+}
+
+@end

--- a/ComponentKit/Components/CKTestTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.mm
@@ -1,10 +1,12 @@
-//
-//  CKTestTypedPropsComponent.m
-//  ComponentKit
-//
-//  Created by Oliver Rickard on 11/23/16.
-//
-//
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #import "CKTestTypedPropsComponent.h"
 

--- a/ComponentKit/Components/CKTestTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTestTypedPropsComponent.mm
@@ -13,16 +13,17 @@
 
 @implementation CKTestTypedPropsComponent
 
-+ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
+CKTypedPropsComponentConstructorImpl(CKTestTypedPropsComponentProps);
+
++ (CKComponent *)renderWithProps:(const CKTestTypedPropsComponentProps &)props
                            state:(id)state
                             view:(const CKComponentViewConfiguration &)view
                             size:(const CKComponentSize &)size
 {
-  const CKTestTypedPropsComponentProps p = props;
   return [CKLabelComponent
           newWithLabelAttributes:{
-            .string = p.string,
-            .font = p.font
+            .string = props.string,
+            .font = props.font
           }
           viewAttributes:*view.attributes()
           size:size];

--- a/ComponentKit/Components/CKTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTypedPropsComponent.h
@@ -1,10 +1,12 @@
-//
-//  CKTypedPropsComponent.h
-//  ComponentKit
-//
-//  Created by Oliver Rickard on 11/22/16.
-//
-//
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #import <ComponentKit/ComponentKit.h>
 

--- a/ComponentKit/Components/CKTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTypedPropsComponent.h
@@ -1,0 +1,52 @@
+//
+//  CKTypedPropsComponent.h
+//  ComponentKit
+//
+//  Created by Oliver Rickard on 11/22/16.
+//
+//
+
+#import <ComponentKit/ComponentKit.h>
+
+
+class CKTypedComponentStruct
+{
+public:
+
+  CKTypedComponentStruct() : _content(nullptr) {}
+
+  CKTypedComponentStruct(const CKTypedComponentStruct& other) : _content(other._content) {}
+
+  template<class T> CKTypedComponentStruct(const T& value) : _content(std::make_shared<holder<T>>(value)) { }
+
+  class placeholder
+  {
+  public:
+    placeholder() {}
+    virtual ~placeholder() {}
+  };
+
+  template<typename T> class holder : public placeholder
+  {
+  public:
+    T content;
+    holder(const T& value) : content(value) {}
+    ~holder<T>() {}
+  };
+
+  template<typename T> operator T () const
+  {
+    return std::dynamic_pointer_cast<holder<T>>(_content)->content;
+  }
+
+private:
+  std::shared_ptr<placeholder> _content;
+};
+
+@interface CKTypedPropsComponent : CKComponent
+
++ (instancetype)newWithProps:(const CKTypedComponentStruct &)props
+                        view:(const CKComponentViewConfiguration &)view
+                        size:(const CKComponentSize &)size;
+
+@end

--- a/ComponentKit/Components/CKTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTypedPropsComponent.h
@@ -43,6 +43,17 @@ private:
   std::shared_ptr<placeholder> _content;
 };
 
+template <typename T>
+struct CKRequiredProp {
+  CKRequiredProp<T>() = delete;
+  CKRequiredProp<T>(const T &val) : _value(val) {};
+  operator T() const {
+    return _value;
+  }
+private:
+  T _value;
+};
+
 @interface CKTypedPropsComponent : CKComponent
 
 #define CKTypedPropsComponentConstructor(PropType) \

--- a/ComponentKit/Components/CKTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTypedPropsComponent.h
@@ -45,8 +45,9 @@ private:
 
 @interface CKTypedPropsComponent : CKComponent
 
-+ (instancetype)newWithProps:(const CKTypedComponentStruct &)props
-                        view:(const CKComponentViewConfiguration &)view
+#define CKTypedPropsComponentConstructor(PropType) \
++ (instancetype)newWithProps:(const PropType &)props \
+                        view:(const CKComponentViewConfiguration &)view \
                         size:(const CKComponentSize &)size;
 
 @end

--- a/ComponentKit/Components/CKTypedPropsComponent.h
+++ b/ComponentKit/Components/CKTypedPropsComponent.h
@@ -56,9 +56,4 @@ private:
 
 @interface CKTypedPropsComponent : CKComponent
 
-#define CKTypedPropsComponentConstructor(PropType) \
-+ (instancetype)newWithProps:(const PropType &)props \
-                        view:(const CKComponentViewConfiguration &)view \
-                        size:(const CKComponentSize &)size;
-
 @end

--- a/ComponentKit/Components/CKTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTypedPropsComponent.mm
@@ -1,10 +1,12 @@
-//
-//  CKTypedPropsComponent.m
-//  ComponentKit
-//
-//  Created by Oliver Rickard on 11/22/16.
-//
-//
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #import "CKTypedPropsComponent.h"
 

--- a/ComponentKit/Components/CKTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTypedPropsComponent.mm
@@ -26,7 +26,7 @@
              @"%@ overrides -newWithView:size: which is not allowed. "
              "Consider subclassing CKComponent or CKCompositeComponent directly.",
              self);
-    CKAssert(!CKSubclassOverridesSelector([CKTypedPropsComponent class], self, @selector(newWithProps:view:size:)),
+    CKAssert(!CKSubclassOverridesSelector([CKTypedPropsComponent class], self, @selector(newWithPropsStruct:view:size:)),
              @"%@ overrides -newWithProps:view:size: which is not allowed. "
              "Instead, you should implement renderWithProps:state:view:size:.",
              self);
@@ -34,27 +34,27 @@
 }
 #endif
 
-+ (instancetype)newWithProps:(const CKTypedComponentStruct &)props
-                        view:(const CKComponentViewConfiguration &)view
-                        size:(const CKComponentSize &)size
++ (instancetype)newWithPropsStruct:(const CKTypedComponentStruct &)props
+                              view:(const CKComponentViewConfiguration &)view
+                              size:(const CKComponentSize &)size
 {
   CKComponentScope scope(self);
   CKTypedPropsComponent *c = [super newWithView:view size:size];
   if (c) {
     c->_props = props;
     c->_state = scope.state();
-    c->_child = [self renderWithProps:props
-                                state:c->_state
-                                 view:view
-                                 size:size];
+    c->_child = [self renderWithPropsStruct:props
+                                      state:c->_state
+                                       view:view
+                                       size:size];
   }
   return c;
 }
 
-+ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
-                           state:(id)state
-                            view:(const CKComponentViewConfiguration &)view
-                            size:(const CKComponentSize &)size
++ (CKComponent *)renderWithPropsStruct:(const CKTypedComponentStruct &)props
+                                 state:(id)state
+                                  view:(const CKComponentViewConfiguration &)view
+                                  size:(const CKComponentSize &)size
 {
   return nil;
 }

--- a/ComponentKit/Components/CKTypedPropsComponent.mm
+++ b/ComponentKit/Components/CKTypedPropsComponent.mm
@@ -1,0 +1,76 @@
+//
+//  CKTypedPropsComponent.m
+//  ComponentKit
+//
+//  Created by Oliver Rickard on 11/22/16.
+//
+//
+
+#import "CKTypedPropsComponent.h"
+
+#import "CKInternalHelpers.h"
+#import "CKTypedPropsComponentSubclass.h"
+#import "CKComponentSubclass.h"
+#import "CKComponentInternal.h"
+
+@implementation CKTypedPropsComponent
+{
+  CKComponent *_child;
+}
+
+#if DEBUG
++ (void)initialize
+{
+  if (self != [CKCompositeComponent class]) {
+    CKAssert(!CKSubclassOverridesSelector([CKTypedPropsComponent class], self, @selector(newWithView:size:)),
+             @"%@ overrides -newWithView:size: which is not allowed. "
+             "Consider subclassing CKComponent or CKCompositeComponent directly.",
+             self);
+    CKAssert(!CKSubclassOverridesSelector([CKTypedPropsComponent class], self, @selector(newWithProps:view:size:)),
+             @"%@ overrides -newWithProps:view:size: which is not allowed. "
+             "Instead, you should implement renderWithProps:state:view:size:.",
+             self);
+  }
+}
+#endif
+
++ (instancetype)newWithProps:(const CKTypedComponentStruct &)props
+                        view:(const CKComponentViewConfiguration &)view
+                        size:(const CKComponentSize &)size
+{
+  CKComponentScope scope(self);
+  CKTypedPropsComponent *c = [super newWithView:view size:size];
+  if (c) {
+    c->_props = props;
+    c->_state = scope.state();
+    c->_child = [self renderWithProps:props
+                                state:c->_state
+                                 view:view
+                                 size:size];
+  }
+  return c;
+}
+
++ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
+                           state:(id)state
+                            view:(const CKComponentViewConfiguration &)view
+                            size:(const CKComponentSize &)size
+{
+  return nil;
+}
+
+- (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize
+                          restrictedToSize:(const CKComponentSize &)size
+                      relativeToParentSize:(CGSize)parentSize
+{
+  CKComponentLayout l = [_child layoutThatFits:constrainedSize parentSize:parentSize];
+  return {self, l.size, {{{0,0}, l}}};
+}
+
+- (UIView *)viewForAnimation
+{
+  // Delegate to the wrapped component's viewForAnimation if we don't have one.
+  return [super viewForAnimation] ?: [_child viewForAnimation];
+}
+
+@end

--- a/ComponentKit/Components/CKTypedPropsComponentSubclass.h
+++ b/ComponentKit/Components/CKTypedPropsComponentSubclass.h
@@ -1,0 +1,22 @@
+//
+//  Header.h
+//  ComponentKit
+//
+//  Created by Oliver Rickard on 11/23/16.
+//
+//
+
+#import <ComponentKit/CKTypedPropsComponent.h>
+#import <ComponentKit/CKComponentSubclass.h>
+
+@interface CKTypedPropsComponent ()
+
++ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
+                           state:(id)state
+                            view:(const CKComponentViewConfiguration &)view
+                            size:(const CKComponentSize &)size;
+
+@property (nonatomic, assign, readonly) CKTypedComponentStruct props;
+@property (nonatomic, strong, readonly) id state;
+
+@end

--- a/ComponentKit/Components/CKTypedPropsComponentSubclass.h
+++ b/ComponentKit/Components/CKTypedPropsComponentSubclass.h
@@ -9,12 +9,29 @@
 #import <ComponentKit/CKTypedPropsComponent.h>
 #import <ComponentKit/CKComponentSubclass.h>
 
+#define CKTypedPropsComponentConstructorImpl(PropType) \
++ (instancetype)newWithProps:(const PropType &)props \
+                        view:(const CKComponentViewConfiguration &)view \
+                        size:(const CKComponentSize &)size { \
+  return [self newWithPropsStruct:props view:view size:size]; \
+} \
++ (CKComponent *)renderWithPropsStruct:(const CKTypedComponentStruct &)props \
+                                 state:(id)state \
+                                  view:(const CKComponentViewConfiguration &)view \
+                                  size:(const CKComponentSize &)size { \
+  return [self renderWithProps:props state:state view:view size:size]; \
+}
+
 @interface CKTypedPropsComponent ()
 
-+ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
-                           state:(id)state
-                            view:(const CKComponentViewConfiguration &)view
-                            size:(const CKComponentSize &)size;
++ (instancetype)newWithPropsStruct:(const CKTypedComponentStruct &)props
+                              view:(const CKComponentViewConfiguration &)view
+                              size:(const CKComponentSize &)size;
+
++ (CKComponent *)renderWithPropsStruct:(const CKTypedComponentStruct &)props
+                                 state:(id)state
+                                  view:(const CKComponentViewConfiguration &)view
+                                  size:(const CKComponentSize &)size;
 
 @property (nonatomic, assign, readonly) CKTypedComponentStruct props;
 @property (nonatomic, strong, readonly) id state;

--- a/ComponentKit/Components/CKTypedPropsComponentSubclass.h
+++ b/ComponentKit/Components/CKTypedPropsComponentSubclass.h
@@ -9,29 +9,16 @@
 #import <ComponentKit/CKTypedPropsComponent.h>
 #import <ComponentKit/CKComponentSubclass.h>
 
-#define CKTypedPropsComponentConstructorImpl(PropType) \
-+ (instancetype)newWithProps:(const PropType &)props \
-                        view:(const CKComponentViewConfiguration &)view \
-                        size:(const CKComponentSize &)size { \
-  return [self newWithPropsStruct:props view:view size:size]; \
-} \
-+ (CKComponent *)renderWithPropsStruct:(const CKTypedComponentStruct &)props \
-                                 state:(id)state \
-                                  view:(const CKComponentViewConfiguration &)view \
-                                  size:(const CKComponentSize &)size { \
-  return [self renderWithProps:props state:state view:view size:size]; \
-}
-
 @interface CKTypedPropsComponent ()
 
 + (instancetype)newWithPropsStruct:(const CKTypedComponentStruct &)props
                               view:(const CKComponentViewConfiguration &)view
                               size:(const CKComponentSize &)size;
 
-+ (CKComponent *)renderWithPropsStruct:(const CKTypedComponentStruct &)props
-                                 state:(id)state
-                                  view:(const CKComponentViewConfiguration &)view
-                                  size:(const CKComponentSize &)size;
++ (CKComponent *)renderWithProps:(const CKTypedComponentStruct &)props
+                           state:(id)state
+                            view:(const CKComponentViewConfiguration &)view
+                            size:(const CKComponentSize &)size;
 
 @property (nonatomic, assign, readonly) CKTypedComponentStruct props;
 @property (nonatomic, strong, readonly) id state;

--- a/ComponentKit/Components/CKTypedPropsComponentSubclass.h
+++ b/ComponentKit/Components/CKTypedPropsComponentSubclass.h
@@ -1,10 +1,12 @@
-//
-//  Header.h
-//  ComponentKit
-//
-//  Created by Oliver Rickard on 11/23/16.
-//
-//
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #import <ComponentKit/CKTypedPropsComponent.h>
 #import <ComponentKit/CKComponentSubclass.h>


### PR DESCRIPTION
This is an RFC that allows a formalized C++ prop component. This lets us move to an implementation of composite components to be implemented as +render instead of +new, which will force people to avoid storing into ivars, and removes the necessity to use component scope in client code to use state.

This brings us a little closer to React, and provides an opportunity for automatic memoization.