### PR TITLE
Revert "Merge pull request #693 from ocrickard/pending-reuse-pool"

### DIFF
--- a/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewComponentController.mm
@@ -131,27 +131,18 @@
 
 - (void)_relinquishStatefulViewIfPossible
 {
-  if ([self canRelinquishStatefulView]) {
-    // There is no guarantee when this reuse pool will execute this block
-    CKStatefulViewComponentController *__weak weakSelf = self;
-    [[CKStatefulViewReusePool sharedPool]
-     enqueueStatefulView:_statefulView
-     forControllerClass:[self class]
-     context:_statefulViewContext
-     mayRelinquishBlock:^BOOL{
-       CKStatefulViewComponentController *strongSelf = weakSelf;
-       if (!strongSelf) {
-         return YES;
-       }
-       if (!strongSelf->_mounted && [strongSelf canRelinquishStatefulView]) {
-         [strongSelf willRelinquishStatefulView:strongSelf->_statefulView];
-         strongSelf->_statefulView = nil;
-         strongSelf->_statefulViewContext = nil;
-         return YES;
-       }
-       return NO;
-     }];
-  }
+  // Wait for the run loop to turn over before trying to relinquish the view. That ensures that if we are remounted on
+  // a different root view, we reuse the same view (since didMount will be called immediately after didUnmount).
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (_statefulView && !_mounted && [self canRelinquishStatefulView]) {
+      [self willRelinquishStatefulView:_statefulView];
+      [[CKStatefulViewReusePool sharedPool] enqueueStatefulView:_statefulView
+                                             forControllerClass:[self class]
+                                                        context:_statefulViewContext];
+      _statefulView = nil;
+      _statefulViewContext = nil;
+    }
+  });
 }
 
 @end

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.h
@@ -10,16 +10,9 @@
 
 #import <UIKit/UIKit.h>
 
-/**
- Should return YES if the stateful view can be reused, or NO to block reuse of the stateful view.
- */
-typedef BOOL (^CKStatefulViewReusePoolPendingMayRelinquishBlock)(void);
-
 @interface CKStatefulViewReusePool : NSObject
 
 + (instancetype)sharedPool;
-
-@property (nonatomic, assign) BOOL pendingReusePoolEnabled;
 
 - (UIView *)dequeueStatefulViewForControllerClass:(Class)controllerClass
                                preferredSuperview:(UIView *)preferredSuperview
@@ -27,7 +20,6 @@ typedef BOOL (^CKStatefulViewReusePoolPendingMayRelinquishBlock)(void);
 
 - (void)enqueueStatefulView:(UIView *)view
          forControllerClass:(Class)controllerClass
-                    context:(id)context
-         mayRelinquishBlock:(CKStatefulViewReusePoolPendingMayRelinquishBlock)mayRelinquishBlock;
+                    context:(id)context;
 
 @end

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
@@ -10,78 +10,40 @@
 #import "CKStatefulViewComponentController.h"
 
 #import "CKStatefulViewReusePool.h"
-#import "CKAssert.h"
 
 #import <unordered_map>
 
