### PR TITLE
Remove incorrect comment for unmounting

### DIFF
--- a/ComponentKit/Core/CKComponentInternal.h
+++ b/ComponentKit/Core/CKComponentInternal.h
@@ -45,7 +45,6 @@
  Unmounts the component:
  - Clears the references to supercomponent and superview.
  - If the component has a _mountedView:
-   - Calls the unapplicator for any attributes that have one.
    - Clears the view's reference back to this component in ck_component.
    - Clears _mountedView.
  */


### PR DESCRIPTION
Fixes https://github.com/facebook/componentkit/issues/621. This comment is simply incorrect. Unapplication occurs on *mounting* not on *unmounting*. I'm open to moving this comment, but couldn't think of a good place to put it.