### PR TITLE
Redo how debug "reflow" works

### DIFF
--- a/ComponentKit/Core/CKComponentLifecycleManager.mm
+++ b/ComponentKit/Core/CKComponentLifecycleManager.mm
@@ -16,6 +16,7 @@
 
 #import "CKComponent.h"
 #import "CKComponentInternal.h"
+#import "CKComponentDebugController.h"
 #import "CKComponentLayout.h"
 #import "CKComponentLifecycleManagerAsynchronousUpdateHandler.h"
 #import "CKComponentMemoizer.h"
@@ -36,6 +37,9 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
   .layout = {},
   .root = nil,
 };
+
+@interface CKComponentLifecycleManager () <CKComponentDebugReflowListener>
+@end
 
 @implementation CKComponentLifecycleManager
 {
@@ -62,6 +66,7 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
   if (self = [super init]) {
     _componentProvider = componentProvider;
     _sizeRangeProvider = sizeRangeProvider;
+    [CKComponentDebugController registerReflowListener:self];
   }
   return self;
 }
@@ -218,6 +223,11 @@ const CKComponentLifecycleManagerState CKComponentLifecycleManagerStateEmpty = {
 - (const CKComponentLifecycleManagerState &)state
 {
   return _state;
+}
+
+- (void)didReceiveReflowComponentsRequest
+{
+  [self prepareForUpdateWithModel:_state.model constrainedSize:_state.constrainedSize context:_state.context];
 }
 
 @end

--- a/ComponentKit/Debug/CKComponentDebugController.h
+++ b/ComponentKit/Debug/CKComponentDebugController.h
@@ -14,7 +14,10 @@
 #import <ComponentKit/CKComponentViewConfiguration.h>
 
 @class CKComponent;
-@class UIView;
+
+@protocol CKComponentDebugReflowListener
+- (void)didReceiveReflowComponentsRequest;
+@end
 
 /**
  CKComponentDebugController exposes the functionality needed by the lldb helpers to control the debug behavior for
@@ -27,16 +30,22 @@
 /**
  Setting the debug mode enables the injection of debug configuration into the component.
  */
-+ (void)setDebugMode:(BOOL)debugMode NS_EXTENSION_UNAVAILABLE("Recursively reflows components using -[UIApplication keyWindow]");
++ (void)setDebugMode:(BOOL)debugMode;
 
 /**
  Components are an immutable construct. Whenever we make changes to the parameters on which the components depended,
  the changes won't be reflected in the component hierarchy until we explicitly cause a reflow/update. A reflow
- essentially rebuilds the component hierarchy and mounts it back on the view.
+ essentially rebuilds the component hierarchy and remounts on the attached view, if any.
 
- This is particularly used in reflowing the component hierarchy when we set the debug mode.
+ This is automatically triggered when changing debug mode, to ensure that debug views are added or removed.
  */
-+ (void)reflowComponents NS_EXTENSION_UNAVAILABLE("Recursively reflows components using -[UIApplication keyWindow]");
++ (void)reflowComponents;
+
+/**
+ Registers an object that will be notified when +reflowComponents is called. The listener is weakly held and will
+ be messaged on the main thread.
+ */
++ (void)registerReflowListener:(id<CKComponentDebugReflowListener>)listener;
 
 @end
 

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -15,6 +15,7 @@
 #import <ComponentKit/CKMacros.h>
 
 #import "CKComponentAnimation.h"
+#import "CKComponentDebugController.h"
 #import "CKComponentHostingViewDelegate.h"
 #import "CKComponentLayout.h"
 #import "CKComponentRootView.h"
@@ -33,7 +34,7 @@ struct CKComponentHostingViewInputs {
   };
 };
 
-@interface CKComponentHostingView () <CKComponentStateListener>
+@interface CKComponentHostingView () <CKComponentStateListener, CKComponentDebugReflowListener>
 {
   Class<CKComponentProvider> _componentProvider;
   id<CKComponentSizeRangeProviding> _sizeRangeProvider;
@@ -75,6 +76,8 @@ struct CKComponentHostingViewInputs {
 
     _componentNeedsUpdate = YES;
     _requestedUpdateMode = CKUpdateModeSynchronous;
+
+    [CKComponentDebugController registerReflowListener:self];
   }
   return self;
 }
@@ -148,6 +151,13 @@ struct CKComponentHostingViewInputs {
   CKAssertMainThread();
   _pendingInputs.stateUpdates.insert({globalIdentifier, stateUpdate});
   [self _setNeedsUpdateWithMode:mode];
+}
+
+#pragma mark - CKComponentDebugController
+
+- (void)didReceiveReflowComponentsRequest
+{
+  [self _setNeedsUpdateWithMode:CKUpdateModeAsynchronous];
 }
 
 #pragma mark - Private

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -12,6 +12,7 @@
 #import "CKTransactionalComponentDataSourceInternal.h"
 
 #import "CKAssert.h"
+#import "CKComponentDebugController.h"
 #import "CKComponentScopeRoot.h"
 #import "CKTransactionalComponentDataSourceChange.h"
 #import "CKTransactionalComponentDataSourceChangesetModification.h"
@@ -35,7 +36,7 @@
 
 @end
 
-@interface CKTransactionalComponentDataSource () <CKComponentStateListener>
+@interface CKTransactionalComponentDataSource () <CKComponentStateListener, CKComponentDebugReflowListener>
 {
   CKTransactionalComponentDataSourceState *_state;
   CKTransactionalComponentDataSourceListenerAnnouncer *_announcer;
@@ -60,6 +61,7 @@
     _workQueue = dispatch_queue_create("org.componentkit.CKTransactionalComponentDataSource", DISPATCH_QUEUE_SERIAL);
     _pendingAsynchronousModifications = [NSMutableArray array];
     _workThreadOverride = configuration.workThreadOverride;
+    [CKComponentDebugController registerReflowListener:self];
   }
   return self;
 }
@@ -161,6 +163,13 @@
   } else {
     _pendingSynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, stateUpdate});
   }
+}
+
+#pragma mark - CKComponentDebugReflowListener
+
+- (void)didReceiveReflowComponentsRequest
+{
+  [self reloadWithMode:CKUpdateModeAsynchronous userInfo:nil];
 }
 
 #pragma mark - Internal


### PR DESCRIPTION
This was never updated after we transitioned away from `CKComponentLifecycleManager`, so it was mostly broken. Now instead of attempting to use the view hierarchy to trigger reflow, we simply message all interested parties and tell them to update themselves.

Crucially this means that offscreen components are recomputed too, not just onscreen ones. Neat.