### PR TITLE
Avoid inline construction of vector in parameter lists

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -376,6 +376,8 @@
 		B761C8AE1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B761C8AD1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm */; };
 		B761C8B11CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B761C8B01CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm */; };
 		B7E2E59F1D077098002A4442 /* CKVectorHelperTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = B7E2E59E1D077098002A4442 /* CKVectorHelperTests.mm */; };
+		CDCC9DD41E568C2C0005D52E /* CKContainerWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = CDCC9DD31E568C2C0005D52E /* CKContainerWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CDCC9DD51E568C4B0005D52E /* CKContainerWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = CDCC9DD31E568C2C0005D52E /* CKContainerWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D000B81D1CC45427005A27CF /* OCMock.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D04977E31CC4145E0046CBCC /* OCMock.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D000B81E1CC45440005A27CF /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D000B8101CC41535005A27CF /* FBSnapshotTestCase.framework */; };
 		D000B81F1CC45446005A27CF /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D000B8101CC41535005A27CF /* FBSnapshotTestCase.framework */; };
@@ -873,6 +875,7 @@
 		B761C8AD1CB36BF700CDD03F /* CKTransactionalComponentDataSourceChangesetTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceChangesetTests.mm; sourceTree = "<group>"; };
 		B761C8B01CB36FA200CDD03F /* CKTransactionalComponentDataSourceAppliedChangesTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTransactionalComponentDataSourceAppliedChangesTests.mm; sourceTree = "<group>"; };
 		B7E2E59E1D077098002A4442 /* CKVectorHelperTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKVectorHelperTests.mm; sourceTree = "<group>"; };
+		CDCC9DD31E568C2C0005D52E /* CKContainerWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKContainerWrapper.h; sourceTree = "<group>"; };
 		D000B8081CC4152A005A27CF /* FBSnapshotTestCase.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FBSnapshotTestCase.xcodeproj; path = "Carthage/Checkouts/ios-snapshot-test-case/FBSnapshotTestCase.xcodeproj"; sourceTree = SOURCE_ROOT; };
 		D023D12D1E242CD4004A0A61 /* CKComponentAccessibilityCustomActionsAttributeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentAccessibilityCustomActionsAttributeTests.mm; sourceTree = "<group>"; tabWidth = 2; };
 		D04977D11CC4145E0046CBCC /* OCMock.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCMock.xcodeproj; path = Carthage/Checkouts/ocmock/Source/OCMock.xcodeproj; sourceTree = SOURCE_ROOT; };
@@ -1694,6 +1697,7 @@
 				D0B47B8E1CBD926700BB33CE /* CKComponentGestureActions.h */,
 				D0B47B8F1CBD926700BB33CE /* CKComponentGestureActions.mm */,
 				D0B47B901CBD926700BB33CE /* CKComponentGestureActionsInternal.h */,
+				CDCC9DD31E568C2C0005D52E /* CKContainerWrapper.h */,
 				D0B47B911CBD926700BB33CE /* CKEqualityHashHelpers.h */,
 				D0B47B921CBD926700BB33CE /* CKEqualityHashHelpers.mm */,
 				D0B47B931CBD926700BB33CE /* CKInternalHelpers.h */,
@@ -1967,6 +1971,7 @@
 				03B8B55E1D2A346F00EDFF59 /* CKTextKitEntityAttribute.h in Headers */,
 				03B8B55F1D2A346F00EDFF59 /* CKAsyncLayerSubclass.h in Headers */,
 				03B8B5601D2A346F00EDFF59 /* CKComponentDebugController.h in Headers */,
+				CDCC9DD51E568C4B0005D52E /* CKContainerWrapper.h in Headers */,
 				03B8B5621D2A346F00EDFF59 /* CKTextComponentViewControlTracker.h in Headers */,
 				03B8B5631D2A346F00EDFF59 /* ComponentLayoutContext.h in Headers */,
 				03B8B5641D2A346F00EDFF59 /* CKCompositeComponent.h in Headers */,
@@ -2029,6 +2034,7 @@
 				D0B47D481CBD948E00BB33CE /* CKTransactionalComponentDataSourceState.h in Headers */,
 				D0B47D461CBD948E00BB33CE /* CKTransactionalComponentDataSourceListener.h in Headers */,
 				D0B47D3E1CBD948E00BB33CE /* CKTransactionalComponentDataSource.h in Headers */,
