### PR TITLE
removed unused scenePath object from CK signatures

### DIFF
--- a/ComponentKit/Components/CKNetworkImageComponent.h
+++ b/ComponentKit/Components/CKNetworkImageComponent.h
@@ -27,7 +27,6 @@ struct CKNetworkImageComponentOptions {
  */
 + (instancetype)newWithURL:(NSURL *)url
            imageDownloader:(id<CKNetworkImageDownloading>)imageDownloader
-                 scenePath:(id)scenePath
                       size:(const CKComponentSize &)size
                    options:(const CKNetworkImageComponentOptions &)options
                 attributes:(const CKViewComponentAttributeValueMap &)attributes;

--- a/ComponentKit/Components/CKNetworkImageComponent.mm
+++ b/ComponentKit/Components/CKNetworkImageComponent.mm
@@ -14,12 +14,10 @@
 - (instancetype)initWithURL:(NSURL *)url
                defaultImage:(UIImage *)defaultImage
             imageDownloader:(id<CKNetworkImageDownloading>)imageDownloader
-                  scenePath:(id)scenePath
                    cropRect:(CGRect)cropRect;
 @property (nonatomic, copy, readonly) NSURL *url;
 @property (nonatomic, strong, readonly) UIImage *defaultImage;
 @property (nonatomic, strong, readonly) id<CKNetworkImageDownloading> imageDownloader;
-@property (nonatomic, strong, readonly) id scenePath;
 @property (nonatomic, assign, readonly) CGRect cropRect;
 @end
 
@@ -33,7 +31,6 @@
 
 + (instancetype)newWithURL:(NSURL *)url
            imageDownloader:(id<CKNetworkImageDownloading>)imageDownloader
-                 scenePath:(id)scenePath
                       size:(const CKComponentSize &)size
                    options:(const CKNetworkImageComponentOptions &)options
                 attributes:(const CKViewComponentAttributeValueMap &)passedAttributes
@@ -47,7 +44,6 @@
     {@selector(setSpecifier:), [[CKNetworkImageSpecifier alloc] initWithURL:url
                                                                defaultImage:options.defaultImage
                                                             imageDownloader:imageDownloader
-                                                                  scenePath:scenePath
                                                                    cropRect:cropRect]},
 
   });
@@ -64,14 +60,12 @@
 - (instancetype)initWithURL:(NSURL *)url
                defaultImage:(UIImage *)defaultImage
             imageDownloader:(id<CKNetworkImageDownloading>)imageDownloader
-                  scenePath:(id)scenePath
                    cropRect:(CGRect)cropRect
 {
   if (self = [super init]) {
     _url = [url copy];
     _defaultImage = defaultImage;
     _imageDownloader = imageDownloader;
-    _scenePath = scenePath;
     _cropRect = cropRect;
   }
   return self;
@@ -91,7 +85,6 @@
     return CKObjectIsEqual(_url, other->_url)
     && CKObjectIsEqual(_defaultImage, other->_defaultImage)
     && CKObjectIsEqual(_imageDownloader, other->_imageDownloader)
-    && CKObjectIsEqual(_scenePath, other->_scenePath)
     && CGRectEqualToRect(_cropRect, other->_cropRect);
   }
   return NO;
