### PR TITLE
Add a relinquish delay controller

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -373,11 +373,15 @@
 		A29D85791D80D37F00913E60 /* CKComponentContextHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A243B52C1D79A40800E6C393 /* CKComponentContextHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2CD66321AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */; };
 		A2D20CF41B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */; };
-		B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B107DA951DFA091D00754473 /* CKStatefulViewRelinquishController.h in Headers */ = {isa = PBXBuildFile; fileRef = B107DA931DFA091D00754473 /* CKStatefulViewRelinquishController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B107DA961DFA091D00754473 /* CKStatefulViewRelinquishController.m in Sources */ = {isa = PBXBuildFile; fileRef = B107DA941DFA091D00754473 /* CKStatefulViewRelinquishController.m */; };
+		B107DAA11DFA0EC600754473 /* CKStatefulViewRelinquishController.h in Headers */ = {isa = PBXBuildFile; fileRef = B107DA931DFA091D00754473 /* CKStatefulViewRelinquishController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B107DAA21DFA0ED500754473 /* CKStatefulViewRelinquishController.m in Sources */ = {isa = PBXBuildFile; fileRef = B107DA941DFA091D00754473 /* CKStatefulViewRelinquishController.m */; };
 		B167C70F1DD38E4200769084 /* CKMemoizingComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B167C7101DD38E4200769084 /* CKMemoizingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */; };
 		B1DC105F1DD480FB00CCBF2F /* CKMemoizingComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */; };
 		B1DC106A1DD4810700CCBF2F /* CKMemoizingComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1EF8FE81DD1562B00E74F43 /* CKComponentActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B342DC6A1AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */; };
 		B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */; };
 		B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B342DC4B1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm */; };
@@ -932,9 +936,11 @@
 		A27C72741AEF0BE800DC6797 /* CKTransactionalComponentDataSourceUpdateStateModificationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceUpdateStateModificationTests.mm; sourceTree = "<group>"; };
 		A2CD66311AF2F0C70083A839 /* CKTransactionalComponentDataSourceStateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceStateTests.mm; sourceTree = "<group>"; tabWidth = 2; };
 		A2D20CF31B431CCF002B2DC7 /* CKComponentHostingViewAsyncStateUpdateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentHostingViewAsyncStateUpdateTests.mm; sourceTree = "<group>"; };
-		B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKComponentActionInternal.h; sourceTree = "<group>"; };
+		B107DA931DFA091D00754473 /* CKStatefulViewRelinquishController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKStatefulViewRelinquishController.h; sourceTree = "<group>"; };
+		B107DA941DFA091D00754473 /* CKStatefulViewRelinquishController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CKStatefulViewRelinquishController.m; sourceTree = "<group>"; };
 		B167C70D1DD38E4200769084 /* CKMemoizingComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKMemoizingComponent.h; sourceTree = "<group>"; };
 		B167C70E1DD38E4200769084 /* CKMemoizingComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKMemoizingComponent.mm; sourceTree = "<group>"; };
+		B1EF8FE71DD1562B00E74F43 /* CKComponentActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKComponentActionInternal.h; sourceTree = "<group>"; };
 		B342DC401AC23E8200ACAC53 /* ComponentKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComponentKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B342DC491AC23EA900ACAC53 /* CKArrayControllerChangesetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKArrayControllerChangesetTests.mm; sourceTree = "<group>"; };
 		B342DC4A1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentAccessibilityTests.mm; sourceTree = "<group>"; };
@@ -1818,6 +1824,8 @@
 				D0B47B5C1CBD926700BB33CE /* CKStatefulViewComponent.mm */,
 				D0B47B5D1CBD926700BB33CE /* CKStatefulViewComponentController.h */,
 				D0B47B5E1CBD926700BB33CE /* CKStatefulViewComponentController.mm */,
