### PR TITLE
[experimental] Introducing an enqueue state API

### DIFF
--- a/ComponentKit/Core/CKComponent.mm
+++ b/ComponentKit/Core/CKComponent.mm
@@ -300,8 +300,15 @@ static void *kRootComponentMountedViewKey = &kRootComponentMountedViewKey;
 - (void)updateState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode
 {
   CKAssertNotNil(_scopeHandle, @"A component without state cannot update its state.");
-  CKAssertNotNil(updateBlock, @"Cannot enqueue component state modification with a nil block.");
+  CKAssertNotNil(updateBlock, @"Cannot schedule component state modification with a nil update block.");
   [_scopeHandle updateState:updateBlock mode:mode];
+}
+
+- (void)enqueueState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode
+{
+  CKAssertNotNil(_scopeHandle, @"A component without state cannot update its state.");
+  CKAssertNotNil(updateBlock, @"Cannot enqueue component state modification with a nil update block.");
+  [_scopeHandle enqueueState:updateBlock mode:mode];
 }
 
 - (CKComponentController *)controller

--- a/ComponentKit/Core/CKComponentSubclass.h
+++ b/ComponentKit/Core/CKComponentSubclass.h
@@ -79,10 +79,9 @@ extern CGSize const kCKComponentParentSizeUndefined;
                       relativeToParentSize:(CGSize)parentSize;
 
 /**
- Enqueue a change to the state.
+ Schedule a change to the state.
 
- @param updateBlock A block that takes the current state as a parameter and returns an instance of the new state.
- The state *must* be immutable since components themselves are. A possible use might be:
+ The state must be immutable since components themselves are. A possible use might be:
 
    [self updateState:^MyState *(MyState *currentState) {
      MyMutableState *nextState = [currentState mutableCopy];
@@ -90,9 +89,20 @@ extern CGSize const kCKComponentParentSizeUndefined;
      return [nextState copy]; // immutable! :D
    }];
 
- @param mode @see CKUpdateMode
+ @param updateBlock A block that takes the current state as a parameter and returns an instance of the new state.
+ @param mode The update mode used to apply the state update.
+ @see CKUpdateMode
  */
 - (void)updateState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode;
+
+/**
+ Enqueue a change to the state without scheduling.
+
+ @param updateBlock A block that takes the current state as a parameter and returns an instance of the new state.
+ @param mode The update mode used to apply the state update.
+ @see CKUpdateMode
+ */
+- (void)enqueueState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode;
 
 /**
  Allows an action to be forwarded to another target. By default, returns the receiver if it implements action,

--- a/ComponentKit/Core/CKUpdateMode.h
+++ b/ComponentKit/Core/CKUpdateMode.h
@@ -10,7 +10,14 @@
 
 #import <Foundation/Foundation.h>
 
+/** The update mode is used to inform ComponentKit how to apply changes. */
 typedef NS_ENUM(NSUInteger, CKUpdateMode) {
+  /** Apply the update off the main thread. */
   CKUpdateModeAsynchronous,
+  /**
+   Apply the update on the main thread.
+   The synchronous update mode will not immediately block the executing thread when apply updates. Instead ComponentKit
+   will schedule the update to be performed on the next tick of the main thread's run loop.
+   */
   CKUpdateModeSynchronous,
 };

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -41,7 +41,15 @@
 /** Creates a new, but identical, instance of the scope handle that will be reacquired due to a scope collision. */
 - (instancetype)newHandleToBeReacquiredDueToScopeCollision;
 
-- (void)updateState:(id (^)(id))updateFunction mode:(CKUpdateMode)mode;
+/** Schedules a state update to be applied to the scope with the given mode. */
+- (void)updateState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode;
+
+/**
+ Enqueues a state update to be applied to the scope with the given mode.
+ State updates that are enqueued will not be immediately scheduled. Instead they will be delayed until a future state
+ update is scheduled.
+ */
+- (void)enqueueState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode;
 
 /** Informs the scope handle that it should complete its configuration. This will generate the controller */
 - (void)resolve;

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -121,18 +121,33 @@
 
 #pragma mark - State
 