+				CDCC9DD41E568C2C0005D52E /* CKContainerWrapper.h in Headers */,
 				D0B47D471CBD948E00BB33CE /* CKTransactionalComponentDataSourceListenerAnnouncer.h in Headers */,
 				D0B47D441CBD948E00BB33CE /* CKTransactionalComponentDataSourceItem.h in Headers */,
 				D0B47D491CBD948E00BB33CE /* CKTransactionalComponentDataSourceStateInternal.h in Headers */,

--- a/ComponentKit/ComponentKit.h
+++ b/ComponentKit/ComponentKit.h
@@ -53,6 +53,7 @@
 #import <ComponentKit/CKComponentAction.h>
 #import <ComponentKit/CKComponentContext.h>
 #import <ComponentKit/CKComponentGestureActions.h>
+#import <ComponentKit/CKContainerWrapper.h>
 #import <ComponentKit/CKOptimisticViewMutations.h>
 #import <ComponentKit/CKComponentDelegateAttribute.h>
 //Text

--- a/ComponentKit/Components/CKButtonComponent.h
+++ b/ComponentKit/Components/CKButtonComponent.h
@@ -12,6 +12,7 @@
 
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentAction.h>
+#import <ComponentKit/CKContainerWrapper.h>
 
 struct CKButtonComponentAccessibilityConfiguration {
   /** Accessibility label for the button. If one is not provided, the button title will be used as a label */
@@ -26,10 +27,10 @@ struct CKButtonComponentAccessibilityConfiguration {
  */
 @interface CKButtonComponent : CKComponent
 
-+ (instancetype)newWithTitles:(const std::unordered_map<UIControlState, NSString *> &)titles
-                  titleColors:(const std::unordered_map<UIControlState, UIColor *> &)titleColors
-                       images:(const std::unordered_map<UIControlState, UIImage *> &)images
-             backgroundImages:(const std::unordered_map<UIControlState, UIImage *> &)backgroundImages
++ (instancetype)newWithTitles:(CKContainerWrapper<std::unordered_map<UIControlState, NSString *>> &&)titles
+                  titleColors:(CKContainerWrapper<std::unordered_map<UIControlState, UIColor *>> &&)titleColors
+                       images:(CKContainerWrapper<std::unordered_map<UIControlState, UIImage *>> &&)images
+             backgroundImages:(CKContainerWrapper<std::unordered_map<UIControlState, UIImage *>> &&)backgroundImages
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -83,10 +83,10 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
   CGSize _intrinsicSize;
 }
 
-+ (instancetype)newWithTitles:(const std::unordered_map<UIControlState, NSString *> &)titles
-                  titleColors:(const std::unordered_map<UIControlState, UIColor *> &)titleColors
-                       images:(const std::unordered_map<UIControlState, UIImage *> &)images
-             backgroundImages:(const std::unordered_map<UIControlState, UIImage *> &)backgroundImages
++ (instancetype)newWithTitles:(CKContainerWrapper<std::unordered_map<UIControlState, NSString *>> &&)titlesParam
+                  titleColors:(CKContainerWrapper<std::unordered_map<UIControlState, UIColor *>> &&)titleColorsParam
+                       images:(CKContainerWrapper<std::unordered_map<UIControlState, UIImage *>> &&)imagesParam
+             backgroundImages:(CKContainerWrapper<std::unordered_map<UIControlState, UIImage *>> &&)backgroundImagesParam
                     titleFont:(UIFont *)titleFont
                      selected:(BOOL)selected
                       enabled:(BOOL)enabled
@@ -95,6 +95,10 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                    attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
    accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration
 {
+  const auto titles = titlesParam.take();
+  const auto titleColors = titleColorsParam.take();
+  const auto images = imagesParam.take();
+  const auto backgroundImages = backgroundImagesParam.take();
   static const CKComponentViewAttribute titleFontAttribute = {"CKButtonComponent.titleFont", ^(UIButton *button, id value){
     button.titleLabel.font = value;
   }};

--- a/ComponentKit/Core/CKComponentViewConfiguration.h
+++ b/ComponentKit/Core/CKComponentViewConfiguration.h
@@ -18,6 +18,8 @@
 #import <ComponentKit/ComponentViewReuseUtilities.h>
 #import <ComponentKit/CKComponentAccessibility.h>
 #import <ComponentKit/CKComponentViewAttribute.h>
+#import <ComponentKit/CKContainerWrapper.h>
+
 
 class CKComponentDebugConfiguration;
 
@@ -101,10 +103,10 @@ struct CKComponentViewConfiguration {
   CKComponentViewConfiguration() noexcept;
 
   CKComponentViewConfiguration(CKComponentViewClass &&cls,
-                               CKViewComponentAttributeValueMap &&attrs = {}) noexcept;
+                               CKContainerWrapper<CKViewComponentAttributeValueMap> &&attrs = {}) noexcept;
 
   CKComponentViewConfiguration(CKComponentViewClass &&cls,
-                               CKViewComponentAttributeValueMap &&attrs,
+                               CKContainerWrapper<CKViewComponentAttributeValueMap> &&attrs,
                                CKComponentAccessibilityContext &&accessibilityCtx) noexcept;
 
   ~CKComponentViewConfiguration();
@@ -134,4 +136,3 @@ namespace std {
     size_t operator()(const CKComponentViewConfiguration &cl) const noexcept;
   };
 }
-

--- a/ComponentKit/Core/CKComponentViewConfiguration.mm
+++ b/ComponentKit/Core/CKComponentViewConfiguration.mm
@@ -73,18 +73,19 @@ CKComponentViewConfiguration::CKComponentViewConfiguration() noexcept
 // the compiler must insert initialization of each default value inline at the callsite.
 CKComponentViewConfiguration::CKComponentViewConfiguration(
     CKComponentViewClass &&cls,
-    CKViewComponentAttributeValueMap &&attrs) noexcept
+    CKContainerWrapper<CKViewComponentAttributeValueMap> &&attrs) noexcept
 : CKComponentViewConfiguration(std::move(cls), std::move(attrs), {}) {}
 
 CKComponentViewConfiguration::CKComponentViewConfiguration(CKComponentViewClass &&cls,
-                                                           CKViewComponentAttributeValueMap &&attrs,
+                                                           CKContainerWrapper<CKViewComponentAttributeValueMap> &&attrs,
                                                            CKComponentAccessibilityContext &&accessibilityCtx) noexcept
 {
   // Need to use attrs before we move it below.
-  CK::Component::PersistentAttributeShape attributeShape(attrs);
+  CKViewComponentAttributeValueMap attrsMap = attrs.take();
+  CK::Component::PersistentAttributeShape attributeShape(attrsMap);
   rep.reset(new Repr({
     .viewClass = std::move(cls),
-    .attributes = std::make_shared<CKViewComponentAttributeValueMap>(std::move(attrs)),
+    .attributes = std::make_shared<CKViewComponentAttributeValueMap>(std::move(attrsMap)),
     .accessibilityContext = std::move(accessibilityCtx),
     .attributeShape = std::move(attributeShape)}));
 }