+				B107DA931DFA091D00754473 /* CKStatefulViewRelinquishController.h */,
+				B107DA941DFA091D00754473 /* CKStatefulViewRelinquishController.m */,
 				D0B47B5F1CBD926700BB33CE /* CKStatefulViewReusePool.h */,
 				D0B47B601CBD926700BB33CE /* CKStatefulViewReusePool.mm */,
 			);
@@ -2070,6 +2078,7 @@
 				03B8B4D31D2A346F00EDFF59 /* CKCollectionViewTransactionalDataSource.h in Headers */,
 				03B8B4D41D2A346F00EDFF59 /* CKWeakObjectContainer.h in Headers */,
 				03B8B4D51D2A346F00EDFF59 /* CKTransactionalComponentDataSourceInternal.h in Headers */,
+				B107DAA11DFA0EC600754473 /* CKStatefulViewRelinquishController.h in Headers */,
 				03B8B4D61D2A346F00EDFF59 /* CKTransactionalComponentDataSourceUpdateStateModification.h in Headers */,
 				03B8B4D71D2A346F00EDFF59 /* CKTransactionalComponentDataSourceChangeset.h in Headers */,
 				B1DC106A1DD4810700CCBF2F /* CKMemoizingComponent.h in Headers */,
@@ -2248,6 +2257,7 @@
 				D0B47D271CBD948E00BB33CE /* CKComponentProvider.h in Headers */,
 				D0B47D161CBD948E00BB33CE /* CKComponentAnnouncerBase.h in Headers */,
 				D0B47CF61CBD948E00BB33CE /* CKComponentLayout.h in Headers */,
+				B107DA951DFA091D00754473 /* CKStatefulViewRelinquishController.h in Headers */,
 				D0B47D3F1CBD948E00BB33CE /* CKTransactionalComponentDataSourceAppliedChanges.h in Headers */,
 				D0B47D3C1CBD948E00BB33CE /* CKStatefulViewComponentController.h in Headers */,
 				D0B47D5E1CBD948E00BB33CE /* CKSectionedArrayController.h in Headers */,
@@ -2845,6 +2855,7 @@
 				03B8B4731D2A346F00EDFF59 /* CKComponentBoundsAnimation.mm in Sources */,
 				03B8B4741D2A346F00EDFF59 /* CKComponentController.mm in Sources */,
 				03B8B4751D2A346F00EDFF59 /* CKComponentLayout.mm in Sources */,
+				B107DAA21DFA0ED500754473 /* CKStatefulViewRelinquishController.m in Sources */,
 				03B8B4761D2A346F00EDFF59 /* CKComponentLifecycleManager.mm in Sources */,
 				03B8B4771D2A346F00EDFF59 /* CKComponentMemoizer.mm in Sources */,
 				2D34A4AA1D777EB80020B11C /* CKArrayControllerChangesetVerification.mm in Sources */,
@@ -3191,6 +3202,7 @@
 				D0B47CCE1CBD943400BB33CE /* CKOptimisticViewMutations.mm in Sources */,
 				D0B47CCF1CBD943400BB33CE /* CKSectionedArrayController.mm in Sources */,
 				D0B47CD01CBD943400BB33CE /* CKWeakObjectContainer.m in Sources */,
+				B107DA961DFA091D00754473 /* CKStatefulViewRelinquishController.m in Sources */,
 				2D7A98181DB56BD10064FC6D /* CKTransactionalComponentDataSourceChangesetVerification.mm in Sources */,
 				D0B47CD11CBD943400BB33CE /* CKLabelComponent.mm in Sources */,
 				D0B47CD21CBD943400BB33CE /* CKTextComponent.mm in Sources */,

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -63,7 +63,7 @@
 
 - (void)canRelinquishStatefulViewDidChange
 {
-  [self _relinquishStatefulViewIfPossible];
+  [self relinquishStatefulViewIfPossible];
 }
 
 #pragma mark - Lifecycle
@@ -89,14 +89,14 @@
     [[self class] configureStatefulView:_statefulView forComponent:[self component]];
     [self didAcquireStatefulView:_statefulView];
   }