-- (void)updateState:(id (^)(id))updateFunction mode:(CKUpdateMode)mode
+- (void)updateState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode
 {
-  CKAssertNotNil(updateFunction, @"The block for updating state cannot be nil");
+  CKAssertNotNil(updateBlock, @"The update block cannot be nil");
   if (![NSThread isMainThread]) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self updateState:updateFunction mode:mode];
+      [self updateState:updateBlock mode:mode];
     });
     return;
   }
   [_listener componentScopeHandleWithIdentifier:_globalIdentifier
                                  rootIdentifier:_rootIdentifier
-                          didReceiveStateUpdate:updateFunction
+             didReceiveStateUpdateToBeScheduled:updateBlock
+                                           mode:mode];
+}
+
+- (void)enqueueState:(id (^)(id))updateBlock mode:(CKUpdateMode)mode
+{
+  CKAssertNotNil(updateBlock, @"The update block cannot be nil");
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self enqueueState:updateBlock mode:mode];
+    });
+    return;
+  }
+  [_listener componentScopeHandleWithIdentifier:_globalIdentifier
+                                 rootIdentifier:_rootIdentifier
+              didReceiveStateUpdateToBeEnqueued:updateBlock
                                            mode:mode];
 }
 

--- a/ComponentKit/Core/Scope/CKComponentScopeRoot.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeRoot.h
@@ -23,12 +23,19 @@ typedef NS_ENUM(NSUInteger, CKComponentAnnouncedEvent) {
   CKComponentAnnouncedEventTreeDidDisappear,
 };
 
+/** Component state announcements will always be made on the main thread. */
 @protocol CKComponentStateListener <NSObject>
-/** Always sent on the main thread. */
+
 - (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
                             rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
-                     didReceiveStateUpdate:(id (^)(id))stateUpdate
+        didReceiveStateUpdateToBeScheduled:(id (^)(id))updateBlock
                                       mode:(CKUpdateMode)mode;
+
+- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
+                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
+         didReceiveStateUpdateToBeEnqueued:(id (^)(id))updateBlock
+                                      mode:(CKUpdateMode)mode;
+
 @end
 
 struct CKBuildComponentResult {

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -148,14 +148,23 @@ struct CKComponentHostingViewInputs {
 
 #pragma mark - CKComponentStateListener
 
-- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
-                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
-                     didReceiveStateUpdate:(id (^)(id))stateUpdate
+- (void)componentScopeHandleWithIdentifier:(int32_t)globalIdentifier
+                            rootIdentifier:(int32_t)rootIdentifier
+        didReceiveStateUpdateToBeScheduled:(id (^)(id))updateBlock
                                       mode:(CKUpdateMode)mode
 {
   CKAssertMainThread();
-  _pendingInputs.stateUpdates.insert({globalIdentifier, stateUpdate});
+  _pendingInputs.stateUpdates.insert({globalIdentifier, updateBlock});
   [self _setNeedsUpdateWithMode:mode];
+}
+
+- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
+                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
+         didReceiveStateUpdateToBeEnqueued:(id (^)(id))updateBlock
+                                      mode:(CKUpdateMode)mode
+{
+  CKAssertMainThread();
+  _pendingInputs.stateUpdates.insert({globalIdentifier, updateBlock});
 }
 
 #pragma mark - CKComponentDebugController

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -144,11 +144,11 @@
   [_announcer removeListener:listener];
 }
 
-#pragma mark - State Listener
+#pragma mark - CKComponentStateListener
 
-- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
-                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
-                     didReceiveStateUpdate:(id (^)(id))stateUpdate
+- (void)componentScopeHandleWithIdentifier:(int32_t)globalIdentifier
+                            rootIdentifier:(int32_t)rootIdentifier
+        didReceiveStateUpdateToBeScheduled:(id (^)(id))updateBlock
                                       mode:(CKUpdateMode)mode
 {
   CKAssertMainThread();
@@ -157,11 +157,23 @@
       [self _processStateUpdates];
     });
   }
-
   if (mode == CKUpdateModeAsynchronous) {
-    _pendingAsynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, stateUpdate});
+    _pendingAsynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, updateBlock});
   } else {
-    _pendingSynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, stateUpdate});
+    _pendingSynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, updateBlock});
+  }
+}
+
+- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
+                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
+         didReceiveStateUpdateToBeEnqueued:(id (^)(id))updateBlock
+                                      mode:(CKUpdateMode)mode
+{
+  CKAssertMainThread();
+  if (mode == CKUpdateModeAsynchronous) {
+    _pendingAsynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, updateBlock});
+  } else {
+    _pendingSynchronousStateUpdates[rootIdentifier].insert({globalIdentifier, updateBlock});
   }
 }
 

