### PR TITLE
Fix gesture actions still using selector identifier

### DIFF
--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -23,7 +23,7 @@
 static UIGestureRecognizer *recognizerForAction(UIView *view, CKTypedComponentAction<UIGestureRecognizer *> action)
 {
   for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
-    if (sel_isEqual([recognizer ck_componentAction].selector(), action.selector())) {
+    if ([recognizer ck_componentAction] == action) {
       return recognizer;
     }
   }
@@ -126,7 +126,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
     {
       std::string(class_getName(gestureRecognizerClass))
       + "-" + CKStringFromPointer((const void *)setupFunction)
-      + "-" + std::string(sel_getName(action.selector()))
+      + "-" + action.identifier()
       + CKIdentifierFromDelegateForwarderSelectors(delegateSelectors),
       ^(UIView *view, id value){
         CKCAssertNil(recognizerForAction(view, blockAction),

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -120,7 +120,25 @@
   XCTAssertNil(gesture.delegate, @"Gesture delegate should not be set");
 }
 
+- (void)testThatApplyingATapRecognizerAttributeWithDifferentTargetToViewWithExistingRecognizerUpdatesAction
+{
 
+  CKFakeActionComponent *fake1 = [CKFakeActionComponent new];
+  CKComponentViewAttributeValue attr1 = CKComponentTapGestureAttribute({fake1, @selector(test:)});
+
+  CKFakeActionComponent *fake2 = [CKFakeActionComponent new];
+  CKTypedComponentAction<UIGestureRecognizer *> action2 = {fake2, @selector(test:)};
+  CKComponentViewAttributeValue attr2 = CKComponentTapGestureAttribute(action2);
+  UIView *view = [[UIView alloc] init];
+
+  attr1.first.applicator(view, attr1.second);
+  attr1.first.unapplicator(view, attr1.second);
+
+  attr2.first.applicator(view, attr2.second);
+  UITapGestureRecognizer *recognizer = [view.gestureRecognizers firstObject];
+  XCTAssert([recognizer ck_componentAction] == action2, @"Expected ck_componentAction to be set on the GR");
+  attr2.first.unapplicator(view, attr2.second);
+}
 
 @end
 


### PR DESCRIPTION
I missed this one yesterday. Identifiers for actions should be built with both the selector and its target, or we risk not installing an updated action attribute when components update and we get a new target.