### PR TITLE
Allow passing components into hierarchy logger

### DIFF
--- a/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
+++ b/ComponentKit/Debug/CKComponentHierarchyDebugHelper.mm
@@ -52,6 +52,9 @@ static NSString *const indentString = @"| ";
 
 + (NSString *)componentHierarchyDescriptionForView:(UIView *)view searchUpwards:(BOOL)upwards showViews:(BOOL)showViews
 {
+  if ([view isKindOfClass:[CKComponent class]]) {
+    view = ((CKComponent *)view).viewContext.view;
+  }
   if (upwards) {
     return ancestorComponentHierarchyDescriptionForView(view, showViews);
   } else {


### PR DESCRIPTION
Sometimes when dumping components hierarchy all you have is a reference to a component and not a view. This allows to dump hierarchy starting with a component and not a view