### PR TITLE
Explicitly instantiate some commonly used templates.

### DIFF
--- a/ComponentKit/Core/CKComponentViewAttribute.h
+++ b/ComponentKit/Core/CKComponentViewAttribute.h
@@ -100,7 +100,7 @@ struct CKBoxedValue {
   CKBoxedValue(double v) noexcept : __actual(@(v)) {};
   CKBoxedValue(SEL v) noexcept : __actual([NSValue valueWithPointer:v]) {};
   CKBoxedValue(std::nullptr_t v) noexcept : __actual(nil) {};
-  
+
   // Any objects go here
   CKBoxedValue(id obj) noexcept : __actual(obj) {};
 
@@ -109,7 +109,7 @@ struct CKBoxedValue {
   CKBoxedValue(CGPoint v) noexcept : __actual([NSValue valueWithCGPoint:v]) {};
   CKBoxedValue(CGSize v) noexcept : __actual([NSValue valueWithCGSize:v]) {};
   CKBoxedValue(UIEdgeInsets v) noexcept : __actual([NSValue valueWithUIEdgeInsets:v]) {};
-  
+
   operator id () const {
     return __actual;
   };
@@ -154,5 +154,8 @@ namespace std {
       return CKHash64ToNative(hash);
     }
   };
-  
+
 }
+
+// Explicitly instantiate this CKViewComponentAttributeValueMap to improve compile time.
+extern template class std::unordered_map<CKComponentViewAttribute, CKBoxedValue>;

--- a/ComponentKit/Core/CKComponentViewAttribute.mm
+++ b/ComponentKit/Core/CKComponentViewAttribute.mm
@@ -219,3 +219,5 @@ CKComponentViewAttribute CKComponentViewAttribute::LayerAttribute(SEL setter) no
     performSetter(view.layer, setter, value);
   });
 }
+
+template class std::unordered_map<CKComponentViewAttribute, CKBoxedValue>;

--- a/ComponentKit/LayoutComponents/CKStackLayoutComponent.h
+++ b/ComponentKit/LayoutComponents/CKStackLayoutComponent.h
@@ -95,6 +95,8 @@ struct CKStackLayoutComponentChild {
   CKStackLayoutAlignSelf alignSelf;
 };
 
+extern template class std::vector<CKStackLayoutComponentChild>;
+
 /**
  A simple layout component that stacks a list of children vertically or horizontally.
 

--- a/ComponentKit/LayoutComponents/CKStackLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKStackLayoutComponent.mm
@@ -20,6 +20,8 @@
 #import "CKStackPositionedLayout.h"
 #import "CKStackUnpositionedLayout.h"
 
+template class std::vector<CKStackLayoutComponentChild>;
+
 @implementation CKStackLayoutComponent
 {
   CKStackLayoutComponentStyle _style;


### PR DESCRIPTION
Doing so prevents instantiations of methods of these templates in every
compilation unit that use them.

These templates were picked empirically based on statistics of which
symbols are duplicated across object files. This reduces the size of
generated static library archives in a large app by 3.6%.

One can examine duplicate symbols in object files by doing something like this:

```
find buck-out/gen -name '*.a' | xargs -L1 objdump -t | grep ' gw ' | grep '__TEXT,__text' | c++filt | cut -f2 |  sort | uniq -c | sort -n
```