--- a/ComponentKitTestHelpers/CKComponentLifecycleTestController.mm
+++ b/ComponentKitTestHelpers/CKComponentLifecycleTestController.mm
@@ -106,15 +106,25 @@
 
 - (void)componentScopeHandleWithIdentifier:(int32_t)globalIdentifier
                             rootIdentifier:(int32_t)rootIdentifier
-                     didReceiveStateUpdate:(id (^)(id))stateUpdate
+        didReceiveStateUpdateToBeScheduled:(id (^)(id))updateBlock
                                       mode:(CKUpdateMode)mode
 {
   CKAssertMainThread();
-  _pendingStateUpdates.insert({globalIdentifier, stateUpdate});
-  const CKSizeRange constrainedSize = _sizeRangeProvider ? [_sizeRangeProvider sizeRangeForBoundingSize:_state.constrainedSize.max] : _state.constrainedSize;
+  _pendingStateUpdates.insert({globalIdentifier, updateBlock});
   [self updateWithState:[self prepareForUpdateWithModel:_state.model
-                                        constrainedSize:constrainedSize
+                                        constrainedSize:_sizeRangeProvider
+                                                        ? [_sizeRangeProvider sizeRangeForBoundingSize:_state.constrainedSize.max]
+                                                        : _state.constrainedSize
                                                 context:_state.context]];
+}
+
+- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
+                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
+         didReceiveStateUpdateToBeEnqueued:(id (^)(id))updateBlock
+                                      mode:(CKUpdateMode)mode
+{
+  CKAssertMainThread();
+  _pendingStateUpdates.insert({globalIdentifier, updateBlock});
 }
 
 @end

--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceUpdateStateModificationTests.mm
@@ -54,12 +54,20 @@
   return [CKStatefulTestComponent new];
 }
 
-- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
-                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
-                     didReceiveStateUpdate:(id (^)(id))stateUpdate
+- (void)componentScopeHandleWithIdentifier:(int32_t)globalIdentifier
+                            rootIdentifier:(int32_t)rootIdentifier
+        didReceiveStateUpdateToBeScheduled:(id (^)(id))updateBlock
                                       mode:(CKUpdateMode)mode
 {
-  _pendingStateUpdates[rootIdentifier].insert({globalIdentifier, stateUpdate});
+  _pendingStateUpdates[rootIdentifier].insert({globalIdentifier, updateBlock});
+}
+
+- (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier
+                            rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
+         didReceiveStateUpdateToBeEnqueued:(id (^)(id))updateBlock
+                                      mode:(CKUpdateMode)mode
+{
+  _pendingStateUpdates[rootIdentifier].insert({globalIdentifier, updateBlock});
 }
 
 - (void)tearDown

--- a/Examples/WildeGuess/WildeGuess.xcodeproj/project.pbxproj
+++ b/Examples/WildeGuess/WildeGuess.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2DCC6D571E468A6E0033946C /* EnqueueStateButtonComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DCC6D561E468A6E0033946C /* EnqueueStateButtonComponent.mm */; };
 		A2BC94DC1AC235A60043B82F /* QuoteComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2BC94DB1AC235A60043B82F /* QuoteComponent.mm */; };
 		B34FB9761ABE8BA300D2D896 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = B34FB95B1ABE8BA300D2D896 /* AppDelegate.mm */; };
 		B34FB9771ABE8BA300D2D896 /* FrostedQuoteComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = B34FB95E1ABE8BA300D2D896 /* FrostedQuoteComponent.mm */; };
@@ -28,6 +29,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2DCC6D4C1E4687820033946C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D0B47DC41CBDAFFF00BB33CE /* ComponentKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03B8B56A1D2A346F00EDFF59;
+			remoteInfo = ComponentKitAppleTV;
+		};
+		2DCC6D4E1E4687820033946C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D0B47DC41CBDAFFF00BB33CE /* ComponentKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03A98A721D2B2BFD00C5BAC2;
+			remoteInfo = ComponentKitTestHelpersAppleTV;
+		};
+		2DCC6D501E4687820033946C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D0B47DC41CBDAFFF00BB33CE /* ComponentKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03F1AC061D2B2A9B00867584;
+			remoteInfo = ComponentKitTestsAppleTV;
+		};
 		D093266C1CC4647700CFEBC4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D0B47DC41CBDAFFF00BB33CE /* ComponentKit.xcodeproj */;