@@ -178,7 +171,6 @@
 
   __weak CKNetworkImageComponentView *weakSelf = self;
   _download = [_specifier.imageDownloader downloadImageWithURL:_specifier.url
-                                                     scenePath:_specifier.scenePath
                                                         caller:self
                                                  callbackQueue:dispatch_get_main_queue()
                                          downloadProgressBlock:nil

--- a/ComponentKit/Components/CKNetworkImageDownloading.h
+++ b/ComponentKit/Components/CKNetworkImageDownloading.h
@@ -18,7 +18,6 @@
 /**
   @abstract Downloads an image with the given URL.
   @param URL The URL of the image to download.
-  @param scenePath Opaque context for where this is from.
   @param caller The object that initiated the request.
   @param callbackQueue The queue to call `downloadProgressBlock` and `completion` on. If this value is nil, both blocks will be invoked on the main-queue.
   @param downloadProgressBlock The block to be invoked when the download of `URL` progresses.
@@ -30,7 +29,6 @@
   @result An opaque identifier to be used in canceling the download, via `cancelImageDownload:`. You must retain the identifier if you wish to use it later.
  */
 - (id)downloadImageWithURL:(NSURL *)URL
-                 scenePath:(id)scenePath
                     caller:(id)caller
              callbackQueue:(dispatch_queue_t)callbackQueue
      downloadProgressBlock:(void (^)(CGFloat progress))downloadProgressBlock
@@ -38,7 +36,7 @@
 
 /**
   @abstract Cancels an image download.
-  @param download The opaque download identifier object returned from `downloadImageWithURL:scenePath:caller:callbackQueue:downloadProgressBlock:completion:`.
+  @param download The opaque download identifier object returned from `downloadImageWithURL:caller:callbackQueue:downloadProgressBlock:completion:`.
   @discussion This method has no effect if `download` is nil.
  */
 - (void)cancelImageDownload:(id)download;

--- a/ComponentKitApplicationTests/CKNetworkImageComponentTests.mm
+++ b/ComponentKitApplicationTests/CKNetworkImageComponentTests.mm
@@ -41,7 +41,6 @@ static UIImage *ck_fakeImage(UIColor *imageBackgroundColor, CGSize size)
 }
 
 typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
-                                                      id scenePath,
                                                       id caller,
                                                       dispatch_queue_t callbackQueue,
                                                       void (^downloadProgressBlock)(CGFloat),
@@ -65,13 +64,12 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
 }
 
 - (id)downloadImageWithURL:(NSURL *)URL
-                 scenePath:(id)scenePath
                     caller:(id)caller
              callbackQueue:(dispatch_queue_t)callbackQueue
      downloadProgressBlock:(void (^)(CGFloat))downloadProgressBlock
                 completion:(void (^)(CGImageRef, NSError *))completion
 {
-  return _downloadImageBlock(URL, scenePath, caller, callbackQueue, downloadProgressBlock, completion);
+  return _downloadImageBlock(URL, caller, callbackQueue, downloadProgressBlock, completion);
 }
 
 - (void)cancelImageDownload:(id)download { /* no-op */ }
@@ -97,7 +95,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
   [CKNetworkImageComponent
    newWithURL:nil
    imageDownloader:nil
-   scenePath:nil
    size:{}
    options:{}
    attributes:{
@@ -114,7 +111,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
   [CKNetworkImageComponent
    newWithURL:nil
    imageDownloader:nil
-   scenePath:nil
    size:{}
    options:{
      .defaultImage = ck_fakeImage([UIColor greenColor], CGSizeMake(50, 50)),
@@ -131,7 +127,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
 {
   CKTestImageDownloader *imageDownloader =
     [[CKTestImageDownloader alloc] initWithDownloadImageBlock:^id(NSURL *url,
-                                                                  id scenePath,
                                                                   id caller,
                                                                   dispatch_queue_t callbackQueue,
                                                                   void (^downloadProgressBlock)(CGFloat),
@@ -146,7 +141,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
   [CKNetworkImageComponent
    newWithURL:nil
    imageDownloader:imageDownloader
-   scenePath:nil
    size:{}
    options:{}
    attributes:{
@@ -162,7 +156,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
 {
   CKTestImageDownloader *imageDownloader =
     [[CKTestImageDownloader alloc] initWithDownloadImageBlock:^id(NSURL *url,
-                                                                  id scenePath,
                                                                   id caller,
                                                                   dispatch_queue_t callbackQueue,
                                                                   void (^downloadProgressBlock)(CGFloat),
@@ -178,7 +171,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
   [CKNetworkImageComponent
    newWithURL:[NSURL URLWithString:@"http://literally-any-non-nil-url-can-be-used-here.com"]
    imageDownloader:imageDownloader
-   scenePath:nil
    size:{}
    options:{
      // This opaque green default image will be replaced in favor of the image provided by the image downloader.
@@ -198,7 +190,6 @@ typedef id (^CKTestImageDownloaderDownloadImageBlock)(NSURL *url,
   [CKNetworkImageComponent
    newWithURL:nil
    imageDownloader:nil
-   scenePath:nil
    size:{}
    options:{
      .cropRect = CGRectMake(0, 0, 40, 40),


### PR DESCRIPTION
codemod -m --extensions h,m,mm 'scenePath'

and one by one removed all the instances of this signature

This is an API breaking change.

Tested in Xcode CMD-U.