### PR TITLE
Correct identifier used in view action attributes

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -41,7 +41,8 @@ CKComponentActionSendBehavior CKTypedComponentActionBase::defaultBehavior() cons
           : CKComponentActionSendBehaviorStartAtSender);
 };
 
-id CKTypedComponentActionBase::initialTarget(CKComponent *sender) const {
+id CKTypedComponentActionBase::initialTarget(CKComponent *sender) const
+{
   switch (_variant) {
     case CKTypedComponentActionVariantRawSelector:
       return sender;
@@ -68,7 +69,8 @@ CKTypedComponentActionBase::CKTypedComponentActionBase(std::nullptr_t n) : CKTyp
 
 CKTypedComponentActionBase::operator bool() const { return _selector != NULL; };
 
-bool CKTypedComponentActionBase::isEqual(const CKTypedComponentActionBase &rhs) const {
+bool CKTypedComponentActionBase::isEqual(const CKTypedComponentActionBase &rhs) const
+{
   return (_variant == rhs._variant
           && CKObjectIsEqual(_target, rhs._target)
           && CKObjectIsEqual(_scopeHandle, rhs._scopeHandle)
@@ -76,6 +78,11 @@ bool CKTypedComponentActionBase::isEqual(const CKTypedComponentActionBase &rhs) 
 };
 
 SEL CKTypedComponentActionBase::selector() const { return _selector; };
+
+std::string CKTypedComponentActionBase::identifier() const
+{
+  return std::string(sel_getName(_selector)) + "-" + std::to_string((long)(_target ?: _scopeHandle));
+}
 
 #pragma mark - Sending
 
@@ -190,7 +197,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
   }
 
   std::string identifier = std::string("CKComponentActionAttribute-")
-  + std::string(sel_getName(action.selector()))
+  + action.identifier()
   + "-" + std::to_string(controlEvents);
   return {
     {

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -70,6 +70,7 @@ public:
   explicit operator bool() const;
   bool isEqual(const CKTypedComponentActionBase &rhs) const;
   SEL selector() const;
+  std::string identifier() const;
 };
 
 #pragma mark - Typed Helpers

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -172,4 +172,12 @@
   XCTAssertNotEqual(attr1.first.identifier, attr2.first.identifier);
 }
 
+- (void)testControlActionsWithRawSelectorActionsHaveEqualIdentifiers
+{
+  CKComponentViewAttributeValue attr1 = CKComponentActionAttribute(@selector(someAction));
+  CKComponentViewAttributeValue attr2 = CKComponentActionAttribute(@selector(someAction));
+
+  XCTAssertEqual(attr1.first.identifier, attr2.first.identifier);
+}
+
 @end

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -19,6 +19,14 @@
 #import <ComponentKit/CKComponentInternal.h>
 #import <ComponentKit/CKComponentLayout.h>
 
+@interface CKComponentActionAttributeTestObject : NSObject
+- (void)someAction;
+@end
+
+@implementation CKComponentActionAttributeTestObject
+- (void)someAction {}
+@end
+
 @interface CKComponentActionAttributeTests : XCTestCase
 @end
 
@@ -143,6 +151,25 @@
   XCTAssertFalse(receivedAction, @"Should not have received callback if no action specified");
 
   CKUnmountComponents(mountedComponents);
+}
+
+- (void)testControlActionsWithEqualTargetsHasEqualIdentifiers
+{
+  CKComponentActionAttributeTestObject *obj1 = [CKComponentActionAttributeTestObject new];
+  CKComponentViewAttributeValue attr1 = CKComponentActionAttribute({obj1, @selector(someAction)});
+  CKComponentViewAttributeValue attr2 = CKComponentActionAttribute({obj1, @selector(someAction)});
+
+  XCTAssertEqual(attr1.first.identifier, attr2.first.identifier);
+}
+
+- (void)testControlActionsWithNonEqualTargetsHasNonEqualIdentifiers
+{
+  CKComponentActionAttributeTestObject *obj1 = [CKComponentActionAttributeTestObject new];
+  CKComponentActionAttributeTestObject *obj2 = [CKComponentActionAttributeTestObject new];
+  CKComponentViewAttributeValue attr1 = CKComponentActionAttribute({obj1, @selector(someAction)});
+  CKComponentViewAttributeValue attr2 = CKComponentActionAttribute({obj2, @selector(someAction)});
+
+  XCTAssertNotEqual(attr1.first.identifier, attr2.first.identifier);
 }
 
 @end


### PR DESCRIPTION
When I updated the actions to use scoped/target actions I forgot to update this. What this means is that the identifier for the action only included the selector, so when a new component mounted we wouldn't update the action registered on the view. That means that old actions were being left on the views, which could cause weird problems. This was fine when we were exclusively responder-chain-based since it would always crawl up from the current component, but no longer. Now we take a reference to the target scope or object.

Fix is simple, just include the pointer value of the action at the time of application. This means that we'll update the value when a new target/selector pair is set.