### PR TITLE
Fix crash after assertion fire

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -239,7 +239,7 @@ static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSigna
 
   CKCAssert(signature.methodReturnLength == 0, @"Component action methods should not have any return value. Any objects returned from this method will be leaked.");
 
-  for (int i = 0; i + 3 < signature.numberOfArguments; i++) {
+  for (int i = 0; i + 3 < signature.numberOfArguments && i < typeEncodings.size(); i++) {
     const char *methodEncoding = [signature getArgumentTypeAtIndex:i + 3];
     const char *typeEncoding = typeEncodings[i];
 

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -408,4 +408,22 @@
   XCTAssertTrue(calledAction, @"Should have called the action on the test component");
 }
 
+- (void)testDemotedTargetSelectorActionCallsMethodOnScopedComponent
+{
+  __block BOOL calledAction = NO;
+
+  // We have to use build component here to ensure the scopes are properly configured.
+  CKTestScopeActionComponent *component = (CKTestScopeActionComponent *)CKBuildComponent([CKComponentScopeRoot rootWithListener:nil], {}, ^{
+    return [CKTestScopeActionComponent
+            newWithBlock:^(CKComponent *sender, id context) {
+              calledAction = YES;
+            }];
+  }).component;
+
+  CKComponentAction action = CKComponentAction(CKTypedComponentAction<id>(component, @selector(actionMethod:context:)));
+  action.send(component);
+
+  XCTAssertTrue(calledAction, @"Should have called the action on the test component");
+}
+
 @end


### PR DESCRIPTION
If assertions are disabled, or if they log and continue, then the assertion above this call won't stop execution, and we can get to this for loop where the number of arguments in the type signature and the type encodings don't match. In that case we will hard-crash. Let's not crash if that happens.