-struct FBStatefulReusePoolItemEntry {
-  UIView *view;
-  CKStatefulViewReusePoolPendingMayRelinquishBlock block;
-};
-
 class FBStatefulReusePoolItem {
 public:
+  FBStatefulReusePoolItem()
+  : views([NSMutableArray array]) {};
+
   UIView *viewWithPreferredSuperview(UIView *preferredSuperview)
   {
-    if (_entries.empty()) {
+    if ([views count] == 0) {
       return nil;
     }
-    // Preferentially return the parent view.
-    auto preferIt = std::find_if(_entries.begin(), _entries.end(),
-                           [preferredSuperview](const FBStatefulReusePoolItemEntry entry)->bool {
-                             return entry.view == preferredSuperview;
-                           });
-    if (preferIt != _entries.end()) {
-      FBStatefulReusePoolItemEntry entry = *preferIt;
-      _entries.erase(preferIt);
-      if (entry.block == NULL || entry.block()) {
-        return entry.view;
-      }
-    }
-
-    // We didn't find the item preferentially. Time to fall back to going from start to finish.
-    auto it = _entries.begin();
-    while (it != _entries.end()) {
-      FBStatefulReusePoolItemEntry entry = *it;
-      // erase returns the next iterator
-      it = _entries.erase(it);
-      if (entry.block == NULL || entry.block()) {
-        // The block tells us it's OK to reuse this view
-        return entry.view;
-      }
-    }
-
-    return nil;
+    const NSUInteger matchingIndex = [views indexOfObjectPassingTest:^BOOL(UIView *view, NSUInteger idx, BOOL *stop) {
+      return [view superview] == preferredSuperview;
+    }];
+    const NSUInteger viewIndex = (matchingIndex == NSNotFound) ? 0 : matchingIndex;
+    UIView *view = views[viewIndex];
+    [views removeObjectAtIndex:viewIndex];
+    return view;
   };
   
   NSUInteger viewCount()
   {
-    return _entries.size();
+    return [views count];
   };
 
-  void addEntry(const FBStatefulReusePoolItemEntry &entry)
+  void addView(UIView *view)
   {
-    _entries.push_back(entry);
+    [views addObject:view];
   };
-
-  void absorbPendingPool(const FBStatefulReusePoolItem &otherPool, NSInteger maxEntries)
-  {
-    for (const FBStatefulReusePoolItemEntry &entry : otherPool._entries) {
-      // In the future, we should consider not evaluating the block here immediately, and letting it move into the
-      // normal reuse pool. That way we can let stateful components hold onto their own views without any
-      // reconfiguration for a longer period of time.
-      if (entry.block == NULL || entry.block()) {
-        // The stateful view component can decide not to allow reuse of its view if the component has re-mounted before
-        // the block is evaluated.
-        if (maxEntries < 0 || viewCount() < maxEntries) {
-          _entries.push_back({entry.view});
-        }
-      }
-    }
-  }
 
 private:
-  std::vector<FBStatefulReusePoolItemEntry> _entries;
+  NSMutableArray<UIView *> *views;
 };
 
 struct PoolKeyHasher {
@@ -94,8 +56,6 @@ struct PoolKeyHasher {
 @implementation CKStatefulViewReusePool
 {
   std::unordered_map<std::pair<__unsafe_unretained Class, id>, FBStatefulReusePoolItem, PoolKeyHasher> _pool;
-  std::unordered_map<std::pair<__unsafe_unretained Class, id>, FBStatefulReusePoolItem, PoolKeyHasher> _pendingPool;
-  BOOL _enqueuedPendingPurge;
 }
 
 + (instancetype)sharedPool
@@ -112,59 +72,30 @@ struct PoolKeyHasher {
                                preferredSuperview:(UIView *)preferredSuperview
                                           context:(id)context
 {
-  CKAssertMainThread();
-  CKAssertNotNil(controllerClass, @"Must provide a controller class");
-  const std::pair<__unsafe_unretained Class, id> key = std::make_pair(controllerClass, context);
-  const auto it = _pool.find(key);
+  NSAssert([NSThread isMainThread], nil);
+  NSParameterAssert(controllerClass != nil);
+  const auto it = _pool.find(std::make_pair(controllerClass, context));
   if (it == _pool.end()) { // Avoid overhead of creating the item unless it already exists
     return nil;
   }
-  UIView *candidate = it->second.viewWithPreferredSuperview(preferredSuperview);
-  if (!_pendingReusePoolEnabled || candidate) {
-    return candidate;
-  }
-  const auto pendingIt = _pendingPool.find(key);
-  if (pendingIt == _pendingPool.end()) {
-    return nil;
-  }
-  return pendingIt->second.viewWithPreferredSuperview(preferredSuperview);
+  return it->second.viewWithPreferredSuperview(preferredSuperview);
 }
 
 - (void)enqueueStatefulView:(UIView *)view
          forControllerClass:(Class)controllerClass
                     context:(id)context
-         mayRelinquishBlock:(CKStatefulViewReusePoolPendingMayRelinquishBlock)mayRelinquishBlock
 {
-  CKAssertMainThread();
-  CKAssertNotNil(view, @"Must provide a view");
-  CKAssertNotNil(controllerClass, @"Must provide a controller class");
-  CKAssertNotNil(mayRelinquishBlock, @"Must provide a relinquish block");
-
-  FBStatefulReusePoolItem &poolItem = _pendingPool[std::make_pair(controllerClass, context)];
-  poolItem.addEntry({view, mayRelinquishBlock});
-  if (_enqueuedPendingPurge) {
-    return;
+  NSAssert([NSThread isMainThread], nil);
+  NSParameterAssert(view != nil);
+  NSParameterAssert(controllerClass != nil);
+  
+  // maximumPoolSize will be -1 by default
+  NSInteger maximumPoolSize = [controllerClass maximumPoolSize:context];
+  
+  FBStatefulReusePoolItem poolItem = _pool[std::make_pair(controllerClass, context)];
+  if (maximumPoolSize < 0 || poolItem.viewCount() < maximumPoolSize) {
+    poolItem.addView(view);
   }
-  _enqueuedPendingPurge = YES;
-  // Wait for the run loop to turn over before trying to relinquish the view. That ensures that if we are remounted on
-  // a different root view, we reuse the same view (since didMount will be called immediately after didUnmount).
-  dispatch_async(dispatch_get_main_queue(), ^{
-    self->_enqueuedPendingPurge = NO;
-    [self purgePendingPool];
-  });
-}
-
-- (void)purgePendingPool
-{
-  CKAssertMainThread();
-  for (const auto &it : _pendingPool) {
-    // maximumPoolSize will be -1 by default
-    NSInteger maximumPoolSize = [it.first.first maximumPoolSize:it.first.second];
-
-    FBStatefulReusePoolItem &poolItem = _pool[it.first];
-    poolItem.absorbPendingPool(it.second, maximumPoolSize);
-  }
-  _pendingPool.clear();
 }
 
 @end


### PR DESCRIPTION
This reverts commit 42cb8f37f9eecd60c513c3dfc2f2de2bb7b9e522, reversing
changes made to 9df31ebdbd78c8d6b72f48cb93a56738360d1296.

While we're reviewing fixes to stateful views, we decided to revert this diff during the holidays.

Reverts:
https://github.com/facebook/componentkit/pull/693