### PR TITLE
Add noexcept specifications

### DIFF
--- a/ComponentKit/Core/CKComponentAnimation.h
+++ b/ComponentKit/Core/CKComponentAnimation.h
@@ -34,10 +34,10 @@ struct CKComponentAnimation {
    @param animation A CAAnimation to apply on the component's layer.
    @param layerPath A key path to a sublayer of the component's view. Defaults to nil.
    */
-  CKComponentAnimation(CKComponent *component, CAAnimation *animation, NSString *layerPath = nil);
+  CKComponentAnimation(CKComponent *component, CAAnimation *animation, NSString *layerPath = nil) noexcept;
   
   /** Creates a completely custom animation with arbitrary hooks. */
-  CKComponentAnimation(const CKComponentAnimationHooks &hooks);
+  CKComponentAnimation(const CKComponentAnimationHooks &hooks) noexcept;
 
   id willRemount() const;
   id didRemount(id context) const;

--- a/ComponentKit/Core/CKComponentAnimation.mm
+++ b/ComponentKit/Core/CKComponentAnimation.mm
@@ -18,7 +18,7 @@
 @property (nonatomic, copy, readonly) NSString *key;
 @end
 
-static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation, NSString *layerPath)
+static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAAnimation *originalAnimation, NSString *layerPath) noexcept
 {
   CKCAssertNotNil(component, @"Component being animated must be non-nil");
   CKCAssertNotNil(originalAnimation, @"Animation being added must be non-nil");
@@ -47,10 +47,10 @@ static CKComponentAnimationHooks hooksForCAAnimation(CKComponent *component, CAA
   };
 }
 
-CKComponentAnimation::CKComponentAnimation(CKComponent *component, CAAnimation *animation, NSString *layerPath)
+CKComponentAnimation::CKComponentAnimation(CKComponent *component, CAAnimation *animation, NSString *layerPath) noexcept
 : hooks(hooksForCAAnimation(component, animation, layerPath)) {}
 
-CKComponentAnimation::CKComponentAnimation(const CKComponentAnimationHooks &h) : hooks(h) {}
+CKComponentAnimation::CKComponentAnimation(const CKComponentAnimationHooks &h) noexcept : hooks(h) {}
 
 id CKComponentAnimation::willRemount() const
 {

--- a/ComponentKit/Core/CKComponentBacktraceDescription.h
+++ b/ComponentKit/Core/CKComponentBacktraceDescription.h
@@ -12,4 +12,4 @@
 
 @class CKComponent;
 
-NSString *CKComponentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace);
+NSString *CKComponentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace) noexcept;

--- a/ComponentKit/Core/CKComponentBacktraceDescription.mm
+++ b/ComponentKit/Core/CKComponentBacktraceDescription.mm
@@ -12,7 +12,7 @@
 
 #import "CKComponent.h"
 