-  [self _presentStatefulView];
+  [self presentStatefulView];
   _mounted = YES;
 }
 
 - (void)didRemount
 {
   [super didRemount];
-  [self _presentStatefulView];
+  [self presentStatefulView];
 }
 
 - (void)didUpdateComponent
@@ -111,12 +111,12 @@
 {
   [super didUnmount];
   _mounted = NO;
-  [self _relinquishStatefulViewIfPossible];
+  [self relinquishStatefulViewIfPossible];
 }
 
 #pragma mark - Helpers
 
-- (void)_presentStatefulView
+- (void)presentStatefulView
 {
   const CKComponentViewContext &context = [[self component] viewContext];
   [_statefulView setFrame:context.frame];
@@ -130,7 +130,7 @@
   [context.view addSubview:_statefulView];
 }
 
-- (void)_relinquishStatefulViewIfPossible
+- (void)relinquishStatefulViewIfPossible
 {
   if ([CKStatefulViewRelinquishController sharedInstance].delayedRelinquishEnabled) {
     // Wait for the run loop to turn over before trying to relinquish the view. That ensures that if we are remounted on
@@ -138,14 +138,14 @@
     // We only do this if the relinquish controller allows us to. For normal scrolling, we don't want to do this, since
     // we want our stateful view to re-enter the reuse pool.
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self _immediatelyRelinquishStatefulViewIfPossible];
+      [self immediatelyRelinquishStatefulViewIfPossible];
     });
   } else {
-    [self _immediatelyRelinquishStatefulViewIfPossible];
+    [self immediatelyRelinquishStatefulViewIfPossible];
   }
 }
 
-- (void)_immediatelyRelinquishStatefulViewIfPossible
+- (void)immediatelyRelinquishStatefulViewIfPossible
 {
   if (_statefulView && !_mounted && [self canRelinquishStatefulView]) {
     [self willRelinquishStatefulView:_statefulView];

--- a/ComponentKit/StatefulViews/CKStatefulViewRelinquishController.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewRelinquishController.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ A singleton controller which can be used to force a delay in stateful view relinquish for all stateful views.
+ 
+ Stateful view component controllers may prefer to maintain ownership of their stateful views during insertion into
+ the collection or table view above the viewport. In that case, the active cell can be recycled and the stateful view
+ may choose to delay the relinquish of the stateful view for one runloop turn so that if the view is immediately re-
+ rendered, it may render with the same stateful view as it just had.
+ 
+ This controller allows us to avoid the delayed relinquish hack for normal scrolling, while still supporting it in
+ stateful view component controllers in cases where active viewport jumping could trigger a remount on an active cell.
+ */
+@interface CKStatefulViewRelinquishController : NSObject
+
++ (CKStatefulViewRelinquishController *)sharedInstance;
+
+/**
+ By default, delayed relinquishing is enabled. To turn off delayed relinquish for all views, and manage delaying
+ stateful view relinquishing manually, you may disable it here.
+ 
+ If you disable this parameter, it takes effect for *all stateful views*.
+ */
+- (void)setDelayedRelinquishDefault:(BOOL)delayedRelinquishEnabled;
+
+/**
+ If the default has been set to NO, then calling this method will enable the delayed relinquish operation for one
+ runloop turn. It's a good idea to call this before making updates to the collection view.
+ */
+- (void)delayRelinquishForRunloopTurn;
+
+/**
+ Called by the stateful view component controller to determine if it should delay relinquishing its view.
+ */
+@property (nonatomic, assign, readonly) BOOL delayedRelinquishEnabled;
+
+@end

--- a/ComponentKit/StatefulViews/CKStatefulViewRelinquishController.m
+++ b/ComponentKit/StatefulViews/CKStatefulViewRelinquishController.m
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKStatefulViewRelinquishController.h"
+
+#import "CKAssert.h"
+
+@implementation CKStatefulViewRelinquishController
+{
+  BOOL _defaultDelayedRelinquishEnabled;
+  BOOL _delayRelinquish;
+}
+
++ (CKStatefulViewRelinquishController *)sharedInstance
+{
+  static CKStatefulViewRelinquishController *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [self new];
+  });
+  return sharedInstance;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _defaultDelayedRelinquishEnabled = YES;
+  }
+  return self;
+}
+
+- (void)setDelayedRelinquishDefault:(BOOL)delayedRelinquishEnabled
+{
+  CKAssertMainThread();
+  _defaultDelayedRelinquishEnabled = delayedRelinquishEnabled;
+}
+
+- (void)delayRelinquishForRunloopTurn
+{
+  CKAssertMainThread();
+  if (_delayRelinquish) {
+    return;
+  }
+  _delayRelinquish = YES;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    _delayRelinquish = NO;
+  });
+}
+
+- (BOOL)delayedRelinquishEnabled
+{
+  CKAssertMainThread();
+  return _delayRelinquish ?: _defaultDelayedRelinquishEnabled;
+}
+
+@end


