### PR TITLE
Fix logic flaw in CKCollectionViewTransactionalDataSource

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		03B8B5291D2A346F00EDFF59 /* CKStaticLayoutComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B581CBD926700BB33CE /* CKStaticLayoutComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03B8B52A1D2A346F00EDFF59 /* CKComponentAccessibility_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47AC61CBD926700BB33CE /* CKComponentAccessibility_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03B8B52B1D2A346F00EDFF59 /* CKComponentBoundsAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47ADA1CBD926700BB33CE /* CKComponentBoundsAnimation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		03B8B52C1D2A346F00EDFF59 /* CKCollectionViewDataSourceCell.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B111CBD926700BB33CE /* CKCollectionViewDataSourceCell.h */; };
+		03B8B52C1D2A346F00EDFF59 /* CKCollectionViewDataSourceCell.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B111CBD926700BB33CE /* CKCollectionViewDataSourceCell.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03B8B52D1D2A346F00EDFF59 /* CKComponentDataSourceAttachController.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B221CBD926700BB33CE /* CKComponentDataSourceAttachController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		03B8B52E1D2A346F00EDFF59 /* CKButtonComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47ACD1CBD926700BB33CE /* CKButtonComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03B8B52F1D2A346F00EDFF59 /* CKComponentDelegateForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B8C1CBD926700BB33CE /* CKComponentDelegateForwarder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -510,7 +510,7 @@
 		D0B47D0E1CBD948E00BB33CE /* CKComponentScopeRootInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B0A1CBD926700BB33CE /* CKComponentScopeRootInternal.h */; };
 		D0B47D0F1CBD948E00BB33CE /* CKComponentScopeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B0B1CBD926700BB33CE /* CKComponentScopeTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D0B47D101CBD948E00BB33CE /* CKThreadLocalComponentScope.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B0C1CBD926700BB33CE /* CKThreadLocalComponentScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D0B47D121CBD948E00BB33CE /* CKCollectionViewDataSourceCell.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B111CBD926700BB33CE /* CKCollectionViewDataSourceCell.h */; };
+		D0B47D121CBD948E00BB33CE /* CKCollectionViewDataSourceCell.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B111CBD926700BB33CE /* CKCollectionViewDataSourceCell.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D0B47D131CBD948E00BB33CE /* CKCollectionViewTransactionalDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B131CBD926700BB33CE /* CKCollectionViewTransactionalDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0B47D141CBD948E00BB33CE /* CKComponentBoundsAnimation+UICollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B151CBD926700BB33CE /* CKComponentBoundsAnimation+UICollectionView.h */; };
 		D0B47D151CBD948E00BB33CE /* CKSupplementaryViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D0B47B171CBD926700BB33CE /* CKSupplementaryViewDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };

--- a/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewTransactionalDataSource.mm
@@ -71,12 +71,14 @@ CKTransactionalComponentDataSourceListener
 static void applyChangesToCollectionView(UICollectionView *collectionView,
                                          CKComponentDataSourceAttachController *attachController,
                                          NSMapTable<UICollectionViewCell *, CKTransactionalComponentDataSourceItem *> *cellToItemMap,
-                                         CKTransactionalComponentDataSourceState *currentState,
+                                         CKTransactionalComponentDataSourceState *state,
                                          CKTransactionalComponentDataSourceAppliedChanges *changes)
 {
-  [changes.updatedIndexPaths enumerateObjectsUsingBlock:^(NSIndexPath *indexPath, BOOL *stop) {
-    if (CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *) [collectionView cellForItemAtIndexPath:indexPath]) {
-      attachToCell(cell, [currentState objectAtIndexPath:indexPath], attachController, cellToItemMap);
+  NSDictionary<NSIndexPath *, NSIndexPath *> *mapping = CKComputeFinalUpdatedIndexPathsForAppliedChanges(changes);
+  [mapping enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPathBeforeUpdate, NSIndexPath *indexPathAfterUpdate, BOOL *stop) {
+    CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *)[collectionView cellForItemAtIndexPath:indexPathBeforeUpdate];
+    if (cell) {
+      attachToCell(cell, [state objectAtIndexPath:indexPathAfterUpdate], attachController, cellToItemMap);
     }
   }];
   [collectionView deleteItemsAtIndexPaths:[changes.removedIndexPaths allObjects]];

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachController.mm
@@ -11,7 +11,6 @@
 #import <objc/runtime.h>
 #import "CKComponentInternal.h"
 
-#import "CKComponentDataSourceAttachController.h"
 #import "CKComponentDataSourceAttachControllerInternal.h"
 
 @implementation CKComponentDataSourceAttachController

--- a/ComponentKit/DataSources/Common/CKComponentDataSourceAttachControllerInternal.h
+++ b/ComponentKit/DataSources/Common/CKComponentDataSourceAttachControllerInternal.h
@@ -8,7 +8,9 @@
  *
  */
 
-#import <Foundation/Foundation.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentScopeTypes.h>
+#import <ComponentKit/CKComponentDataSourceAttachController.h>
 
 /** This is exposed for unit tests. */
 @interface CKComponentDataSourceAttachState : NSObject

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceAppliedChanges.h
@@ -33,3 +33,5 @@
                                  userInfo:(NSDictionary *)userInfo NS_DESIGNATED_INITIALIZER;
 
 @end
+
+extern NSDictionary<NSIndexPath *, NSIndexPath *> *CKComputeFinalUpdatedIndexPathsForAppliedChanges(CKTransactionalComponentDataSourceAppliedChanges *changes);

--- a/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKCollectionViewTransactionalDataSourceTests.mm
@@ -14,35 +14,88 @@
 
 #import <ComponentKit/CKCollectionViewTransactionalDataSource.h>
 #import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
