### PR TITLE
Maintain strong reference to controller while in reuse pool

### DIFF
--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -133,20 +133,15 @@
 {
   if ([self canRelinquishStatefulView]) {
     // There is no guarantee when this reuse pool will execute this block
-    CKStatefulViewComponentController *__weak weakSelf = self;
     [[CKStatefulViewReusePool sharedPool]
      enqueueStatefulView:_statefulView
      forControllerClass:[self class]
      context:_statefulViewContext
      mayRelinquishBlock:^BOOL{
-       CKStatefulViewComponentController *strongSelf = weakSelf;
-       if (!strongSelf) {
-         return YES;
-       }
-       if (!strongSelf->_mounted && [strongSelf canRelinquishStatefulView]) {
-         [strongSelf willRelinquishStatefulView:strongSelf->_statefulView];
-         strongSelf->_statefulView = nil;
-         strongSelf->_statefulViewContext = nil;
+       if (!self->_mounted && [self canRelinquishStatefulView]) {
+         [self willRelinquishStatefulView:self->_statefulView];
+         self->_statefulView = nil;
+         self->_statefulViewContext = nil;
          return YES;
        }
        return NO;


### PR DESCRIPTION
If the component controller is deallocated before the block is called, then we won't call willRelinquishStatefulView on the controller at all, leaving important cleanup work undone. Before my cleanup this was a strong ref. I changed it to a weak ref without really thinking through the details. Returning to a strong reference.