### PR TITLE
Pending reuse pool

### DIFF
--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -133,13 +133,13 @@
 {
   if ([self canRelinquishStatefulView]) {
     // There is no guarantee when this reuse pool will execute this block
-    __weak __typeof(self) weakSelf = self;
+    CKStatefulViewComponentController *__weak weakSelf = self;
     [[CKStatefulViewReusePool sharedPool]
      enqueueStatefulView:_statefulView
      forControllerClass:[self class]
      context:_statefulViewContext
      mayRelinquishBlock:^BOOL{
-       __typeof(self) strongSelf = weakSelf;
+       CKStatefulViewComponentController *strongSelf = weakSelf;
        if (!strongSelf) {
          return YES;
        }

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -144,7 +144,7 @@
          return YES;
        }
        if (!strongSelf->_mounted && [strongSelf canRelinquishStatefulView]) {
-         [strongSelf willRelinquishStatefulView:_statefulView];
+         [strongSelf willRelinquishStatefulView:strongSelf->_statefulView];
          strongSelf->_statefulView = nil;
          strongSelf->_statefulViewContext = nil;
          return YES;

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -136,7 +136,7 @@
      enqueueStatefulView:_statefulView
      forControllerClass:[self class]
      context:_statefulViewContext
-     enqueueComplete:^BOOL{
+     mayRelinquishBlock:^BOOL{
        if (!_mounted && [self canRelinquishStatefulView]) {
          [self willRelinquishStatefulView:_statefulView];
          _statefulView = nil;

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -131,19 +131,21 @@
 
 - (void)_relinquishStatefulViewIfPossible
 {
-  [[CKStatefulViewReusePool sharedPool]
-   enqueueStatefulView:_statefulView
-   forControllerClass:[self class]
-   context:_statefulViewContext
-   enqueueComplete:^BOOL{
-     if (!_mounted && [self canRelinquishStatefulView]) {
-       [self willRelinquishStatefulView:_statefulView];
-       _statefulView = nil;
-       _statefulViewContext = nil;
-       return YES;
-     }
-     return NO;
-   }];
+  if ([self canRelinquishStatefulView]) {
+    [[CKStatefulViewReusePool sharedPool]
+     enqueueStatefulView:_statefulView
+     forControllerClass:[self class]
+     context:_statefulViewContext
+     enqueueComplete:^BOOL{
+       if (!_mounted && [self canRelinquishStatefulView]) {
+         [self willRelinquishStatefulView:_statefulView];
+         _statefulView = nil;
+         _statefulViewContext = nil;
+         return YES;
+       }
+       return NO;
+     }];
+  }
 }
 
 @end

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -131,18 +131,19 @@
 
 - (void)_relinquishStatefulViewIfPossible
 {
-  // Wait for the run loop to turn over before trying to relinquish the view. That ensures that if we are remounted on
-  // a different root view, we reuse the same view (since didMount will be called immediately after didUnmount).
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (_statefulView && !_mounted && [self canRelinquishStatefulView]) {
-      [self willRelinquishStatefulView:_statefulView];
-      [[CKStatefulViewReusePool sharedPool] enqueueStatefulView:_statefulView
-                                             forControllerClass:[self class]
-                                                        context:_statefulViewContext];
-      _statefulView = nil;
-      _statefulViewContext = nil;
-    }
-  });
+  [[CKStatefulViewReusePool sharedPool]
+   enqueueStatefulView:_statefulView
+   forControllerClass:[self class]
+   context:_statefulViewContext
+   enqueueComplete:^BOOL{
+     if (!_mounted && [self canRelinquishStatefulView]) {
+       [self willRelinquishStatefulView:_statefulView];
+       _statefulView = nil;
+       _statefulViewContext = nil;
+       return YES;
+     }
+     return NO;
+   }];
 }
 
 @end

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -132,15 +132,21 @@
 - (void)_relinquishStatefulViewIfPossible
 {
   if ([self canRelinquishStatefulView]) {
+    // There is no guarantee when this reuse pool will execute this block
+    __weak __typeof(self) weakSelf = self;
     [[CKStatefulViewReusePool sharedPool]
      enqueueStatefulView:_statefulView
      forControllerClass:[self class]
      context:_statefulViewContext
      mayRelinquishBlock:^BOOL{
-       if (!_mounted && [self canRelinquishStatefulView]) {
-         [self willRelinquishStatefulView:_statefulView];
-         _statefulView = nil;
-         _statefulViewContext = nil;
+       __typeof(self) strongSelf = weakSelf;
+       if (!strongSelf) {
+         return YES;
+       }
+       if (!strongSelf->_mounted && [strongSelf canRelinquishStatefulView]) {
+         [strongSelf willRelinquishStatefulView:_statefulView];
+         strongSelf->_statefulView = nil;
+         strongSelf->_statefulViewContext = nil;
          return YES;
        }
        return NO;

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
@@ -10,11 +10,16 @@
 
 #import <UIKit/UIKit.h>
 
+/**
+ Should return YES if the stateful view can be reused, or NO to block reuse of the stateful view.
+ */
 typedef BOOL (^CKStatefulViewReusePoolPendingMayRelinquishBlock)(void);
 
 @interface CKStatefulViewReusePool : NSObject
 
 + (instancetype)sharedPool;
+
+@property (nonatomic, assign) BOOL pendingReusePoolEnabled;
 
 - (UIView *)dequeueStatefulViewForControllerClass:(Class)controllerClass
                                preferredSuperview:(UIView *)preferredSuperview
@@ -23,6 +28,6 @@ typedef BOOL (^CKStatefulViewReusePoolPendingMayRelinquishBlock)(void);
 - (void)enqueueStatefulView:(UIView *)view
          forControllerClass:(Class)controllerClass
                     context:(id)context
-            enqueueComplete:(CKStatefulViewReusePoolPendingMayRelinquishBlock)enqueueComplete;
+         mayRelinquishBlock:(CKStatefulViewReusePoolPendingMayRelinquishBlock)mayRelinquishBlock;
 
 @end

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
@@ -10,6 +10,8 @@
 
 #import <UIKit/UIKit.h>
 
+typedef BOOL (^CKStatefulViewReusePoolPendingMayRelinquishBlock)(void);
+
 @interface CKStatefulViewReusePool : NSObject
 
 + (instancetype)sharedPool;
@@ -20,6 +22,7 @@
 
 - (void)enqueueStatefulView:(UIView *)view
          forControllerClass:(Class)controllerClass
-                    context:(id)context;
+                    context:(id)context
+            enqueueComplete:(CKStatefulViewReusePoolPendingMayRelinquishBlock)enqueueComplete;
 
 @end

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
@@ -10,6 +10,7 @@
 #import "CKStatefulViewComponentController.h"
 
 #import "CKStatefulViewReusePool.h"
+#import "CKAssert.h"
 
 #import <unordered_map>
 
@@ -72,8 +73,8 @@ struct PoolKeyHasher {
                                preferredSuperview:(UIView *)preferredSuperview
                                           context:(id)context
 {
-  NSAssert([NSThread isMainThread], nil);
-  NSParameterAssert(controllerClass != nil);
+  CKAssertMainThread();
+  CKAssertNotNil(controllerClass, @"Must provide a controller class");
   const auto it = _pool.find(std::make_pair(controllerClass, context));
   if (it == _pool.end()) { // Avoid overhead of creating the item unless it already exists
     return nil;
@@ -85,9 +86,9 @@ struct PoolKeyHasher {
          forControllerClass:(Class)controllerClass
                     context:(id)context
 {
-  NSAssert([NSThread isMainThread], nil);
-  NSParameterAssert(view != nil);
-  NSParameterAssert(controllerClass != nil);
+  CKAssertMainThread();
+  CKAssertNotNil(view, @"Must provide a view");
+  CKAssertNotNil(controllerClass, @"Must provide a controller class");
   
   // maximumPoolSize will be -1 by default
   NSInteger maximumPoolSize = [controllerClass maximumPoolSize:context];

--- a/ComponentKitTests/StatefulViews/CKStatefulViewReusePoolTests.mm
+++ b/ComponentKitTests/StatefulViews/CKStatefulViewReusePoolTests.mm
@@ -13,6 +13,8 @@
 
 #import <ComponentKit/CKStatefulViewReusePool.h>
 
+#import <ComponentKitTestLib/CKTestRunLoopRunning.h>
+
 #import "CKTestStatefulViewComponent.h"
 
 @interface CKStatefulViewReusePoolTests : XCTestCase
@@ -45,16 +47,48 @@
 
 - (void)testEnqueueingViewThenDequeueingReturnsSameView
 {
+  __block BOOL calledBlock = NO;
   CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
   CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
   [pool enqueueStatefulView:view
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return YES;
+         }];
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return calledBlock;
+  });
   UIView *container = [[UIView alloc] init];
   UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
                                                   preferredSuperview:container
                                                              context:nil];
-  XCTAssertTrue(dequeuedView == view, @"Expected enqueued view to be returned");
+  XCTAssertEqualObjects(dequeuedView, view, @"Expected enqueued view to be returned");
+}
+
+- (void)testEnqueueingViewThenDequeueingWhileRefusingToRelinquishReturnsNil
+{
+  __block BOOL calledBlock = NO;
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return NO;
+         }];
+
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return calledBlock;
+  });
+
+  UIView *container = [[UIView alloc] init];
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                  preferredSuperview:container
+                                                             context:nil];
+  XCTAssertTrue(calledBlock && dequeuedView == nil, @"Expected dequeued view to be nil");
 }
 
 - (void)testEnqueueingViewThenDequeueingWithDifferentControllerClassReturnsNil
@@ -63,7 +97,10 @@
   CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
   [pool enqueueStatefulView:view
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           return YES;
+         }];
   UIView *container = [[UIView alloc] init];
   XCTAssertNil([pool dequeueStatefulViewForControllerClass:[CKOtherStatefulViewComponentController class]
                                        preferredSuperview:container
@@ -74,19 +111,33 @@
 {
   CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
 
+  __block int blockCallCount = 0;
+
   UIView *container1 = [[UIView alloc] init];
   CKTestStatefulView *view1 = [[CKTestStatefulView alloc] init];
   [container1 addSubview:view1];
   [pool enqueueStatefulView:view1
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           blockCallCount++;
+           return YES;
+         }];
 
   UIView *container2 = [[UIView alloc] init];
   CKTestStatefulView *view2 = [[CKTestStatefulView alloc] init];
   [container2 addSubview:view2];
   [pool enqueueStatefulView:view2
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           blockCallCount++;
+           return YES;
+         }];
+
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return blockCallCount == 2;
+  });
 
   UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
                                                   preferredSuperview:container1
@@ -103,7 +154,10 @@
   [container1 addSubview:view];
   [pool enqueueStatefulView:view
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           return YES;
+         }];
 
   UIView *container2 = [[UIView alloc] init];
   [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
@@ -123,7 +177,10 @@
   UIView *firstView =[[UIView alloc] init];
   [pool enqueueStatefulView:firstView
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:@"context1"];
+                    context:@"context1"
+         mayRelinquishBlock:^BOOL{
+           return YES;
+         }];
 
   UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
                                                      preferredSuperview:containerView
@@ -135,12 +192,21 @@
 {
   CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
 
+  __block BOOL calledBlock = NO;
   UIView *container1 = [[UIView alloc] init];
   CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
   [container1 addSubview:view];
   [pool enqueueStatefulView:view
          forControllerClass:[CKTestStatefulViewComponentController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return YES;
+         }];
+
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return calledBlock;
+  });
 
   // remove the statefull view from the container
   [view removeFromSuperview];
@@ -162,20 +228,34 @@
 - (void)testMaximumPoolSizeOfOneByEnqueueingTwoViewsThenDequeueingTwoViewsReturnsNewView
 {
   CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
-  
+
+  __block int calledBlockCount = 0;
+
   UIView *container1 = [[UIView alloc] init];
   CKTestStatefulView *view1 = [[CKTestStatefulView alloc] init];
   [container1 addSubview:view1];
   [pool enqueueStatefulView:view1
          forControllerClass:[CKStatefulViewComponentWithMaximumController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlockCount++;
+           return YES;
+         }];
   
   UIView *container2 = [[UIView alloc] init];
   CKTestStatefulView *view2 = [[CKTestStatefulView alloc] init];
   [container2 addSubview:view2];
   [pool enqueueStatefulView:view2
          forControllerClass:[CKStatefulViewComponentWithMaximumController class]
-                    context:nil];
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlockCount++;
+           return YES;
+         }];
+
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return calledBlockCount == 2;
+  });
   
   UIView *dequeuedView1 = [pool dequeueStatefulViewForControllerClass:[CKStatefulViewComponentWithMaximumController class]
                                                   preferredSuperview:container1
@@ -186,6 +266,90 @@
                                                    preferredSuperview:container2
                                                               context:nil];
   XCTAssertTrue(dequeuedView2 != view2, @"Didn't expect view in container2 to be returned");
