### PR TITLE
Force enable accessibility by default on the simulator

### DIFF
--- a/ComponentKit/Accessibility/CKComponentAccessibility.h
+++ b/ComponentKit/Accessibility/CKComponentAccessibility.h
@@ -42,8 +42,8 @@ private:
 };
 
 /**
- Separate structure to handle accessibility as we want the components infrastructure to decide whether to use it or not depending if accessibility is enabled or not. Accessibility is
-     enabled by default on the simulator, but only enabled on device if VoiceOver is on.
+ Separate structure to handle accessibility as we want the components infrastructure to decide whether to use it or not depending if accessibility is enabled or not.
+ Accessibility is enabled by default on the simulator, but only enabled on device if VoiceOver is on.
  Not to be confused with accessibilityIdentifier which is used for automation to identify elements on the screen. To set the identifier pass in {@selector(setAccessibilityIdentifier:), @"accessibilityId"} with the viewConfiguration's attributes
  */
 struct CKComponentAccessibilityContext {

--- a/ComponentKit/Accessibility/CKComponentAccessibility.h
+++ b/ComponentKit/Accessibility/CKComponentAccessibility.h
@@ -42,7 +42,8 @@ private:
 };
 
 /**
- Separate structure to handle accessibility as we want the components infrastructure to decide wether to use it or not depending if accessibility is enabled or not.
+ Separate structure to handle accessibility as we want the components infrastructure to decide whether to use it or not depending if accessibility is enabled or not. Accessibility is
+     enabled by default on the simulator, but only enabled on device if VoiceOver is on.
  Not to be confused with accessibilityIdentifier which is used for automation to identify elements on the screen. To set the identifier pass in {@selector(setAccessibilityIdentifier:), @"accessibilityId"} with the viewConfiguration's attributes
  */
 struct CKComponentAccessibilityContext {

--- a/ComponentKit/Accessibility/CKComponentAccessibility.mm
+++ b/ComponentKit/Accessibility/CKComponentAccessibility.mm
@@ -49,8 +49,13 @@ CKComponentViewConfiguration CK::Component::Accessibility::AccessibleViewConfigu
   }
 }
 
+#if TARGET_OS_SIMULATOR
+static BOOL _forceAccessibilityEnabled = YES;
+static BOOL _forceAccessibilityDisabled = NO;
+#else
 static BOOL _forceAccessibilityEnabled = NO;
 static BOOL _forceAccessibilityDisabled = NO;
+#endif
 
 void CK::Component::Accessibility::SetForceAccessibilityEnabled(BOOL enabled)
 {

--- a/ComponentKit/Accessibility/CKComponentAccessibility.mm
+++ b/ComponentKit/Accessibility/CKComponentAccessibility.mm
@@ -51,11 +51,11 @@ CKComponentViewConfiguration CK::Component::Accessibility::AccessibleViewConfigu
 
 #if TARGET_OS_SIMULATOR
 static BOOL _forceAccessibilityEnabled = YES;
-static BOOL _forceAccessibilityDisabled = NO;
 #else
 static BOOL _forceAccessibilityEnabled = NO;
-static BOOL _forceAccessibilityDisabled = NO;
 #endif
+
+static BOOL _forceAccessibilityDisabled = NO;
 
 void CK::Component::Accessibility::SetForceAccessibilityEnabled(BOOL enabled)
 {


### PR DESCRIPTION
As discussed internally, this change makes it much easier to debug components that use accessibility when inspecting elements on the simulator with the Accessibility Inspector.

**Test Plan:**

- Set breakpoint on `IsAccessibilityEnabled()`
- Run example app in sim, verify that it returns `YES`
- Run example app on device with VoiceOver off, verify that it returns `NO`