### PR TITLE
[ComponentKit] Add __kindof for CKComponentViewContext

### DIFF
--- a/ComponentKit/Core/CKComponent.h
+++ b/ComponentKit/Core/CKComponent.h
@@ -18,7 +18,7 @@
 #import <ComponentKit/CKComponentViewConfiguration.h>
 
 struct CKComponentViewContext {
-  UIView *view;
+  __kindof UIView *view;
   CGRect frame;
 };
 


### PR DESCRIPTION
One often has to perform a cast when reading back the view from view context like this:

`
FooView *fooView = (FooView *)aComponent.viewContext.view;
`

Adding `__kindof` spares this cast and reduces noise in the code.