### PR TITLE
CKOverlayLayoutComponent renders to nil if component is nil

### DIFF
--- a/ComponentKit/LayoutComponents/CKBackgroundLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKBackgroundLayoutComponent.mm
@@ -15,14 +15,11 @@
 
 #import "CKComponentSubclass.h"
 
-@interface CKBackgroundLayoutComponent ()
+@implementation CKBackgroundLayoutComponent
 {
   CKComponent *_component;
   CKComponent *_background;
 }
-@end
-
-@implementation CKBackgroundLayoutComponent
 
 + (instancetype)newWithComponent:(CKComponent *)component
                       background:(CKComponent *)background
@@ -31,8 +28,10 @@
     return nil;
   }
   CKBackgroundLayoutComponent *c = [super newWithView:{} size:{}];
-  c->_component = component;
-  c->_background = background;
+  if (c) {
+    c->_component = component;
+    c->_background = background;
+  }
   return c;
 }
 
@@ -54,14 +53,18 @@
 
   const CKComponentLayout contentsLayout = [_component layoutThatFits:constrainedSize parentSize:parentSize];
 
-  std::vector<CKComponentLayoutChild> children;
-  if (_background) {
-    // Size background to exactly the same size.
-    children.push_back({{0,0}, [_background layoutThatFits:{contentsLayout.size, contentsLayout.size} parentSize:contentsLayout.size]});
-  }
-  children.push_back({{0,0}, contentsLayout});
-
-  return {self, contentsLayout.size, children};
+  return {
+    self,
+    contentsLayout.size,
+    _background
+    ? std::vector<CKComponentLayoutChild> {
+      {{0,0}, [_background layoutThatFits:{contentsLayout.size, contentsLayout.size} parentSize:contentsLayout.size]},
+      {{0,0}, contentsLayout},
+    }
+    : std::vector<CKComponentLayoutChild> {
+      {{0,0}, contentsLayout}
+    }
+  };
 }
 
 @end

--- a/ComponentKit/LayoutComponents/CKOverlayLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKOverlayLayoutComponent.mm
@@ -24,9 +24,11 @@
 + (instancetype)newWithComponent:(CKComponent *)component
                          overlay:(CKComponent *)overlay
 {
+  if (component == nil) {
+    return nil;
+  }
   CKOverlayLayoutComponent *c = [super newWithView:{} size:{}];
   if (c) {
-    CKAssertNotNil(component, @"Component that will be overlayed on shouldn't be nil");
     c->_overlay = overlay;
     c->_component = component;
   }
@@ -49,15 +51,17 @@
            @"CKOverlayLayoutComponent only passes size {} to the super class initializer, but received size %@ "
            "(component=%@, overlay=%@)", size.description(), _component, _overlay);
 
-  CKComponentLayout contentsLayout = [_component layoutThatFits:constrainedSize parentSize:parentSize];
+  const CKComponentLayout contentsLayout = [_component layoutThatFits:constrainedSize parentSize:parentSize];
   
   return {
     self,
     contentsLayout.size,
-    _overlay ? std::vector<CKComponentLayoutChild> {
+    _overlay
+    ? std::vector<CKComponentLayoutChild> {
       {{0,0}, contentsLayout},
-      {{0,0}, CKComputeComponentLayout(_overlay, {contentsLayout.size, contentsLayout.size}, contentsLayout.size)}
-    } : std::vector<CKComponentLayoutChild> {
+      {{0,0}, [_overlay layoutThatFits:{contentsLayout.size, contentsLayout.size} parentSize:contentsLayout.size]},
+    }
+    : std::vector<CKComponentLayoutChild> {
       {{0,0}, contentsLayout},
     }
   };


### PR DESCRIPTION
Match `CKBackgroundLayoutComponent`, which was already doing the same. Also seize the opportunity for code style cleanup.