### PR DESCRIPTION
Stateful views have 3 major jobs:

1. When an insertion occurs above the viewport, they should hold onto their view and not allow it to enter the reuse pool to prevent flickering of videos while actively playing.
2. Stateful views should not be reused when the controller is manually managing their appearance (we've entered a fullscreen video or photo or text editor, and the stateful view cannot be reused in another context).
3. Stateful views generally are our heaviest, memory-intensive views, and unlike normal views, should participate in a global reuse pool. Normal component views are simply hidden, and their reuse pool is localized to a view hierarchy. Stateful views on the other hand share a global reuse pool.

In order to enable (1), we have a hack that does a dispatch_async before adding a stateful view to the global reuse pool (in order to achieve (3)). However, in normal use, this delayed relinquish can mean that we grow our reuse pool, and create many heavy views for no benefit.

This is my proposal to fix the situation. I think we should just do something simple here, and provide a global "delay relinquish" during datasource updates. By default, we remain with the status quo, but if you really want to manage this stuff yourself, you can disable the delayed insertion trick, and manually enable the delayed relinquish hack for a specific runloop turn.

So, before inserting into a collection view, you would call `[[CKStatefulViewRelinquishController sharedInstance] delayRelinquishForRunloopTurn]`. This would mean that any cell reuse/remounting that happens for that runloop turn as the collection view shuffles its cells would have the benefit of the delay hack, and the *rest* of the time, it is disabled. This allows us to have both worlds.

Is this perfect? Absolutely not. It's darn-right ugly. However, we've used similar patterns for async transactions for several years, and the simple flag inside infra has not been a problem.

Other ideas we considered:

1. Some people proposed we try to differentiate the "about to jump viewport" and "you're just being reused" points. I believe this is possible, but would result in a large amount of tricky code that will be very product-specific. I believe it punctures our abstractions even more than this proposal.
2. Provide a "pending" reuse pool that is a staging area for the normal reuse pool. For normal operation, the hope is that if we did this, then we could prioritize returning stateful views that are truly unused, but we still allow access to the ones that are delaying. My problem with this proposal is that it can lead to hard-to-debug flickers as we fall back to the pending reuse pool.

Overall, I believe this proposal is the best idea that we currently have. Either delayed relinquish is enabled, or it is disabled. Simple.

The main problem however is going to be this call to `[[CKStatefulViewRelinquishController sharedInstance] delayRelinquishForRunloopTurn]` in your datasource before touching cells. It also means if you call `-reloadData` on your collection view manually, you have to manually delay relinquish there as well. Since there should be no reason to ever call `-reloadData` on a Components-managed collection view, I don't view that as a huge problem.

## What I would like feedback on:

1. **Naming**. This came out ugly. Suggestions?
2. **Singleton**. Alternative solutions? I could manually thread the controller down to the stateful views, but I view that as yet more boilerplate.
3. **Defaults**. I have enabled the delayed relinquish hack by default in this diff since it's the status quo. Is that right?