--- a/ComponentKit/LayoutComponents/CKStackLayoutComponent.h
+++ b/ComponentKit/LayoutComponents/CKStackLayoutComponent.h
@@ -11,6 +11,7 @@
 #import <vector>
 
 #import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKContainerWrapper.h>
 
 typedef NS_ENUM(NSUInteger, CKStackLayoutDirection) {
   CKStackLayoutDirectionVertical,
@@ -128,6 +129,6 @@ extern template class std::vector<CKStackLayoutComponentChild>;
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view
                        size:(const CKComponentSize &)size
                       style:(const CKStackLayoutComponentStyle &)style
-                   children:(const std::vector<CKStackLayoutComponentChild> &)children;
+                   children:(CKContainerWrapper<std::vector<CKStackLayoutComponentChild>> &&)children;
 
 @end

--- a/ComponentKit/LayoutComponents/CKStackLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKStackLayoutComponent.mm
@@ -31,12 +31,12 @@ template class std::vector<CKStackLayoutComponentChild>;
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view
                        size:(const CKComponentSize &)size
                       style:(const CKStackLayoutComponentStyle &)style
-                   children:(const std::vector<CKStackLayoutComponentChild> &)children
+                   children:(CKContainerWrapper<std::vector<CKStackLayoutComponentChild>> &&)children
 {
   CKStackLayoutComponent *c = [super newWithView:view size:size];
   if (c) {
     c->_style = style;
-    c->_children = children;
+    c->_children = children.take();
   }
   return c;
 }

--- a/ComponentKit/LayoutComponents/CKStaticLayoutComponent.h
+++ b/ComponentKit/LayoutComponents/CKStaticLayoutComponent.h
@@ -8,11 +8,10 @@
  *
  */
 
-#import <vector>
-
 #import <Foundation/Foundation.h>
 
 #import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKContainerWrapper.h>
 #import <ComponentKit/CKDimension.h>
 
 struct CKStaticLayoutComponentChild {
@@ -42,11 +41,11 @@ struct CKStaticLayoutComponentChild {
  */
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view
                        size:(const CKComponentSize &)size
-                   children:(const std::vector<CKStaticLayoutComponentChild> &)children;
+                   children:(CKContainerWrapper<std::vector<CKStaticLayoutComponentChild>> &&)children;
 
 /**
  Convenience that does not have a view or size.
  */
-+ (instancetype)newWithChildren:(const std::vector<CKStaticLayoutComponentChild> &)children;
++ (instancetype)newWithChildren:(CKContainerWrapper<std::vector<CKStaticLayoutComponentChild>> &&)children;
 
 @end

--- a/ComponentKit/LayoutComponents/CKStaticLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKStaticLayoutComponent.mm
@@ -20,18 +20,18 @@
 
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view
                        size:(const CKComponentSize &)size
-                   children:(const std::vector<CKStaticLayoutComponentChild> &)children
+                   children:(CKContainerWrapper<std::vector<CKStaticLayoutComponentChild>> &&)children
 {
   CKStaticLayoutComponent *c = [super newWithView:view size:size];
   if (c) {
-    c->_children = children;
+    c->_children = children.take();
   }
   return c;
 }
 
-+ (instancetype)newWithChildren:(const std::vector<CKStaticLayoutComponentChild> &)children
++ (instancetype)newWithChildren:(CKContainerWrapper<std::vector<CKStaticLayoutComponentChild>> &&)children
 {
-  return [self newWithView:{} size:{} children:children];
+  return [self newWithView:{} size:{} children:std::move(children)];
 }
 
 - (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize

--- a/ComponentKit/Utilities/CKContainerWrapper.h
+++ b/ComponentKit/Utilities/CKContainerWrapper.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <initializer_list>
+#include <vector>
+#include <unordered_map>
+
+/**
+ * Helper class that's useful for function parameters that's likely to take
+ * initializer lists as input. It prevents inlined vector construction.
+ *
+ * For a function of the form: `foo(const std::vector<int> &)`,
+ *   invoked with an initializer list: `foo({1,2,3})`,
+ *   code is generated to construct and destroy a vector from that initializer
+ *   list, usually inlined into the body of the function.
+ * For a function of the form: `foo(CKContainerWrapper<std::vector<int>> &&)`,
+ *   invoked with an initializer list: `foo({1,2,3})`,
+ *   the vector constructor and destructor are not inlined. This lack of
+ *   inlining helps reduce the size of the compiled output.
+ *
+ * Additionally, this type allows vector to be moved in, as if the parameter
+ *   has a rvalue-reference overload (e.g. `foo(std::vector<int> &&)`). In ObjC++
+ *   methods, where overloads are not allowed, this gives the benefit of a
+ *   rvalue-reference overload at the cost of an additional move operation.
+ */
+template<class Container>
+class CKContainerWrapper {
+public:
+  CKContainerWrapper() {}
+  CKContainerWrapper(std::initializer_list<typename Container::value_type> items) : _container(items) {}
+  CKContainerWrapper(Container &&container) : _container(std::move(container)) {}
+  CKContainerWrapper(const Container &container) : _container(container) {}
+  CKContainerWrapper(const CKContainerWrapper<Container> &) = delete;
+  CKContainerWrapper(CKContainerWrapper<Container> &&) = default;
+  ~CKContainerWrapper() = default;
+  
+  Container take() { return std::move(_container); }
+  
+private:
+  Container _container;
+};


### PR DESCRIPTION
ComponentKit frequently uses Objective C++ methods that takes in lists as parameters. These parameters are usually declared as `const std::vector<Foo> &`. This is suboptimal for two reasons:

1. In cases where the parameters specified as an initializer list, this initializer list must be converted into a vector before being passed into this method. This incurs a (potentially inlined) vector construction and destruction operation that bloats the binary.
2. In cases where the parameter is passed in as a pre-constructed vector and stored, it must be copied due to the incoming vector being a mere const reference.

This change introduces `CKContainerWrapper`, which can be used as a drop-in replacement for methods which currently takes in `const vector<T> &`, but will not (in my testing at least) inline initializer-list to vector construction. It also allows a vector to be moved into the field, so that it can be later moved out, without declaring another method which takes `vector<T> &&` as a parameter.

Note that when used with maps, the unordered_map constructor is normally not inlined anyways, so this is less of a size win, but the argument for "free" move construction still applies.

Sample code generated using -Os for:
```
[CKStackLayoutComponent newWithView:... size:... style:... children:{item1, item2}
```

Before:
```
	xorpd	%xmm0, %xmm0
Ltmp184:
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/vector:432:7
	movapd	%xmm0, -624(%rbp)
	movq	$0, -608(%rbp)
Ltmp185:
	.## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/vector:1283:9
Ltmp68:
	leaq	-624(%rbp), %rdi
Ltmp186:
	##DEBUG_VALUE: vector:this <- %RDI
	##DEBUG_VALUE: vector:__il [bit_piece offset=64 size=64] <- 2
	movl	$2, %esi
	callq	std::__1::vector<CKStackLayoutComponentChild, std::__1::allocator<CKStackLayoutComponentChild> >::allocate(unsigned long)
Ltmp187:
Ltmp69:
## BB#33:
	leaq	-232(%rbp), %rbx
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/initializer_list:93:57
Ltmp188:
	leaq	-104(%rbp), %r12
Ltmp189:
	##DEBUG_VALUE: __construct_at_end<const CKStackLayoutComponentChild *>:__last <- %R12
	##DEBUG_VALUE: __construct_range_forward<const CKStackLayoutComponentChild *, CKStackLayoutComponentChild *>:__end1 <- %R12
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/memory:1586:56
	movq	-616(%rbp), %r14
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/memory:1501:57
Ltmp190:
	movq	%r14, %r15
Ltmp191:
LBB0_34:                                ## =>This Inner Loop Header: Depth=1
	##DEBUG_VALUE: construct<CKStackLayoutComponentChild, const CKStackLayoutComponentChild &>:__p <- %R15
	## buck-out/gen/VendorLib/ComponentKit/ComponentKit#headers,iphonesimulator-x86_64/ComponentKit/CKStackLayoutComponent.h:74:8
	movq	(%rbx), %rdi
	callq	*_objc_retain@GOTPCREL(%rip)
	movq	%rax, (%r15)
	movq	56(%rbx), %rax
	movq	%rax, 56(%r15)
	movq	48(%rbx), %rax
	movq	%rax, 48(%r15)
	movq	40(%rbx), %rax
	movq	%rax, 40(%r15)
	movq	32(%rbx), %rax
	movq	%rax, 32(%r15)
	movq	24(%rbx), %rax
	movq	%rax, 24(%r15)
	movq	8(%rbx), %rax
	movq	16(%rbx), %rcx
	movq	%rcx, 16(%r15)
	movq	%rax, 8(%r15)
Ltmp192:
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/memory:1585:29
	addq	$64, %rbx
Ltmp193:
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/memory:1585:13
	addq	$64, %r15
Ltmp194:
	cmpq	%r12, %rbx
	jne	LBB0_34
## BB#35:
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/memory:1586:56
Ltmp195:
	subq	$-128, %r14
	## APPLE_DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/char++/v1/memory:1585:59
	movq	%r14, -616(%rbp)
```

After:
```
Ltmp187:
	## buck-out/gen/VendorLib/ComponentKit/ComponentKit#headers,iphonesimulator-x86_64/ComponentKit/CKParam.h:30:98
Ltmp68:
	leaq	-616(%rbp), %rdi
Ltmp188:
	##DEBUG_VALUE: VectorParam:this <- %RDI
	##DEBUG_VALUE: VectorParam:items [bit_piece offset=64 size=64] <- 2
	leaq	-232(%rbp), %rsi
	movl	$2, %edx
	callq	CK::VectorParam<CKStackLayoutComponentChild>::VectorParam(std::initializer_list<CKStackLayoutComponentChild>)
```