### PR TITLE
Fix blind call to targetForAction:withSender:

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -88,7 +88,9 @@ std::string CKTypedComponentActionBase::identifier() const noexcept
 
 NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender) noexcept
 {
-  id responder = [target targetForAction:selector withSender:target];
+  id responder = ([target respondsToSelector:@selector(targetForAction:withSender:)]
+                  ? [target targetForAction:selector withSender:target]
+                  : target);
   CKCAssertNotNil(responder, @"Unhandled component action %@ following responder chain %@",
                   NSStringFromSelector(selector), _CKComponentResponderChainDebugResponderChain(target));
   // This is not performance-sensitive, so we can just use an invocation here.

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -99,6 +99,22 @@
 
 @end
 
+@interface CKTestObjectTarget : NSObject
+
+- (void)someMethod;
+
+@property (nonatomic, assign, readonly) BOOL calledSomeMethod;
+
+@end
+@implementation CKTestObjectTarget
+
+- (void)someMethod
+{
+  _calledSomeMethod = YES;
+}
+
+@end
+
 @interface CKTestControllerScopeActionComponentController : CKComponentController<CKTestControllerScopeActionComponent *>
 @end
 
@@ -424,6 +440,15 @@
   action.send(component);
 
   XCTAssertTrue(calledAction, @"Should have called the action on the test component");
+}
+
+- (void)testTargetSelectorActionCallsOnNormalNSObject
+{
+  CKTestObjectTarget *target =[CKTestObjectTarget new];
+  CKComponentAction action = CKComponentAction(CKTypedComponentAction<>(target, @selector(someMethod)));
+  action.send([CKComponent new]);
+
+  XCTAssertTrue(target.calledSomeMethod, @"Should have called the method on target");
 }
 
 @end


### PR DESCRIPTION
So what happened here is that we added targetForAction:withSender: to CKComponents which is part of the UIResponder API, but when I made it possible to use non-CKComponents or responders as the target, I didn't catch that targetForAction:withSender: can't be called blindly.

This was working without crashing because I was testing it against views and view controllers, which subclass UIResponder and implement this method.