### PR TITLE
Add __covariant to CKComponentController to avoid casting self.component

### DIFF
--- a/ComponentKit/Core/CKComponentController.h
+++ b/ComponentKit/Core/CKComponentController.h
@@ -14,7 +14,7 @@
 
 @class CKComponent;
 
-@interface CKComponentController : NSObject
+@interface CKComponentController<__covariant ComponentType:CKComponent *> : NSObject
 
 /** The controller's component is not mounted, but is about to be. */
 - (void)willMount NS_REQUIRES_SUPER;
@@ -58,7 +58,7 @@
 - (void)componentTreeDidDisappear NS_REQUIRES_SUPER;
 
 /** The current version of the component. */
-@property (nonatomic, weak, readonly) CKComponent *component;
+@property (nonatomic, weak, readonly) ComponentType component;
 
 /** The view created by the component, if currently mounted. */
 @property (nonatomic, strong, readonly) UIView *view;
@@ -83,7 +83,7 @@
  Initializes a controller with the first generation of component. You should not directly initialize a controller,
  they are initialized for you by the infrastructure.
  */
-- (instancetype)initWithComponent:(CKComponent *)component NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithComponent:(ComponentType)component NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.h
@@ -32,7 +32,7 @@
 
  This controller's corresponding component must subclass CKStatefulViewComponent.
  */
-@interface CKStatefulViewComponentController<__covariant ComponentType:CKComponent *> : CKComponentController
+@interface CKStatefulViewComponentController<__covariant ComponentType:CKComponent *> : CKComponentController<ComponentType>
 
 /** Return a new instance of the stateful view type used by this controller. Views are automatically recycled. */
 + (UIView *)newStatefulView:(id)context;

--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.h
@@ -32,7 +32,7 @@
 
  This controller's corresponding component must subclass CKStatefulViewComponent.
  */
-@interface CKStatefulViewComponentController : CKComponentController
+@interface CKStatefulViewComponentController<__covariant ComponentType:CKComponent *> : CKComponentController
 
 /** Return a new instance of the stateful view type used by this controller. Views are automatically recycled. */
 + (UIView *)newStatefulView:(id)context;

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -99,13 +99,13 @@
 
 @end
 
-@interface CKTestControllerScopeActionComponentController : CKComponentController
+@interface CKTestControllerScopeActionComponentController : CKComponentController<CKTestControllerScopeActionComponent *>
 @end
 
 @implementation CKTestControllerScopeActionComponentController
 - (void)actionMethod:(CKComponent *)sender context:(id)context
 {
-  ((CKTestControllerScopeActionComponent *)self.component).block(sender, context);
+  self.component.block(sender, context);
 }
 @end
 

--- a/ComponentKitTests/CKComponentLifecycleManagerTests.mm
+++ b/ComponentKitTests/CKComponentLifecycleManagerTests.mm
@@ -37,7 +37,7 @@ static BOOL notified;
 }
 @end
 
-@interface CKCoolComponentController : CKComponentController
+@interface CKCoolComponentController : CKComponentController<CKCoolComponent *>
 @end
 
 @implementation CKCoolComponentController
@@ -50,7 +50,7 @@ static BOOL notified;
 - (void)didUpdateComponent
 {
   [super didUpdateComponent];
-  ((CKCoolComponent *)self.component).controller = self;
+  self.component.controller = self;
 }
 
 @end


### PR DESCRIPTION
API clients won't need to cast self.component to their CKComponent subclass inside CKComponentController subclasses anymore.