### PR TITLE
Update 18-datasource-changeset-api.md

### DIFF
--- a/_docs/18-datasource-changeset-api.md
+++ b/_docs/18-datasource-changeset-api.md
@@ -30,6 +30,7 @@ sections.insert(2);
 sections.insert(3);
 
 [datasource enqueueChangeset:{sections, items}];
+
 {% endhighlight %}
 
 Changes can also be created from `NSIndexPaths` :
@@ -38,6 +39,7 @@ Changes can also be created from `NSIndexPaths` :
 CKArrayControllerInputItems items;
 NSIndexPath *insertionIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
 items.insert({insertionIndexPath}, @"Hello");
+
 {% endhighlight %}
 
 You can even get rid of the brackets around the `NSIndexPath`, thanks to [C++ converting constructors](http://en.cppreference.com/w/cpp/language/converting_constructor) :


### PR DESCRIPTION
The bottom line of the code isn't visible in chrome

<img width="697" alt="componentkit___changeset_api" src="https://cloud.githubusercontent.com/assets/2404795/23460476/41a4eee2-fe8e-11e6-9a0b-000a8f16a622.png">
