### PR TITLE
Pass accessibility configuration by reference

### DIFF
--- a/ComponentKit/Components/CKButtonComponent.h
+++ b/ComponentKit/Components/CKButtonComponent.h
@@ -36,6 +36,6 @@ struct CKButtonComponentAccessibilityConfiguration {
                        action:(const CKTypedComponentAction<UIEvent *> &)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)attributes
-   accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration;
+   accessibilityConfiguration:(const CKButtonComponentAccessibilityConfiguration &)accessibilityConfiguration;
 
 @end

--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -93,7 +93,7 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                        action:(const CKTypedComponentAction<UIEvent *> &)action
                          size:(const CKComponentSize &)size
                    attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
-   accessibilityConfiguration:(CKButtonComponentAccessibilityConfiguration)accessibilityConfiguration
+   accessibilityConfiguration:(const CKButtonComponentAccessibilityConfiguration &)accessibilityConfiguration
 {
   static const CKComponentViewAttribute titleFontAttribute = {"CKButtonComponent.titleFont", ^(UIButton *button, id value){
     button.titleLabel.font = value;


### PR DESCRIPTION
Fixes a small bug where accessibility labels aren't being passed through correctly. Also keeps it consistent with some of the recent changes to pass structs by reference.