### PR TITLE
Move animation ivars into lazy unique_ptr

### DIFF
--- a/ComponentKit/Core/CKComponentController.mm
+++ b/ComponentKit/Core/CKComponentController.mm
@@ -13,8 +13,6 @@
 
 #import <ComponentKit/CKAssert.h>
 
-#import <memory>
-
 #import "CKComponentInternal.h"
 #import "CKComponentSubclass.h"
 


### PR DESCRIPTION
In investigating component memory consumption, these ivars were consuming a lot of space, but are relatively rarely used. Move them into a lazily-instantiated wrapper struct.