### PR TITLE
Fix unused static function warning

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -239,9 +239,9 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
 
 #pragma mark - Debug Helpers
 
-static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSignature *signature, const std::vector<const char *> &typeEncodings)
-{
 #if DEBUG
+void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSignature *signature, const std::vector<const char *> &typeEncodings)
+{
   CKCAssert(typeEncodings.size() + 3 >= signature.numberOfArguments, @"Expected action method %@ to take less than %lu arguments, but it suppoorts %lu", NSStringFromSelector(selector), typeEncodings.size(), (unsigned long)signature.numberOfArguments - 3);
 
   CKCAssert(signature.methodReturnLength == 0, @"Component action methods should not have any return value. Any objects returned from this method will be leaked.");
@@ -252,8 +252,8 @@ static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSigna
 
     CKCAssert(methodEncoding == NULL || typeEncoding == NULL || strcmp(methodEncoding, typeEncoding) == 0, @"Implementation of %@ does not match expected types.\nExpected type %s, got %s", NSStringFromSelector(selector), typeEncoding, methodEncoding);
   }
-#endif
 }
+#endif
 
 void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings)
 {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -240,7 +240,7 @@ CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<
 #pragma mark - Debug Helpers
 
 #if DEBUG
-void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSignature *signature, const std::vector<const char *> &typeEncodings)
+static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSignature *signature, const std::vector<const char *> &typeEncodings)
 {
   CKCAssert(typeEncodings.size() + 3 >= signature.numberOfArguments, @"Expected action method %@ to take less than %lu arguments, but it suppoorts %lu", NSStringFromSelector(selector), typeEncodings.size(), (unsigned long)signature.numberOfArguments - 3);
 


### PR DESCRIPTION
When not in debug mode this static function was never called. Let's just move the #if to not compile it when it's not called. I built both for debug and release to confirm that the build doesn't break.