+}
+
+#pragma mark - Pending pool tests
+
+- (void)testEnqueueingViewThenDequeueingWithPendingEnabledReturnsSameViewImmediately
+{
+  __block BOOL calledBlock = NO;
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  pool.pendingReusePoolEnabled = YES;
+
+  // Warm up the pool so that pending reuse will occur
+  [pool enqueueStatefulView:[[CKTestStatefulView alloc] init]
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return YES;
+         }];
+
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return calledBlock;
+  });
+
+  [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                           preferredSuperview:nil
+                                      context:nil];
+
+  calledBlock = NO;
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return YES;
+         }];
+
+  UIView *container = [[UIView alloc] init];
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                  preferredSuperview:container
+                                                             context:nil];
+  XCTAssertTrue(calledBlock);
+  XCTAssertEqualObjects(dequeuedView, view, @"Expected enqueued view to be returned");
+}
+
+- (void)testEnqueueingViewThenDequeueingWhileRefusingToRelinquishWithPendingEnabledReturnsNilImmediately
+{
+  __block BOOL calledBlock = NO;
+  CKStatefulViewReusePool *pool = [[CKStatefulViewReusePool alloc] init];
+  pool.pendingReusePoolEnabled = YES;
+
+  // Warm up the pool so that pending reuse will occur
+  [pool enqueueStatefulView:[[CKTestStatefulView alloc] init]
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return YES;
+         }];
+
+  CKRunRunLoopUntilBlockIsTrue(^BOOL{
+    return calledBlock;
+  });
+
+  [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                           preferredSuperview:nil
+                                      context:nil];
+
+  calledBlock = NO;
+  CKTestStatefulView *view = [[CKTestStatefulView alloc] init];
+  [pool enqueueStatefulView:view
+         forControllerClass:[CKTestStatefulViewComponentController class]
+                    context:nil
+         mayRelinquishBlock:^BOOL{
+           calledBlock = YES;
+           return NO;
+         }];
+
+  UIView *container = [[UIView alloc] init];
+  UIView *dequeuedView = [pool dequeueStatefulViewForControllerClass:[CKTestStatefulViewComponentController class]
+                                                  preferredSuperview:container
+                                                             context:nil];
+  XCTAssertTrue(calledBlock);
+  XCTAssertTrue(dequeuedView == nil, @"Expected dequeued view to be nil");
 }
 
 @end


### PR DESCRIPTION
This is the counter-proposal to https://github.com/facebook/componentkit/pull/692.

The core idea here is that we introduce a pending reuse pool, and move the dispatch_async hack into the reuse pool. This will allow us to prefer reusing "fully" relinquished views, but will allow fallbacks in the case that no fully relinquished view is present.

This still needs a little bit of work, but here it is.