-NSString *CKComponentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace)
+NSString *CKComponentBacktraceDescription(NSArray<CKComponent *> *componentBacktrace) noexcept
 {
   NSMutableString *const description = [NSMutableString string];
   [componentBacktrace enumerateObjectsWithOptions:NSEnumerationReverse

--- a/ComponentKit/Core/CKComponentLayout.h
+++ b/ComponentKit/Core/CKComponentLayout.h
@@ -23,7 +23,7 @@ struct CKComponentLayoutChild;
 
 /** Deletes the target off the main thread; important since component layouts are large recursive structures. */
 struct CKOffMainThreadDeleter {
-  void operator()(std::vector<CKComponentLayoutChild> *target);
+  void operator()(std::vector<CKComponentLayoutChild> *target) noexcept;
 };
 
 /** Represents the computed size of a component, as well as the computed sizes and positions of its children. */
@@ -33,12 +33,12 @@ struct CKComponentLayout {
   std::shared_ptr<const std::vector<CKComponentLayoutChild>> children;
   NSDictionary *extra;
 
-  CKComponentLayout(CKComponent *c, CGSize s, std::vector<CKComponentLayoutChild> ch = {}, NSDictionary *e = nil)
+  CKComponentLayout(CKComponent *c, CGSize s, std::vector<CKComponentLayoutChild> ch = {}, NSDictionary *e = nil) noexcept
   : component(c), size(s), children(new std::vector<CKComponentLayoutChild>(std::move(ch)), CKOffMainThreadDeleter()), extra(e) {
     CKCAssertNotNil(c, @"Nil components are not allowed");
   };
 
-  CKComponentLayout()
+  CKComponentLayout() noexcept
   : component(nil), size({0, 0}), children(new std::vector<CKComponentLayoutChild>(), CKOffMainThreadDeleter()), extra(nil) {};
 };
 

--- a/ComponentKit/Core/CKComponentLayout.mm
+++ b/ComponentKit/Core/CKComponentLayout.mm
@@ -23,12 +23,12 @@
 
 using namespace CK::Component;
 
-static void _deleteComponentLayoutChild(void *target)
+static void _deleteComponentLayoutChild(void *target) noexcept
 {
   delete (std::vector<CKComponentLayoutChild> *)target;
 }
 
-void CKOffMainThreadDeleter::operator()(std::vector<CKComponentLayoutChild> *target)
+void CKOffMainThreadDeleter::operator()(std::vector<CKComponentLayoutChild> *target) noexcept
 {
   // When deallocating a large layout tree this is called first on the root node
   // so we dispatch once and deallocate the whole tree on a background thread.

--- a/ComponentKit/Core/CKComponentSize.h
+++ b/ComponentKit/Core/CKComponentSize.h
@@ -33,16 +33,16 @@ struct CKComponentSize {
   CKRelativeDimension maxWidth;
   CKRelativeDimension maxHeight;
 
-  static CKComponentSize fromCGSize(CGSize size);
+  static CKComponentSize fromCGSize(CGSize size) noexcept;
 
-  CKSizeRange resolve(const CGSize &parentSize) const;
+  CKSizeRange resolve(const CGSize &parentSize) const noexcept;
 
-  bool operator==(const CKComponentSize &other) const;
-  NSString *description() const;
+  bool operator==(const CKComponentSize &other) const noexcept;
+  NSString *description() const noexcept;
 };
 
 namespace std {
   template <> struct hash<CKComponentSize> {
-    size_t operator ()(const CKComponentSize &);
+    size_t operator ()(const CKComponentSize &) noexcept;
   };
 }

--- a/ComponentKit/Core/CKComponentSize.mm
+++ b/ComponentKit/Core/CKComponentSize.mm
@@ -13,12 +13,12 @@
 
 #import <ComponentKit/CKAssert.h>
 
-CKComponentSize CKComponentSize::fromCGSize(CGSize size)
+CKComponentSize CKComponentSize::fromCGSize(CGSize size) noexcept
 {
   return {size.width, size.height};
 }
 
-static inline void CKCSConstrain(CGFloat minVal, CGFloat exactVal, CGFloat maxVal, CGFloat *outMin, CGFloat *outMax)
+static inline void CKCSConstrain(CGFloat minVal, CGFloat exactVal, CGFloat maxVal, CGFloat *outMin, CGFloat *outMax) noexcept
 {
     CKCAssert(!isnan(minVal), @"minVal must not be NaN. Current stack description: %@", CK::Component::LayoutContext::currentStackDescription());
     CKCAssert(!isnan(maxVal), @"maxVal must not be NaN. Current stack description: %@", CK::Component::LayoutContext::currentStackDescription());
@@ -50,7 +50,7 @@ static inline void CKCSConstrain(CGFloat minVal, CGFloat exactVal, CGFloat maxVa
     }
 }
 
-CKSizeRange CKComponentSize::resolve(const CGSize &parentSize) const
+CKSizeRange CKComponentSize::resolve(const CGSize &parentSize) const noexcept
 {
   CGSize resolvedExact = CKRelativeSize(width, height).resolveSize(parentSize, {NAN, NAN});
   CGSize resolvedMin = CKRelativeSize(minWidth, minHeight).resolveSize(parentSize, {0, 0});
@@ -62,14 +62,14 @@ CKSizeRange CKComponentSize::resolve(const CGSize &parentSize) const
   return {rangeMin, rangeMax};
 }
 
-bool CKComponentSize::operator==(const CKComponentSize &other) const
+bool CKComponentSize::operator==(const CKComponentSize &other) const noexcept
 {
   return width == other.width && height == other.height
   && minWidth == other.minWidth && minHeight == other.minHeight
   && maxWidth == other.maxWidth && maxHeight == other.maxHeight;
 }
 
-NSString *CKComponentSize::description() const
+NSString *CKComponentSize::description() const noexcept
 {
   return [NSString stringWithFormat:
           @"<CKComponentSize: exact=%@, min=%@, max=%@>",
@@ -78,7 +78,7 @@ NSString *CKComponentSize::description() const
           CKRelativeSize(maxWidth, maxHeight).description()];
 }
 
-size_t std::hash<CKComponentSize>::operator ()(const CKComponentSize &size) {
+size_t std::hash<CKComponentSize>::operator ()(const CKComponentSize &size) noexcept {
   NSUInteger subhashes[] = {
     std::hash<CKRelativeDimension>()(size.width),
     std::hash<CKRelativeDimension>()(size.height),

--- a/ComponentKit/Core/CKComponentViewAttribute.h
+++ b/ComponentKit/Core/CKComponentViewAttribute.h
@@ -24,7 +24,7 @@ struct CKComponentViewAttribute {
    This single-argument constructor allows implicit conversions, so you can pass a SEL as an attribute without actually
    typing CKComponentViewAttribute().
    */
-  CKComponentViewAttribute(SEL setter);
+  CKComponentViewAttribute(SEL setter) noexcept;
   /**
    Constructor for complex attributes.
 
@@ -71,7 +71,7 @@ struct CKComponentViewAttribute {
    Creates an attribute that invokes the given setter on the view's layer (rather than the view itself). Useful for
    easy access to layer properties, e.g. @selector(setBorderColor:), @selector(setAnchorPoint:), and so on.
    */
-  static CKComponentViewAttribute LayerAttribute(SEL setter);
+  static CKComponentViewAttribute LayerAttribute(SEL setter) noexcept;
 
   std::string identifier;
   void (^applicator)(id view, id value);
@@ -82,33 +82,33 @@ struct CKComponentViewAttribute {
 };
 
 struct CKBoxedValue {
-  CKBoxedValue() : __actual(nil) {};
+  CKBoxedValue() noexcept : __actual(nil) {};
 
   // Could replace this with !CK::is_objc_class<T>
-  CKBoxedValue(bool v) : __actual(@(v)) {};
-  CKBoxedValue(int8_t v) : __actual(@(v)) {};
-  CKBoxedValue(uint8_t v) : __actual(@(v)) {};
-  CKBoxedValue(int16_t v) : __actual(@(v)) {};
-  CKBoxedValue(uint16_t v) : __actual(@(v)) {};
-  CKBoxedValue(int32_t v) : __actual(@(v)) {};
-  CKBoxedValue(uint32_t v) : __actual(@(v)) {};
-  CKBoxedValue(int64_t v) : __actual(@(v)) {};
-  CKBoxedValue(uint64_t v) : __actual(@(v)) {};
-  CKBoxedValue(long v) : __actual(@(v)) {};
-  CKBoxedValue(unsigned long v) : __actual(@(v)) {};
-  CKBoxedValue(float v) : __actual(@(v)) {};
-  CKBoxedValue(double v) : __actual(@(v)) {};
-  CKBoxedValue(SEL v) : __actual([NSValue valueWithPointer:v]) {};
-  CKBoxedValue(std::nullptr_t v) : __actual(nil) {};
+  CKBoxedValue(bool v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(int8_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(uint8_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(int16_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(uint16_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(int32_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(uint32_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(int64_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(uint64_t v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(long v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(unsigned long v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(float v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(double v) noexcept : __actual(@(v)) {};
+  CKBoxedValue(SEL v) noexcept : __actual([NSValue valueWithPointer:v]) {};
+  CKBoxedValue(std::nullptr_t v) noexcept : __actual(nil) {};
   
   // Any objects go here
-  CKBoxedValue(id obj) : __actual(obj) {};
+  CKBoxedValue(id obj) noexcept : __actual(obj) {};
 
   // Define conversions for common Apple types
-  CKBoxedValue(CGRect v) : __actual([NSValue valueWithCGRect:v]) {};
-  CKBoxedValue(CGPoint v) : __actual([NSValue valueWithCGPoint:v]) {};
-  CKBoxedValue(CGSize v) : __actual([NSValue valueWithCGSize:v]) {};
-  CKBoxedValue(UIEdgeInsets v) : __actual([NSValue valueWithUIEdgeInsets:v]) {};
+  CKBoxedValue(CGRect v) noexcept : __actual([NSValue valueWithCGRect:v]) {};
+  CKBoxedValue(CGPoint v) noexcept : __actual([NSValue valueWithCGPoint:v]) {};
+  CKBoxedValue(CGSize v) noexcept : __actual([NSValue valueWithCGSize:v]) {};
+  CKBoxedValue(UIEdgeInsets v) noexcept : __actual([NSValue valueWithUIEdgeInsets:v]) {};
   
   operator id () const {
     return __actual;
@@ -125,7 +125,7 @@ namespace std {
 
   template<> struct hash<CKComponentViewAttribute>
   {
-    size_t operator()(const CKComponentViewAttribute &attr) const
+    size_t operator()(const CKComponentViewAttribute &attr) const noexcept
     {
       return hash<std::string>()(attr.identifier);
     }
@@ -144,7 +144,7 @@ namespace std {
 
   template<> struct hash<CKViewComponentAttributeValueMap>
   {
-    size_t operator()(const CKViewComponentAttributeValueMap &attr) const
+    size_t operator()(const CKViewComponentAttributeValueMap &attr) const noexcept
     {
       uint64_t hash = 0;
       for (const auto& it: attr) {

--- a/ComponentKit/Core/CKComponentViewAttribute.mm
+++ b/ComponentKit/Core/CKComponentViewAttribute.mm
@@ -204,7 +204,7 @@ static void performSetter(id object, SEL setter, id value)
 #pragma clang diagnostic pop
 }
 
-CKComponentViewAttribute::CKComponentViewAttribute(SEL setter) :
+CKComponentViewAttribute::CKComponentViewAttribute(SEL setter) noexcept :
 identifier(sel_getName(setter)),
 applicator(^(UIView *view, id value){
   performSetter(view, setter, value);
@@ -213,7 +213,7 @@ applicator(^(UIView *view, id value){
 // Explicit destructor to prevent inlining, reduce code size. See D1814602.
 CKComponentViewAttribute::~CKComponentViewAttribute() {}
 
-CKComponentViewAttribute CKComponentViewAttribute::LayerAttribute(SEL setter)
+CKComponentViewAttribute CKComponentViewAttribute::LayerAttribute(SEL setter) noexcept
 {
   return CKComponentViewAttribute(std::string("layer") + sel_getName(setter), ^(UIView *view, id value){
     performSetter(view.layer, setter, value);

--- a/ComponentKit/Core/CKComponentViewConfiguration.h
+++ b/ComponentKit/Core/CKComponentViewConfiguration.h
@@ -28,13 +28,13 @@ struct CKComponentViewClass {
   /**
    The no-argument default constructor, which specifies that the component should not have a corresponding view.
    */
-  CKComponentViewClass();
+  CKComponentViewClass() noexcept;
 
   /**
    Specifies that the component should have a view of the given class. The class will be instantiated with UIView's
    designated initializer -initWithFrame:.
    */
-  CKComponentViewClass(Class viewClass);
+  CKComponentViewClass(Class viewClass) noexcept;
 
   /**
    A variant that allows you to specify two selectors that are sent as a view is hidden/unhidden for future reuse.
@@ -42,7 +42,7 @@ struct CKComponentViewClass {
    @param didEnterReusePoolMessage Sent to the view just after it has been hidden for future reuse.
    @param willLeaveReusePool Sent to the view just before it is revealed after being reused.
    */
-  CKComponentViewClass(Class viewClass, SEL didEnterReusePoolMessage, SEL willLeaveReusePoolMessage);
+  CKComponentViewClass(Class viewClass, SEL didEnterReusePoolMessage, SEL willLeaveReusePoolMessage) noexcept;
 
   /**
    Specifies a view class that cannot be instantiated with -initWithFrame:.
@@ -54,7 +54,7 @@ struct CKComponentViewClass {
    */
   CKComponentViewClass(UIView *(*factory)(void),
                        CKComponentViewReuseBlock didEnterReusePool = nil,
-                       CKComponentViewReuseBlock willLeaveReusePool = nil);
+                       CKComponentViewReuseBlock willLeaveReusePool = nil) noexcept;
 
   /** Invoked by the infrastructure to create a new instance of the view. You should not call this directly. */
   UIView *createView() const;
@@ -62,16 +62,16 @@ struct CKComponentViewClass {
   /** Invoked by the infrastructure to determine if this will create a view or not. */
   BOOL hasView() const;
 
-  bool operator==(const CKComponentViewClass &other) const { return other.identifier == identifier; }
-  bool operator!=(const CKComponentViewClass &other) const { return other.identifier != identifier; }
+  bool operator==(const CKComponentViewClass &other) const noexcept { return other.identifier == identifier; }
+  bool operator!=(const CKComponentViewClass &other) const noexcept { return other.identifier != identifier; }
 
-  const std::string &getIdentifier() const { return identifier; }
+  const std::string &getIdentifier() const noexcept { return identifier; }
 
 private:
   CKComponentViewClass(const std::string &ident,
                        UIView *(^factory)(void),
                        CKComponentViewReuseBlock didEnterReusePool = nil,
-                       CKComponentViewReuseBlock willLeaveReusePool = nil);
+                       CKComponentViewReuseBlock willLeaveReusePool = nil) noexcept;
   std::string identifier;
   UIView *(^factory)(void);
   CKComponentViewReuseBlock didEnterReusePool;
@@ -98,21 +98,21 @@ namespace std {
  */
 struct CKComponentViewConfiguration {
 
-  CKComponentViewConfiguration();
+  CKComponentViewConfiguration() noexcept;
 
   CKComponentViewConfiguration(CKComponentViewClass &&cls,
-                               CKViewComponentAttributeValueMap &&attrs = {});
+                               CKViewComponentAttributeValueMap &&attrs = {}) noexcept;
 
   CKComponentViewConfiguration(CKComponentViewClass &&cls,
                                CKViewComponentAttributeValueMap &&attrs,
-                               CKComponentAccessibilityContext &&accessibilityCtx);
+                               CKComponentAccessibilityContext &&accessibilityCtx) noexcept;
 
   ~CKComponentViewConfiguration();
-  bool operator==(const CKComponentViewConfiguration &other) const;
+  bool operator==(const CKComponentViewConfiguration &other) const noexcept;
 
-  const CKComponentViewClass &viewClass() const;
-  std::shared_ptr<const CKViewComponentAttributeValueMap> attributes() const;
-  const CKComponentAccessibilityContext &accessibilityContext() const;
+  const CKComponentViewClass &viewClass() const noexcept;
+  std::shared_ptr<const CKViewComponentAttributeValueMap> attributes() const noexcept;
+  const CKComponentAccessibilityContext &accessibilityContext() const noexcept;
 
 private:
   struct Repr {
@@ -131,7 +131,7 @@ private:
 namespace std {
   template<> struct hash<CKComponentViewConfiguration>
   {
-    size_t operator()(const CKComponentViewConfiguration &cl) const;
+    size_t operator()(const CKComponentViewConfiguration &cl) const noexcept;
   };
 }
 

--- a/ComponentKit/Core/CKComponentViewConfiguration.mm
+++ b/ComponentKit/Core/CKComponentViewConfiguration.mm
@@ -16,13 +16,13 @@
 
 #import "CKInternalHelpers.h"
 
-CKComponentViewClass::CKComponentViewClass() : factory(nil) {}
+CKComponentViewClass::CKComponentViewClass() noexcept : factory(nil) {}
 
-CKComponentViewClass::CKComponentViewClass(Class viewClass) :
+CKComponentViewClass::CKComponentViewClass(Class viewClass) noexcept :
 identifier(class_getName(viewClass)),
 factory(^{return [[viewClass alloc] init];}) {}
 
-static CKComponentViewReuseBlock blockFromSEL(SEL sel)
+static CKComponentViewReuseBlock blockFromSEL(SEL sel) noexcept
 {
   if (sel) {
 #pragma clang diagnostic push
@@ -33,7 +33,7 @@ static CKComponentViewReuseBlock blockFromSEL(SEL sel)
   return nil;
 }
 
-CKComponentViewClass::CKComponentViewClass(Class viewClass, SEL enter, SEL leave) :
+CKComponentViewClass::CKComponentViewClass(Class viewClass, SEL enter, SEL leave) noexcept :
 identifier(std::string(class_getName(viewClass)) + "-" + sel_getName(enter) + "-" + sel_getName(leave)),
 factory(^{return [[viewClass alloc] init];}),
 didEnterReusePool(blockFromSEL(enter)),
@@ -41,7 +41,7 @@ willLeaveReusePool(blockFromSEL(leave)) {}
 
 CKComponentViewClass::CKComponentViewClass(UIView *(*fact)(void),
                                            void (^enter)(UIView *),
-                                           void (^leave)(UIView *))
+                                           void (^leave)(UIView *)) noexcept
 : identifier(CKStringFromPointer((const void *)fact)), factory(^UIView*(void) {return fact();}), didEnterReusePool(enter), willLeaveReusePool(leave)
 {
 }
@@ -49,7 +49,7 @@ CKComponentViewClass::CKComponentViewClass(UIView *(*fact)(void),
 CKComponentViewClass::CKComponentViewClass(const std::string &i,
                                            UIView *(^fact)(void),
                                            void (^enter)(UIView *),
-                                           void (^leave)(UIView *))
+                                           void (^leave)(UIView *)) noexcept
 : identifier(i), factory(fact), didEnterReusePool(enter), willLeaveReusePool(leave)
 {
 #if DEBUG
@@ -66,19 +66,19 @@ std::shared_ptr<const CKComponentViewConfiguration::Repr> CKComponentViewConfigu
   return p;
 }
 
-CKComponentViewConfiguration::CKComponentViewConfiguration()
+CKComponentViewConfiguration::CKComponentViewConfiguration() noexcept
   :rep(singletonViewConfiguration()) {}
 
 // Prefer overloaded constructors to default arguments to prevent code bloat; with default arguments
 // the compiler must insert initialization of each default value inline at the callsite.
 CKComponentViewConfiguration::CKComponentViewConfiguration(
     CKComponentViewClass &&cls,
-    CKViewComponentAttributeValueMap &&attrs)
+    CKViewComponentAttributeValueMap &&attrs) noexcept
 : CKComponentViewConfiguration(std::move(cls), std::move(attrs), {}) {}
 
 CKComponentViewConfiguration::CKComponentViewConfiguration(CKComponentViewClass &&cls,
                                                            CKViewComponentAttributeValueMap &&attrs,
-                                                           CKComponentAccessibilityContext &&accessibilityCtx)
+                                                           CKComponentAccessibilityContext &&accessibilityCtx) noexcept
 {
   // Need to use attrs before we move it below.
   CK::Component::PersistentAttributeShape attributeShape(attrs);
@@ -92,7 +92,7 @@ CKComponentViewConfiguration::CKComponentViewConfiguration(CKComponentViewClass 
 // Constructors and destructors are defined out-of-line to prevent code bloat.
 CKComponentViewConfiguration::~CKComponentViewConfiguration() {}
 
-bool CKComponentViewConfiguration::operator==(const CKComponentViewConfiguration &other) const
+bool CKComponentViewConfiguration::operator==(const CKComponentViewConfiguration &other) const noexcept
 {
   if (other.rep == rep) {
     return true;
@@ -118,17 +118,17 @@ bool CKComponentViewConfiguration::operator==(const CKComponentViewConfiguration
   }
 }
 
-const CKComponentViewClass &CKComponentViewConfiguration::viewClass() const
+const CKComponentViewClass &CKComponentViewConfiguration::viewClass() const noexcept
 {
   return rep->viewClass;
 }
 
-std::shared_ptr<const CKViewComponentAttributeValueMap> CKComponentViewConfiguration::attributes() const
+std::shared_ptr<const CKViewComponentAttributeValueMap> CKComponentViewConfiguration::attributes() const noexcept
 {
   return rep->attributes;
 }
 
-const CKComponentAccessibilityContext &CKComponentViewConfiguration::accessibilityContext() const
+const CKComponentAccessibilityContext &CKComponentViewConfiguration::accessibilityContext() const noexcept
 {
   return rep->accessibilityContext;
 }
@@ -143,7 +143,7 @@ BOOL CKComponentViewClass::hasView() const
   return factory != nil;
 }
 
-size_t std::hash<CKComponentViewConfiguration>::operator()(const CKComponentViewConfiguration &cl) const
+size_t std::hash<CKComponentViewConfiguration>::operator()(const CKComponentViewConfiguration &cl) const noexcept
 {
   NSUInteger subhashes[] = {
     std::hash<CKComponentViewClass>()(cl.viewClass()),

--- a/ComponentKit/Core/CKDimension.h
+++ b/ComponentKit/Core/CKDimension.h
@@ -44,25 +44,25 @@ class CKRelativeDimension;
 
 namespace std {
   template <> struct hash<CKRelativeDimension> {
-    size_t operator ()(const CKRelativeDimension &);
+    size_t operator ()(const CKRelativeDimension &) noexcept;
   };
 }
 
 class CKRelativeDimension {
 public:
-  CKRelativeDimension() : CKRelativeDimension(Type::AUTO, 0) {}
-  CKRelativeDimension(CGFloat points) : CKRelativeDimension(Type::POINTS, points) {}
+  CKRelativeDimension() noexcept : CKRelativeDimension(Type::AUTO, 0) {}
+  CKRelativeDimension(CGFloat points) noexcept : CKRelativeDimension(Type::POINTS, points) {}
 
-  static CKRelativeDimension Auto() { return CKRelativeDimension(); }
-  static CKRelativeDimension Points(CGFloat p) { return CKRelativeDimension(p); }
-  static CKRelativeDimension Percent(CGFloat p) { return {CKRelativeDimension::Type::PERCENT, p}; }
+  static CKRelativeDimension Auto() noexcept { return CKRelativeDimension(); }
+  static CKRelativeDimension Points(CGFloat p) noexcept { return CKRelativeDimension(p); }
+  static CKRelativeDimension Percent(CGFloat p) noexcept { return {CKRelativeDimension::Type::PERCENT, p}; }
 
   CKRelativeDimension(const CKRelativeDimension &) = default;
   CKRelativeDimension &operator=(const CKRelativeDimension &) = default;
 
-  bool operator==(const CKRelativeDimension &) const;
-  NSString *description() const;
-  CGFloat resolve(CGFloat autoSize, CGFloat parent) const;
+  bool operator==(const CKRelativeDimension &) const noexcept;
+  NSString *description() const noexcept;
+  CGFloat resolve(CGFloat autoSize, CGFloat parent) const noexcept;
 
 private:
   enum class Type {
@@ -89,19 +89,19 @@ private:
 struct CKRelativeSize {
   CKRelativeDimension width;
   CKRelativeDimension height;
-  CKRelativeSize(const CKRelativeDimension &width, const CKRelativeDimension &height);
+  CKRelativeSize(const CKRelativeDimension &width, const CKRelativeDimension &height) noexcept;
 
   /** Convenience constructor to provide size in Points. */
-  CKRelativeSize(const CGSize &size);
+  CKRelativeSize(const CGSize &size) noexcept;
 
   /** Convenience constructor for {Auto, Auto} */
-  CKRelativeSize();
+  CKRelativeSize() noexcept;
 
   /** Resolve this size relative to a parent size and an auto size. */
-  CGSize resolveSize(const CGSize &parentSize, const CGSize &autoSize) const;
+  CGSize resolveSize(const CGSize &parentSize, const CGSize &autoSize) const noexcept;
 
-  bool operator==(const CKRelativeSize &other) const;
-  NSString *description() const;
+  bool operator==(const CKRelativeSize &other) const noexcept;
+  NSString *description() const noexcept;
 };
 
 /**
@@ -116,12 +116,12 @@ struct CKRelativeSizeRange {
    Convenience constructors to provide an exact size (min == max).
    CKRelativeSizeRange r = {80, 60} // width: [80, 80], height: [60, 60].
    */
-  CKRelativeSizeRange(const CKRelativeSize &exact);
-  CKRelativeSizeRange(const CGSize &exact);
-  CKRelativeSizeRange(const CKRelativeDimension &exactWidth, const CKRelativeDimension &exactHeight);
+  CKRelativeSizeRange(const CKRelativeSize &exact) noexcept;
+  CKRelativeSizeRange(const CGSize &exact) noexcept;
+  CKRelativeSizeRange(const CKRelativeDimension &exactWidth, const CKRelativeDimension &exactHeight) noexcept;
 
   /** Convenience constructor for {{Auto, Auto}, {Auto, Auto}}. */
-  CKRelativeSizeRange();
+  CKRelativeSizeRange() noexcept;
 
   /**
    Provided a parent size and values to use in place of Auto, compute final dimensions for this RelativeSizeRange
@@ -134,5 +134,5 @@ struct CKRelativeSizeRange {
    The default for Auto() is *everything*, meaning min = {0,0}; max = {INFINITY, INFINITY};
    */
   CKSizeRange resolveSizeRange(const CGSize &parentSize,
-                               const CKSizeRange &autoSizeRange = {{0,0}, {INFINITY, INFINITY}}) const;
+                               const CKSizeRange &autoSizeRange = {{0,0}, {INFINITY, INFINITY}}) const noexcept;
 };

--- a/ComponentKit/Core/CKDimension.mm
+++ b/ComponentKit/Core/CKDimension.mm
@@ -19,7 +19,7 @@
 #import "CKInternalHelpers.h"
 #import "CKEqualityHashHelpers.h"
 
-bool CKRelativeDimension::operator==(const CKRelativeDimension &other) const
+bool CKRelativeDimension::operator==(const CKRelativeDimension &other) const noexcept
 {
   // Implementation assumes that "auto" assigns '0' to value.
   if (_type != other._type) {
@@ -34,7 +34,7 @@ bool CKRelativeDimension::operator==(const CKRelativeDimension &other) const
   }
 }
 
-NSString *CKRelativeDimension::description() const
+NSString *CKRelativeDimension::description() const noexcept
 {
   switch (_type) {
     case Type::AUTO:
@@ -46,7 +46,7 @@ NSString *CKRelativeDimension::description() const
   }
 }
 
-CGFloat CKRelativeDimension::resolve(CGFloat autoSize, CGFloat parent) const
+CGFloat CKRelativeDimension::resolve(CGFloat autoSize, CGFloat parent) const noexcept
 {
   switch (_type) {
     case Type::AUTO:
@@ -58,7 +58,7 @@ CGFloat CKRelativeDimension::resolve(CGFloat autoSize, CGFloat parent) const
   }
 }
 
-size_t std::hash<CKRelativeDimension>::operator ()(const CKRelativeDimension &size) {
+size_t std::hash<CKRelativeDimension>::operator ()(const CKRelativeDimension &size) noexcept {
   NSUInteger subhashes[] = {
     (size_t)(size._type),
     std::hash<CGFloat>()(size._value),
@@ -67,11 +67,11 @@ size_t std::hash<CKRelativeDimension>::operator ()(const CKRelativeDimension &si
 };
 
 
-CKRelativeSize::CKRelativeSize(const CKRelativeDimension &_width, const CKRelativeDimension &_height) : width(_width), height(_height) {}
-CKRelativeSize::CKRelativeSize(const CGSize &size) : CKRelativeSize(size.width, size.height) {}
-CKRelativeSize::CKRelativeSize() : CKRelativeSize({}, {}) {}
+CKRelativeSize::CKRelativeSize(const CKRelativeDimension &_width, const CKRelativeDimension &_height) noexcept : width(_width), height(_height) {}
+CKRelativeSize::CKRelativeSize(const CGSize &size) noexcept : CKRelativeSize(size.width, size.height) {}
+CKRelativeSize::CKRelativeSize() noexcept : CKRelativeSize({}, {}) {}
 
-CGSize CKRelativeSize::resolveSize(const CGSize &parentSize, const CGSize &autoSize) const
+CGSize CKRelativeSize::resolveSize(const CGSize &parentSize, const CGSize &autoSize) const noexcept
 {
   return {
     width.resolve(autoSize.width, parentSize.width),
@@ -79,23 +79,23 @@ CGSize CKRelativeSize::resolveSize(const CGSize &parentSize, const CGSize &autoS
   };
 }
 
-bool CKRelativeSize::operator==(const CKRelativeSize &other) const
+bool CKRelativeSize::operator==(const CKRelativeSize &other) const noexcept
 {
   return width == other.width && height == other.height;
 }
 
-NSString *CKRelativeSize::description() const
+NSString *CKRelativeSize::description() const noexcept
 {
   return [NSString stringWithFormat:@"{%@, %@}", width.description(), height.description()];
 }
 
 CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeSize &_min, const CKRelativeSize &_max) : min(_min), max(_max) {}
-CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeSize &exact) : CKRelativeSizeRange(exact, exact) {}
-CKRelativeSizeRange::CKRelativeSizeRange(const CGSize &exact) : CKRelativeSizeRange(CKRelativeSize(exact)) {}
-CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeDimension &exactWidth, const CKRelativeDimension &exactHeight) : CKRelativeSizeRange(CKRelativeSize(exactWidth, exactHeight)) {}
-CKRelativeSizeRange::CKRelativeSizeRange() : CKRelativeSizeRange(CKRelativeSize(), CKRelativeSize()) {}
+CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeSize &exact) noexcept : CKRelativeSizeRange(exact, exact) {}
+CKRelativeSizeRange::CKRelativeSizeRange(const CGSize &exact) noexcept : CKRelativeSizeRange(CKRelativeSize(exact)) {}
+CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeDimension &exactWidth, const CKRelativeDimension &exactHeight) noexcept : CKRelativeSizeRange(CKRelativeSize(exactWidth, exactHeight)) {}
+CKRelativeSizeRange::CKRelativeSizeRange() noexcept : CKRelativeSizeRange(CKRelativeSize(), CKRelativeSize()) {}
 
-CKSizeRange CKRelativeSizeRange::resolveSizeRange(const CGSize &parentSize, const CKSizeRange &autoCKSizeRange) const
+CKSizeRange CKRelativeSizeRange::resolveSizeRange(const CGSize &parentSize, const CKSizeRange &autoCKSizeRange) const noexcept
 {
   return {
     min.resolveSize(parentSize, autoCKSizeRange.min),

--- a/ComponentKit/Core/Scope/CKComponentScope.h
+++ b/ComponentKit/Core/Scope/CKComponentScope.h
@@ -49,12 +49,12 @@ public:
                               for why this is usually a bad idea:
                               http://facebook.github.io/react/tips/props-in-getInitialState-as-anti-pattern.html
    */
-  CKComponentScope(Class __unsafe_unretained componentClass, id identifier = nil, id (^initialStateCreator)(void) = nil);
+  CKComponentScope(Class __unsafe_unretained componentClass, id identifier = nil, id (^initialStateCreator)(void) = nil) noexcept;
 
   ~CKComponentScope();
 
   /** @return The current state for the component being built. */
-  id state(void) const;
+  id state(void) const noexcept;
 
   /**
    @return A block that schedules a state update when invoked.
@@ -63,14 +63,14 @@ public:
    CKComponentAction and the parent should call -updateState:mode: on itself; this hides the implementation details
    of the parent's state from the child.)
   */
-  CKComponentStateUpdater stateUpdater(void) const;
+  CKComponentStateUpdater stateUpdater(void) const noexcept;
 
   /**
    @return The scope handle associated with this scope.
    @discussion This is exposed for use by the framework. You should almost certainly never call this for any reason
                in your components.
    */
-  CKComponentScopeHandle *scopeHandle(void) const;
+  CKComponentScopeHandle *scopeHandle(void) const noexcept;
 
 private:
   CKComponentScope(const CKComponentScope&) = delete;

--- a/ComponentKit/Core/Scope/CKComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKComponentScope.mm
@@ -22,7 +22,7 @@ CKComponentScope::~CKComponentScope()
   }
 }
 
-CKComponentScope::CKComponentScope(Class __unsafe_unretained componentClass, id identifier, id (^initialStateCreator)(void))
+CKComponentScope::CKComponentScope(Class __unsafe_unretained componentClass, id identifier, id (^initialStateCreator)(void)) noexcept
 {
   _threadLocalScope = CKThreadLocalComponentScope::currentScope();
   if (_threadLocalScope != nullptr) {
@@ -37,19 +37,19 @@ CKComponentScope::CKComponentScope(Class __unsafe_unretained componentClass, id 
   }
 }
 
-id CKComponentScope::state(void) const
+id CKComponentScope::state(void) const noexcept
 {
   return _scopeHandle.state;
 }
 
-CKComponentStateUpdater CKComponentScope::stateUpdater(void) const
+CKComponentStateUpdater CKComponentScope::stateUpdater(void) const noexcept
 {
   // We must capture _scopeHandle in a local, since this may be destroyed by the time the block executes.
   CKComponentScopeHandle *const scopeHandle = _scopeHandle;
   return ^(id (^update)(id), CKUpdateMode mode){ [scopeHandle updateState:update mode:mode]; };
 }
 
-CKComponentScopeHandle *CKComponentScope::scopeHandle(void) const
+CKComponentScopeHandle *CKComponentScope::scopeHandle(void) const noexcept
 {
   return _scopeHandle;
 }

--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
@@ -22,7 +22,7 @@ public:
   ~CKThreadLocalComponentScope();
 
   /** Returns nullptr if there isn't a current scope */
-  static CKThreadLocalComponentScope *currentScope();
+  static CKThreadLocalComponentScope *currentScope() noexcept;
 
   CKComponentScopeRoot *const newScopeRoot;
   const CKComponentStateUpdateMap stateUpdates;
@@ -35,7 +35,7 @@ public:
  */
 class CKThreadLocalComponentScopeOverride {
 public:
-  CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope);
+  CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope) noexcept;
   ~CKThreadLocalComponentScopeOverride();
 
 private:

--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.mm
@@ -17,7 +17,7 @@
 
 #import "CKComponentScopeRoot.h"
 
-static pthread_key_t _threadKey()
+static pthread_key_t _threadKey() noexcept
 {
   static pthread_key_t thread_key;
   static dispatch_once_t onceToken;
@@ -27,7 +27,7 @@ static pthread_key_t _threadKey()
   return thread_key;
 }
 
-CKThreadLocalComponentScope *CKThreadLocalComponentScope::currentScope()
+CKThreadLocalComponentScope *CKThreadLocalComponentScope::currentScope() noexcept
 {
   return (CKThreadLocalComponentScope *)pthread_getspecific(_threadKey());
 }
@@ -48,7 +48,7 @@ CKThreadLocalComponentScope::~CKThreadLocalComponentScope()
   pthread_setspecific(_threadKey(), nullptr);
 }
 
-CKThreadLocalComponentScopeOverride::CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope)
+CKThreadLocalComponentScopeOverride::CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope) noexcept
 : previousScope(CKThreadLocalComponentScope::currentScope())
 {
   pthread_setspecific(_threadKey(), scope);

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -91,8 +91,8 @@ class CKTypedComponentAction : public CKTypedComponentActionBase {
                 CKTypedComponentActionBoolPack<(CKTypedComponentActionDenyType<T>::value)...>
                 >::value, "You must either use a pointer (like an NSObject) or a trivially constructible type. Complex types are not allowed as arguments of component actions.");
 public:
-  CKTypedComponentAction<T...>() : CKTypedComponentActionBase() {};
-  CKTypedComponentAction<T...>(id target, SEL selector) : CKTypedComponentActionBase(target, selector)
+  CKTypedComponentAction<T...>() noexcept : CKTypedComponentActionBase() {};
+  CKTypedComponentAction<T...>(id target, SEL selector) noexcept : CKTypedComponentActionBase(target, selector)
   {
 #if DEBUG
     std::vector<const char *> typeEncodings;
@@ -101,7 +101,7 @@ public:
 #endif
   }
 
-  CKTypedComponentAction<T...>(const CKComponentScope &scope, SEL selector) : CKTypedComponentActionBase(scope, selector)
+  CKTypedComponentAction<T...>(const CKComponentScope &scope, SEL selector) noexcept : CKTypedComponentActionBase(scope, selector)
   {
 #if DEBUG
     std::vector<const char *> typeEncodings;
@@ -111,23 +111,23 @@ public:
   }
 
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
-  CKTypedComponentAction(SEL selector) : CKTypedComponentActionBase(selector) {};
+  CKTypedComponentAction(SEL selector) noexcept : CKTypedComponentActionBase(selector) {};
 
   /** Allows conversion from NULL actions. */
-  CKTypedComponentAction(int s) : CKTypedComponentActionBase() {};
-  CKTypedComponentAction(long s) : CKTypedComponentActionBase() {};
-  CKTypedComponentAction(std::nullptr_t n) : CKTypedComponentActionBase() {};
+  CKTypedComponentAction(int s) noexcept : CKTypedComponentActionBase() {};
+  CKTypedComponentAction(long s) noexcept : CKTypedComponentActionBase() {};
+  CKTypedComponentAction(std::nullptr_t n) noexcept : CKTypedComponentActionBase() {};
 
   /** We support promotion from actions that take no arguments. */
   template <typename... Ts>
-  CKTypedComponentAction<Ts...>(const CKTypedComponentAction<> &action) : CKTypedComponentActionBase(action) { };
+  CKTypedComponentAction<Ts...>(const CKTypedComponentAction<> &action) noexcept : CKTypedComponentActionBase(action) { };
 
   /**
    We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the
    method specified here will have nil values at runtime. Used for interoperation with older API's.
    */
   template<typename... Ts>
-  explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action) : CKTypedComponentActionBase(action) { };
+  explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action) noexcept : CKTypedComponentActionBase(action) { };
 
   ~CKTypedComponentAction() {};
 
@@ -140,7 +140,7 @@ public:
     CKComponentActionSendResponderChain(selector(), responder, sender, args...);
   };
 
-  bool operator==(const CKTypedComponentAction<T...> &rhs) const {
+  bool operator==(const CKTypedComponentAction<T...> &rhs) const noexcept {
     return isEqual(rhs);
   };
 
@@ -176,11 +176,11 @@ void CKComponentActionSend(CKTypedComponentAction<id> action, CKComponent *sende
  @param controlEvents The events that should result in the action being sent. Default is touch up inside.
  */
 CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<UIEvent *> action,
-                                                         UIControlEvents controlEvents = UIControlEventTouchUpInside);
+                                                         UIControlEvents controlEvents = UIControlEventTouchUpInside) noexcept;
 
 /**
  Returns a view attribute that configures a view to have custom accessibility actions.
 
  @param actions An ordered list of actions, each with a name and an associated CKComponentAction
  */
-CKComponentViewAttributeValue CKComponentAccessibilityCustomActionsAttribute(const std::vector<std::pair<NSString *, CKComponentAction>> &actions);
+CKComponentViewAttributeValue CKComponentAccessibilityCustomActionsAttribute(const std::vector<std::pair<NSString *, CKComponentAction>> &actions) noexcept;

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -21,8 +21,8 @@
 #import "CKComponentScopeHandle.h"
 #import "CKComponentViewInterface.h"
 
-void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list) { }
-void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index) { }
+void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list) noexcept { }
+void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index) noexcept { }
 
 #pragma mark - CKTypedComponentActionBase
 
@@ -53,23 +53,23 @@ id CKTypedComponentActionBase::initialTarget(CKComponent *sender) const
   }
 }
 
-CKTypedComponentActionBase::CKTypedComponentActionBase() : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _scopeHandle(nil), _selector(NULL) {}
+CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _scopeHandle(nil), _selector(NULL) {}
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) : _variant(CKTypedComponentActionVariantTargetSelector), _target(target), _scopeHandle(nil), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) noexcept : _variant(CKTypedComponentActionVariantTargetSelector), _target(target), _scopeHandle(nil), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) : _variant(CKTypedComponentActionVariantComponentScope), _target(nil), _scopeHandle(scope.scopeHandle()), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _variant(CKTypedComponentActionVariantComponentScope), _target(nil), _scopeHandle(scope.scopeHandle()), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _scopeHandle(nil), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _variant(CKTypedComponentActionVariantRawSelector), _target(nil), _scopeHandle(nil), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(int s) : CKTypedComponentActionBase() {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(int s) noexcept : CKTypedComponentActionBase() {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(long s) : CKTypedComponentActionBase() {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(long s) noexcept : CKTypedComponentActionBase() {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(std::nullptr_t n) : CKTypedComponentActionBase() {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(std::nullptr_t n) noexcept : CKTypedComponentActionBase() {};
 
-CKTypedComponentActionBase::operator bool() const { return _selector != NULL; };
+CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL; };
 
-bool CKTypedComponentActionBase::isEqual(const CKTypedComponentActionBase &rhs) const
+bool CKTypedComponentActionBase::isEqual(const CKTypedComponentActionBase &rhs) const noexcept
 {
   return (_variant == rhs._variant
           && CKObjectIsEqual(_target, rhs._target)
@@ -77,16 +77,16 @@ bool CKTypedComponentActionBase::isEqual(const CKTypedComponentActionBase &rhs) 
           && _selector == rhs._selector);
 };
 
-SEL CKTypedComponentActionBase::selector() const { return _selector; };
+SEL CKTypedComponentActionBase::selector() const noexcept { return _selector; };
 
-std::string CKTypedComponentActionBase::identifier() const
+std::string CKTypedComponentActionBase::identifier() const noexcept
 {
   return std::string(sel_getName(_selector)) + "-" + std::to_string((long)(_target ?: _scopeHandle));
 }
 
 #pragma mark - Sending
 
-NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender)
+NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender) noexcept
 {
   id responder = [target targetForAction:selector withSender:target];
   CKCAssertNotNil(responder, @"Unhandled component action %@ following responder chain %@",
@@ -162,7 +162,7 @@ struct CKComponentActionHasher
 typedef std::unordered_map<CKTypedComponentAction<UIEvent *>, CKComponentActionControlForwarder *, CKComponentActionHasher> ForwarderMap;
 
 CKComponentViewAttributeValue CKComponentActionAttribute(CKTypedComponentAction<UIEvent *> action,
-                                                         UIControlEvents controlEvents)
+                                                         UIControlEvents controlEvents) noexcept
 {
   static ForwarderMap *map = new ForwarderMap(); // never destructed to avoid static destruction fiasco
   static CK::StaticMutex lock = CK_MUTEX_INITIALIZER;   // protects map
@@ -255,7 +255,7 @@ static void checkMethodSignatureAgainstTypeEncodings(SEL selector, NSMethodSigna
 }
 #endif
 
-void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings)
+void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings) noexcept
 {
 #if DEBUG
   // In DEBUG mode, we want to do the minimum of type-checking for the action that's possible in Objective-C. We
@@ -272,7 +272,7 @@ void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SE
 #endif
 }
 
-void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings)
+void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings) noexcept
 {
 #if DEBUG
   // In DEBUG mode, we want to do the minimum of type-checking for the action that's possible in Objective-C. We
@@ -288,7 +288,7 @@ void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const st
 
 
 // This method returns a friendly-print of a responder chain. Used for debug purposes.
-NSString *_CKComponentResponderChainDebugResponderChain(id responder) {
+NSString *_CKComponentResponderChainDebugResponderChain(id responder) noexcept {
   return (responder
           ? [NSString stringWithFormat:@"%@ -> %@", responder, _CKComponentResponderChainDebugResponderChain([responder nextResponder])]
           : @"nil");
@@ -325,7 +325,7 @@ NSString *_CKComponentResponderChainDebugResponderChain(id responder) {
 
 @end
 
-CKComponentViewAttributeValue CKComponentAccessibilityCustomActionsAttribute(const std::vector<std::pair<NSString *, CKComponentAction>> &passedActions)
+CKComponentViewAttributeValue CKComponentAccessibilityCustomActionsAttribute(const std::vector<std::pair<NSString *, CKComponentAction>> &passedActions) noexcept
 {
   auto const actions = passedActions;
   return {

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -41,18 +41,18 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
 /** A base-class for typed components that doesn't use templates to avoid template bloat. */
 class CKTypedComponentActionBase {
 protected:
-  CKTypedComponentActionBase();
-  CKTypedComponentActionBase(id target, SEL selector);
+  CKTypedComponentActionBase() noexcept;
+  CKTypedComponentActionBase(id target, SEL selector) noexcept;
   
-  CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector);
+  CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept;
   
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
-  CKTypedComponentActionBase(SEL selector);
+  CKTypedComponentActionBase(SEL selector) noexcept;
   
   /** Allows conversion from NULL actions. */
-  CKTypedComponentActionBase(int s);
-  CKTypedComponentActionBase(long s);
-  CKTypedComponentActionBase(std::nullptr_t n);
+  CKTypedComponentActionBase(int s) noexcept;
+  CKTypedComponentActionBase(long s) noexcept;
+  CKTypedComponentActionBase(std::nullptr_t n) noexcept;
   
   ~CKTypedComponentActionBase() {};
   
@@ -67,10 +67,10 @@ protected:
   SEL _selector;
   
 public:
-  explicit operator bool() const;
-  bool isEqual(const CKTypedComponentActionBase &rhs) const;
-  SEL selector() const;
-  std::string identifier() const;
+  explicit operator bool() const noexcept;
+  bool isEqual(const CKTypedComponentActionBase &rhs) const noexcept;
+  SEL selector() const noexcept;
+  std::string identifier() const noexcept;
 };
 
 #pragma mark - Typed Helpers
@@ -84,28 +84,28 @@ template <typename... TS>
 struct CKTypedComponentActionDenyType : std::true_type {};
 
 /** Base case, recursion should stop here. */
-void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list);
+void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<> &list) noexcept;
 
 /**
  Recursion through variadic argument type unpacking. This allows us to build a vector of encoded const char * before
  any actual arguments have been provided. All of this is done at compile-time.
  */
 template<typename T, typename... Ts>
-void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<T, Ts...> &list)
+void CKTypedComponentActionTypeVectorBuild(std::vector<const char *> &typeVector, const CKTypedComponentActionTypelist<T, Ts...> &list) noexcept
 {
   typeVector.push_back(@encode(T));
   CKTypedComponentActionTypeVectorBuild(typeVector, CKTypedComponentActionTypelist<Ts...>{});
 }
 
 /** Base case, recursion should stop here. */
-void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index);
+void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index) noexcept;
 
 /**
  Recursion here is through normal variadic argument list unpacking. Unlike above, we have the arguments, so we don't
  require the intermediary struct.
  */
 template <typename T, typename... Ts>
-void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index, T t, Ts... args)
+void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger index, T t, Ts... args) noexcept
 {
   // We have to be able to handle methods that take less than the provided number of arguments, since that will cause
   // an exception to be thrown.
@@ -117,15 +117,15 @@ void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger inde
 
 #pragma mark - Debug Helpers
 
-void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings);
+void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings) noexcept;
 
-void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings);
+void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings) noexcept;
 
-NSString *_CKComponentResponderChainDebugResponderChain(id responder);
+NSString *_CKComponentResponderChainDebugResponderChain(id responder) noexcept;
 
 #pragma mark - Sending
 
-NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender);
+NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender) noexcept;
 
 template<typename... T>
 static void CKComponentActionSendResponderChain(SEL selector, id target, CKComponent *sender, T... args) {

--- a/ComponentKit/Utilities/CKComponentDelegateAttribute.h
+++ b/ComponentKit/Utilities/CKComponentDelegateAttribute.h
@@ -35,4 +35,4 @@
 
  */
 CKComponentViewAttributeValue CKComponentDelegateAttribute(SEL delegatePropertySelector,
-                                                           CKComponentForwardedSelectors selectors);
+                                                           CKComponentForwardedSelectors selectors) noexcept;

--- a/ComponentKit/Utilities/CKComponentDelegateAttribute.mm
+++ b/ComponentKit/Utilities/CKComponentDelegateAttribute.mm
@@ -24,7 +24,7 @@
 @end
 
 CKComponentViewAttributeValue CKComponentDelegateAttribute(SEL selector,
-                                                           CKComponentForwardedSelectors selectors)
+                                                           CKComponentForwardedSelectors selectors) noexcept
 {
   if (selector == NULL) {
     return {

--- a/ComponentKit/Utilities/CKInternalHelpers.h
+++ b/ComponentKit/Utilities/CKInternalHelpers.h
@@ -12,16 +12,16 @@
 
 #import <UIKit/UIKit.h>
 
-BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector);
+BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector) noexcept;
 
-Class CKComponentControllerClassFromComponentClass(Class componentClass);
+Class CKComponentControllerClassFromComponentClass(Class componentClass) noexcept;
 
-std::string CKStringFromPointer(const void *ptr);
+std::string CKStringFromPointer(const void *ptr) noexcept;
 
-CGFloat CKScreenScale();
+CGFloat CKScreenScale() noexcept;
 
-CGFloat CKFloorPixelValue(CGFloat f);
+CGFloat CKFloorPixelValue(CGFloat f) noexcept;
 
-CGFloat CKCeilPixelValue(CGFloat f);
+CGFloat CKCeilPixelValue(CGFloat f) noexcept;
 
-CGFloat CKRoundPixelValue(CGFloat f);
+CGFloat CKRoundPixelValue(CGFloat f) noexcept;

--- a/ComponentKit/Utilities/CKInternalHelpers.mm
+++ b/ComponentKit/Utilities/CKInternalHelpers.mm
@@ -21,7 +21,7 @@
 #import "CKComponentSubclass.h"
 #import "CKMutex.h"
 
-BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
+BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector) noexcept
 {
   Method superclassMethod = class_getInstanceMethod(superclass, selector);
   Method subclassMethod = class_getInstanceMethod(subclass, selector);
@@ -30,7 +30,7 @@ BOOL CKSubclassOverridesSelector(Class superclass, Class subclass, SEL selector)
   return (superclassIMP != subclassIMP);
 }
 
-Class CKComponentControllerClassFromComponentClass(Class componentClass)
+Class CKComponentControllerClassFromComponentClass(Class componentClass) noexcept
 {
   if (componentClass == [CKComponent class]) {
     return Nil; // Don't create root CKComponentControllers as it does nothing interesting.
@@ -57,14 +57,14 @@ Class CKComponentControllerClassFromComponentClass(Class componentClass)
   return it->second;
 }
 
-std::string CKStringFromPointer(const void *ptr)
+std::string CKStringFromPointer(const void *ptr) noexcept
 {
   char buf[64];
   snprintf(buf, sizeof(buf), "%p", ptr);
   return buf;
 }
 
-CGFloat CKScreenScale()
+CGFloat CKScreenScale() noexcept
 {
   static CGFloat _scale;
   static dispatch_once_t onceToken;
@@ -74,17 +74,17 @@ CGFloat CKScreenScale()
   return _scale;
 }
 
-CGFloat CKFloorPixelValue(CGFloat f)
+CGFloat CKFloorPixelValue(CGFloat f) noexcept
 {
   return floorf(f * CKScreenScale()) / CKScreenScale();
 }
 
-CGFloat CKCeilPixelValue(CGFloat f)
+CGFloat CKCeilPixelValue(CGFloat f) noexcept
 {
   return ceilf(f * CKScreenScale()) / CKScreenScale();
 }
 
-CGFloat CKRoundPixelValue(CGFloat f)
+CGFloat CKRoundPixelValue(CGFloat f) noexcept
 {
   return roundf(f * CKScreenScale()) / CKScreenScale();
 }


### PR DESCRIPTION
From the first diff in the stack:

Presents a guarantee to the compiler that these functions will not
throw. For reviewers' reference, the consequence of violating a
`noexcept` specification is that `std::terminate` is called.

`NSAssert` seems to throw on error, and `CKAssert` wraps `NSAssert`,
so I considered using `noexcept(!CK_ASSERTIONS_ENABLED)` on those
functions that use `CKAssert`. However, local testing revealed that
`NSAssert` failure in a `noexcept` function doesn't result in an
unusable exception backtrace, at least on Mac. (It doesn't seem to
change the exception crash message at all.)

I did a profile build of WildeGuess for simulator (having difficulty
building for device right now) and observed a 1.4% code size
improvement with this diff, which seems to support my hypothesis that
these `noexcept` specifications provide additional optimization
opportunities.