### PR TITLE
remove custom font-weight

### DIFF
--- a/static/componentkit.css
+++ b/static/componentkit.css
@@ -16,7 +16,6 @@ html {
 body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-weight: 300;
     color: #444;
     margin: 0;
     padding-top: 50px;


### PR DESCRIPTION
# before
![before](https://cloud.githubusercontent.com/assets/157390/22031187/c1a6819e-dc94-11e6-9a1f-073604305464.png)

# after
![after](https://cloud.githubusercontent.com/assets/157390/22031197/c80ea8e0-dc94-11e6-9835-f2c0be3a420e.png)

# I keep the font-weight in reference since that doesn't bother
![screen shot 2017-01-17 at 9 04 02 am](https://cloud.githubusercontent.com/assets/157390/22031149/a106d5ce-dc94-11e6-951d-5f268f10155c.png)
