### PR TITLE
Remove unused CK_FINAL_CLASS

### DIFF
--- a/ComponentKit/Base/CKMacros.h
+++ b/ComponentKit/Base/CKMacros.h
@@ -23,19 +23,4 @@
 __attribute__((unavailable("Not the designated initializer")))
 #endif // CK_NOT_DESIGNATED_INITIALIZER_ATTRIBUTE
 
-#ifndef CK_FINAL_CLASS_INITIALIZE_IMP
-#define CK_FINAL_CLASS_INITIALIZE_IMP(__finalClass) \
-  do { \
-    if (![NSStringFromClass(self) hasPrefix:@"NSKVONotifying"] && self != (__finalClass)) { \
-      NSString *reason = [NSString stringWithFormat:@"%@ is a final class and cannot be subclassed. %@", NSStringFromClass((__finalClass)), NSStringFromClass(self)]; \
-      @throw [NSException exceptionWithName:@"CKFinalClassViolationException" reason:reason userInfo:nil]; \
-    } \
-  } while(0)
-#endif // CK_FINAL_CLASS_INITIALIZE_IMP
-
-#ifndef CK_FINAL_CLASS
-#define CK_FINAL_CLASS(__finalClass) \
-  + (void)initialize { CK_FINAL_CLASS_INITIALIZE_IMP((__finalClass)); }
-#endif // Ck_FINAL_CLASS
-
 #define CK_ARRAY_COUNT(x) sizeof(x) / sizeof(x[0])


### PR DESCRIPTION
This can be done at compile time with the `objc_subclassing_restricted` attribute.