### PR TITLE
Make default constructor of CKRelativeDimension and friends constexpr

### DIFF
--- a/ComponentKit/Core/CKDimension.h
+++ b/ComponentKit/Core/CKDimension.h
@@ -50,10 +50,11 @@ namespace std {
 
 class CKRelativeDimension {
 public:
-  CKRelativeDimension() noexcept : CKRelativeDimension(Type::AUTO, 0) {}
+  /** Default constructor is equivalent to "Auto". */
+  constexpr CKRelativeDimension() noexcept : _type(Type::AUTO), _value(0) {}
   CKRelativeDimension(CGFloat points) noexcept : CKRelativeDimension(Type::POINTS, points) {}
 
-  static CKRelativeDimension Auto() noexcept { return CKRelativeDimension(); }
+  constexpr static CKRelativeDimension Auto() noexcept { return CKRelativeDimension(); }
   static CKRelativeDimension Points(CGFloat p) noexcept { return CKRelativeDimension(p); }
   static CKRelativeDimension Percent(CGFloat p) noexcept { return {CKRelativeDimension::Type::PERCENT, p}; }
 
@@ -95,7 +96,7 @@ struct CKRelativeSize {
   CKRelativeSize(const CGSize &size) noexcept;
 
   /** Convenience constructor for {Auto, Auto} */
-  CKRelativeSize() noexcept;
+  constexpr CKRelativeSize() = default;
 
   /** Resolve this size relative to a parent size and an auto size. */
   CGSize resolveSize(const CGSize &parentSize, const CGSize &autoSize) const noexcept;
@@ -121,7 +122,7 @@ struct CKRelativeSizeRange {
   CKRelativeSizeRange(const CKRelativeDimension &exactWidth, const CKRelativeDimension &exactHeight) noexcept;
 
   /** Convenience constructor for {{Auto, Auto}, {Auto, Auto}}. */
-  CKRelativeSizeRange() noexcept;
+  constexpr CKRelativeSizeRange() = default;
 
   /**
    Provided a parent size and values to use in place of Auto, compute final dimensions for this RelativeSizeRange

--- a/ComponentKit/Core/CKDimension.mm
+++ b/ComponentKit/Core/CKDimension.mm
@@ -69,7 +69,6 @@ size_t std::hash<CKRelativeDimension>::operator ()(const CKRelativeDimension &si
 
 CKRelativeSize::CKRelativeSize(const CKRelativeDimension &_width, const CKRelativeDimension &_height) noexcept : width(_width), height(_height) {}
 CKRelativeSize::CKRelativeSize(const CGSize &size) noexcept : CKRelativeSize(size.width, size.height) {}
-CKRelativeSize::CKRelativeSize() noexcept : CKRelativeSize({}, {}) {}
 
 CGSize CKRelativeSize::resolveSize(const CGSize &parentSize, const CGSize &autoSize) const noexcept
 {
@@ -93,7 +92,6 @@ CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeSize &_min, const CKRel
 CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeSize &exact) noexcept : CKRelativeSizeRange(exact, exact) {}
 CKRelativeSizeRange::CKRelativeSizeRange(const CGSize &exact) noexcept : CKRelativeSizeRange(CKRelativeSize(exact)) {}
 CKRelativeSizeRange::CKRelativeSizeRange(const CKRelativeDimension &exactWidth, const CKRelativeDimension &exactHeight) noexcept : CKRelativeSizeRange(CKRelativeSize(exactWidth, exactHeight)) {}
-CKRelativeSizeRange::CKRelativeSizeRange() noexcept : CKRelativeSizeRange(CKRelativeSize(), CKRelativeSize()) {}
 
 CKSizeRange CKRelativeSizeRange::resolveSizeRange(const CGSize &parentSize, const CKSizeRange &autoCKSizeRange) const noexcept
 {


### PR DESCRIPTION
`CKRelativeDimension` and classes which have `CKRelativeDimensions` as fields, such as `CKRelativeSize`, `CKRelativeSizeRange` and `CKComponentSize` especially, are frequently default-constructed (taken to mean "I want everything to be `Auto`"). By making these constructors `constexpr`, they can be evaluated to a compile time constant, and call sites don't need to initialize new instances with Auto/0 in its fields.

Note that for `CKComponentSize` specifically, due to the idiom of using aggregate initialization to generate it, we cannot use the trick of declaring an out-of-line default constructor, as doing so disables aggregate initialization. As a result, a simple `{}` will generate code to inline initialize 6 `CKRelativeDimension` objects. Making `CKRelativeDimension` constructors constexpr allows aggregate initialization to simply use compile-time autogenerated `CKRelativeDimension` constants. Furthermore, the implicit default constructor of `CKRelativeDimension` itself becomes constexpr, so passing a `const CKComponentSize &` parameter specified as `{}` becomes a simple address load instruction for a pre-computed `CKComponentSize` function.

Given this test:
```
#include <ComponentKit/CKComponentSize.h>
void foo(const CKComponentSize &);
void test();
void test() { foo({}); }
```

Before:
```
__Z4testv:
Lfunc_begin0:
	push	{r4, r7, lr}
	add	r7, sp, #4
	sub	sp, #52
	mov	r4, sp
	bfc	r4, #0, #3
	mov	sp, r4
Ltmp0:
	vmov.i32	q8, #0x0  @ here it initializes a NEON register to 0
	mov	r0, sp 
Ltmp1:  
	add.w	r1, r0, #32
	vst1.64	{d16, d17}, [r1] @here it uses that zero'd NEON register to zero the fields.
	mov	r1, r0
	vst1.64	{d16, d17}, [r1]! @more zeroing
	vst1.64	{d16, d17}, [r1] @more zeroing
Ltmp2:
	bl	__Z3fooRK15CKComponentSize
	subs	r4, r7, #4
	mov	sp, r4
	pop	{r4, r7, pc}
Ltmp3:
Lfunc_end0:
```

After:
```
__Z4testv:
Lfunc_begin0: @ Here the code loads a pointer to a precomputed value.
	movw	r0, :lower16:(l_.ref.tmp-(LPC0_0+4))
	movt	r0, :upper16:(l_.ref.tmp-(LPC0_0+4))
LPC0_0:
	add	r0, pc
	b.w	__Z3fooRK15CKComponentSize
Ltmp0:
Lfunc_end0:
```

One minor downside of this approach is that currently, the compile time evaluated values are effectively `static`, so the linker does not de-duplicate identical pre-computed constants in different compilation units, resulting in a larger `.rodata` section. 