@@ -87,6 +109,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2DCC6D551E468A6E0033946C /* EnqueueStateButtonComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnqueueStateButtonComponent.h; sourceTree = "<group>"; };
+		2DCC6D561E468A6E0033946C /* EnqueueStateButtonComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EnqueueStateButtonComponent.mm; sourceTree = "<group>"; };
 		A2BC94DA1AC235A60043B82F /* QuoteComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuoteComponent.h; sourceTree = "<group>"; };
 		A2BC94DB1AC235A60043B82F /* QuoteComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuoteComponent.mm; sourceTree = "<group>"; };
 		B34FB95A1ABE8BA300D2D896 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -146,6 +170,8 @@
 		B34FB95C1ABE8BA300D2D896 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				2DCC6D551E468A6E0033946C /* EnqueueStateButtonComponent.h */,
+				2DCC6D561E468A6E0033946C /* EnqueueStateButtonComponent.mm */,
 				B34FB95D1ABE8BA300D2D896 /* FrostedQuoteComponent.h */,
 				B34FB95E1ABE8BA300D2D896 /* FrostedQuoteComponent.mm */,
 				B34FB95F1ABE8BA300D2D896 /* InteractiveQuoteComponent.h */,
@@ -219,11 +245,14 @@
 			isa = PBXGroup;
 			children = (
 				D093266D1CC4647700CFEBC4 /* ComponentKit.framework */,
-				D093266F1CC4647700CFEBC4 /* ComponentKitApplicationsTestsHost.app */,
+				D09326771CC4647700CFEBC4 /* libComponentKitTestHelpers.a */,
 				D09326711CC4647700CFEBC4 /* ComponentKitTests.xctest */,
 				D09326731CC4647700CFEBC4 /* ComponentKitApplicationTests.xctest */,
 				D09326751CC4647700CFEBC4 /* ComponentTextKitApplicationTests.xctest */,
-				D09326771CC4647700CFEBC4 /* libComponentKitTestHelpers.a */,
+				D093266F1CC4647700CFEBC4 /* ComponentKitApplicationsTestsHost.app */,
+				2DCC6D4D1E4687820033946C /* ComponentKit.framework */,
+				2DCC6D4F1E4687820033946C /* libComponentKitTestHelpers.a */,
+				2DCC6D511E4687820033946C /* ComponentKitTestsAppleTV.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -255,7 +284,7 @@
 		B3E848B81ABE848900377D52 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0820;
 				TargetAttributes = {
 					B3E848BF1ABE848900377D52 = {
 						CreatedOnToolsVersion = 6.1;
@@ -287,6 +316,27 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		2DCC6D4D1E4687820033946C /* ComponentKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ComponentKit.framework;
+			remoteRef = 2DCC6D4C1E4687820033946C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2DCC6D4F1E4687820033946C /* libComponentKitTestHelpers.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libComponentKitTestHelpers.a;
+			remoteRef = 2DCC6D4E1E4687820033946C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2DCC6D511E4687820033946C /* ComponentKitTestsAppleTV.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ComponentKitTestsAppleTV.xctest;
+			remoteRef = 2DCC6D501E4687820033946C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		D093266D1CC4647700CFEBC4 /* ComponentKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -347,6 +397,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DCC6D571E468A6E0033946C /* EnqueueStateButtonComponent.mm in Sources */,
 				B34FB97F1ABE8BA300D2D896 /* QuoteContext.m in Sources */,
 				B34FB9811ABE8BA300D2D896 /* QuotesPage.m in Sources */,
 				B34FB97E1ABE8BA300D2D896 /* Quote.m in Sources */,
@@ -381,15 +432,19 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -422,8 +477,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -431,6 +488,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -450,6 +508,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				INFOPLIST_FILE = "WildeGuess/WildeGuess-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.componentkit.wildeguess;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -460,6 +519,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				INFOPLIST_FILE = "WildeGuess/WildeGuess-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.componentkit.wildeguess;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Examples/WildeGuess/WildeGuess.xcodeproj/xcshareddata/xcschemes/WildeGuess.xcscheme
+++ b/Examples/WildeGuess/WildeGuess.xcodeproj/xcshareddata/xcschemes/WildeGuess.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/WildeGuess/WildeGuess/Components/EnqueueStateButtonComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/EnqueueStateButtonComponent.h
@@ -1,0 +1,20 @@
+/* This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import <ComponentKit/ComponentKit.h>
+
+@class QuoteContext;
+
+@interface EnqueueStateButtonComponent : CKCompositeComponent
+
++ (instancetype)newWithContext:(QuoteContext *)context;
+
+@end

--- a/Examples/WildeGuess/WildeGuess/Components/EnqueueStateButtonComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/EnqueueStateButtonComponent.mm
@@ -1,0 +1,54 @@
+/* This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#import "EnqueueStateButtonComponent.h"
+
+#import <ComponentKit/CKComponentSubclass.h>
+
+@implementation EnqueueStateButtonComponent
+
++ (instancetype)newWithContext:(QuoteContext *)context
+{
+  CKComponentScope scope(self);
+  return
+  [super
+   newWithComponent:
+   [CKButtonComponent
+    newWithTitles:{
+      {UIControlStateNormal, [NSString stringWithFormat:@"Tap Count: %@", scope.state()]},
+    }
+    titleColors:{
+      {UIControlStateNormal, [UIColor blackColor]},
+    }
+    images:{}
+    backgroundImages:{}
+    titleFont:{}
+    selected:NO
+    enabled:YES
+    action:@selector(didTap)
+    size:{}
+    attributes:{}
+    accessibilityConfiguration:{}]];
+}
+
++ (id)initialState
+{
+  return @0;
+}
+
+- (void)didTap
+{
+  [self enqueueState:^NSNumber *(NSNumber *oldState) {
+    return @([oldState integerValue] + 1);
+  } mode:CKUpdateModeAsynchronous];
+}
+
+@end

--- a/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.mm
@@ -13,6 +13,7 @@
 
 #import <ComponentKit/CKComponentSubclass.h>
 
+#import "EnqueueStateButtonComponent.h"
 #import "Quote.h"
 #import "QuoteComponent.h"
 #import "QuoteContext.h"
@@ -42,19 +43,29 @@ static NSString *const oscarWilde = @"Oscar Wilde";
   InteractiveQuoteComponent *c =
   [super newWithComponent:
    [CKStackLayoutComponent
-    newWithView:{
-      [UIView class],
-      {CKComponentTapGestureAttribute(@selector(didTap))}
-    }
+    newWithView:{}
     size:{}
     style:{
       .alignItems = CKStackLayoutAlignItemsStretch
     }
     children:{
-      {[CKOverlayLayoutComponent
-        newWithComponent:[QuoteComponent newWithQuote:quote context:context]
-        overlay:overlay]},
-      {hairlineComponent()}
+      {[CKStackLayoutComponent
+        newWithView:{
+          [UIView class],
+          {CKComponentTapGestureAttribute(@selector(didTap))}
+        }
+        size:{}
+        style:{
+          .alignItems = CKStackLayoutAlignItemsStretch
+        }
+        children:{
+          {[CKOverlayLayoutComponent
+            newWithComponent:[QuoteComponent newWithQuote:quote context:context]
+            overlay:overlay]},
+        }]},
+      {hairlineComponent()},
+      {[EnqueueStateButtonComponent newWithContext:context]},
+      {hairlineComponent()},
     }]];
   if (c) {
     c->_overlay = overlay;

--- a/Examples/WildeGuess/WildeGuess/WildeGuess-Info.plist
+++ b/Examples/WildeGuess/WildeGuess/WildeGuess-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.componentkit.wildeguess</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
I wanted to explore an API that allows you to enqueue a state update that does not trigger a complete reflow of the component hierarchy. The idea here is to permit "lazy" state updates that aren't applied until a proper state update is scheduled.

There isn't anything here that can't be done without component controllers. Given that, and the somewhat confusing behavior of enqueued state updates, I don't recommend merging these changes. This pull request is completely experimental and for exploratory purposes only.