### PR TITLE
Fix changeset verification with a move whose original index path is non-existent after update

### DIFF
--- a/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
+++ b/ComponentKitTests/TransactionalDataSource/CKTransactionalComponentDataSourceChangesetVerificationTests.mm
@@ -565,6 +565,32 @@
   XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
 }
 
+- (void)test_validMoveBackwardWithOriginalIndexRemoved
+{
+  CKTransactionalComponentDataSourceState *state =
+  [[CKTransactionalComponentDataSourceState alloc] initWithConfiguration:nil
+                                                                sections:@[
+                                                                           @[
+                                                                             itemWithModel(@"A"),
+                                                                             itemWithModel(@"B"),
+                                                                             itemWithModel(@"C"),
+                                                                             itemWithModel(@"D"),
+                                                                             ],
+                                                                            ]];
+  // Changeset for transition from [A, B, C, D] to [D, A]
+  CKTransactionalComponentDataSourceChangeset *changeset =
+  [[[[CKTransactionalComponentDataSourceChangesetBuilder transactionalComponentDataSourceChangeset]
+     withMovedItems:@{
+                      [NSIndexPath indexPathForItem:3 inSection:0] : [NSIndexPath indexPathForItem:0 inSection:0],
+                      }]
+    withRemovedItems:[NSSet setWithArray:@[
+                                           [NSIndexPath indexPathForItem:1 inSection:0],
+                                           [NSIndexPath indexPathForItem:2 inSection:0],
+                                           ]]]
+   build];
+  XCTAssertEqual(CKIsValidChangesetForState(changeset, state, nil), CKBadChangesetOperationTypeNone);
+}
+
 #pragma mark - Invalid changesets
 
 - (void)test_invalidUpdateInNegativeSection


### PR DESCRIPTION
Here is an example of what this diff is fixing. Consider a list being updated from `[A, B, C, D]` to `[D, A]`.

The changeset would be `[delete(from:[1,2]), move(from:3, to:0)]`.

Because this algorithm apply these changes in place with move handled in the last, at the time when moves are being verified, index 3 no longer exists.

The fix is to keep a copy of the original state and always verify fromIndexPath or fromSection with that.