+#import <ComponentKit/CKTransactionalComponentDataSourceChangeset.h>
 #import <ComponentKit/CKSupplementaryViewDataSource.h>
-#import <ComponentKit/CKSizeRange.h>
+#import <ComponentKit/CKCollectionViewDataSourceCell.h>
+#import <ComponentKit/CKComponentDataSourceAttachControllerInternal.h>
+#import <ComponentKit/CKComponentRootView.h>
+#import <ComponentKit/CKComponentProvider.h>
+#import <ComponentKit/CKComponent.h>
+
+#import "CKTransactionalComponentDataSourceStateTestHelpers.h"
+
+@interface CKTestModelComponent : CKComponent
+@property (nonatomic, strong, readonly) id<NSObject> model;
++ (instancetype)newWithModel:(id<NSObject>)context;
+@end
+
+@implementation CKTestModelComponent
+
++ (instancetype)newWithModel:(id<NSObject>)model
+{
+  CKTestModelComponent *c = [super newWithView:{} size:{}];
+  if (c) {
+    c->_model = model;
+  }
+  return c;
+}
+
+@end
+
+static id<NSObject> CKMountedModelAtIndexPath(UICollectionView *collectionView, NSIndexPath *indexPath)
+{
+  CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *)[collectionView cellForItemAtIndexPath:indexPath];
+  CKComponentDataSourceAttachState *attachState = cell.rootView.ck_attachState;
+  if (!attachState)
+    return nil;
+  
+  return [(CKTestModelComponent *)attachState.layout.component model];
+}
 
 @interface CKCollectionViewTransactionalDataSource () <UICollectionViewDataSource>
 @end
 
-@interface CKCollectionViewTransactionalDataSourceTests : XCTestCase
+@interface CKCollectionViewTransactionalDataSourceTests : XCTestCase <CKComponentProvider>
 @property (strong) CKCollectionViewTransactionalDataSource *dataSource;
-@property (strong) id mockCollectionView;
+@property (strong) UICollectionView *collectionView;
 @property (strong) id mockSupplementaryViewDataSource;
 @end
 
 @implementation CKCollectionViewTransactionalDataSourceTests
 
-- (void)setUp {
-  [super setUp];
++ (CKComponent *)componentForModel:(id<NSObject>)model context:(id<NSObject>)context
+{
+  return [CKTestModelComponent newWithModel:model];
+}
 
+- (void)setUp
+{
+  [super setUp];
+  
+  UICollectionViewFlowLayout *collectionViewLayout = [UICollectionViewFlowLayout new];
+  self.collectionView = [[UICollectionView alloc] initWithFrame:{0, 0, 100, 1000} collectionViewLayout:collectionViewLayout];
+  
   self.mockSupplementaryViewDataSource = [OCMockObject mockForProtocol:@protocol(CKSupplementaryViewDataSource)];
-  self.mockCollectionView = [OCMockObject niceMockForClass:[UICollectionView class]];
 
   CKTransactionalComponentDataSourceConfiguration *config = [[CKTransactionalComponentDataSourceConfiguration alloc]
-                                                             initWithComponentProvider:nil
+                                                             initWithComponentProvider:[self class]
                                                              context:nil
-                                                             sizeRange:CKSizeRange()];
+                                                             sizeRange:{{100, 10}, {100, 10}}];
 
   self.dataSource = [[CKCollectionViewTransactionalDataSource alloc]
-                     initWithCollectionView:self.mockCollectionView
+                     initWithCollectionView:self.collectionView
                      supplementaryViewDataSource:self.mockSupplementaryViewDataSource
                      configuration:config];
+  
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withInsertedSections:[NSIndexSet indexSetWithIndex:0]]
+    withInsertedItems:@{[NSIndexPath indexPathForItem:0 inSection:0]: @0,
+                        [NSIndexPath indexPathForItem:1 inSection:0]: @1,
+                        [NSIndexPath indexPathForItem:2 inSection:0]: @2}]
+   build];
+  
+  [self.dataSource applyChangeset:changeset mode:CKUpdateModeSynchronous userInfo:nil];
 }
 
 - (void)testSupplementaryViewDataSource
@@ -50,8 +103,22 @@
   NSIndexPath *indexPath = [NSIndexPath indexPathForItem:3 inSection:4];
   NSString *viewKind = @"foo";
   
-  [[self.mockSupplementaryViewDataSource expect] collectionView:self.mockCollectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
-  [self.dataSource collectionView:self.mockCollectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+  [[self.mockSupplementaryViewDataSource expect] collectionView:self.collectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+  [self.dataSource collectionView:self.collectionView viewForSupplementaryElementOfKind:viewKind atIndexPath:indexPath];
+}
+
+- (void)testRemovingAndUpdatingSimultaneously
+{
+  NSIndexPath *firstIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withUpdatedItems:@{[NSIndexPath indexPathForItem:1 inSection:0]: @"updated"}]
+    withRemovedItems:[NSSet setWithObject:firstIndexPath]]
+   build];
+  
+  [self.dataSource applyChangeset:changeset mode:CKUpdateModeSynchronous userInfo:nil];
+  
+  XCTAssertEqualObjects(CKMountedModelAtIndexPath(self.collectionView, firstIndexPath), @"updated");
 }
 
 @end


### PR DESCRIPTION
If a changeset was applied with an update and a remove positioned before that update, the wrong components would be mounted on the cells. I'm actually surprised that this bug has existed for so long!

I wrote a fix for it and an associated test that now passes. `CKCollectionViewTransactionalDataSourceTests` currently punches a hole through the test coverage...

I'm not sure if my proposed fix is the best one, but it works. I can write tests for `-newIndexPathForPreviousIndexPath:` if we decide to go with it , but I am also open to better suggestions 😄 