### PR TITLE
Tweak object layout of CKTypedComponentActionBase to reduce code size

### DIFF
--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -19,15 +19,6 @@
 
 @class CKComponent;
 
-/**
- We support several different types of action variants. You don't need to use this value anywhere, it's set for you
- by whatever initializer you end up using.
- */
-typedef NS_ENUM(NSUInteger, CKTypedComponentActionVariant) {
-  CKTypedComponentActionVariantRawSelector = 0,
-  CKTypedComponentActionVariantTargetSelector,
-  CKTypedComponentActionVariantComponentScope
-};
 
 typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   /** Starts searching at the sender's next responder. Usually this is what you want to prevent infinite loops. */
@@ -40,35 +31,45 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
 
 /** A base-class for typed components that doesn't use templates to avoid template bloat. */
 class CKTypedComponentActionBase {
+  /**
+   We support several different types of action variants. You don't need to use this value anywhere, it's set for you
+   by whatever initializer you end up using.
+   */
+  enum class CKTypedComponentActionVariant {
+    RawSelector,
+    TargetSelector,
+    ComponentScope
+  };
+
 protected:
   CKTypedComponentActionBase() noexcept;
   CKTypedComponentActionBase(id target, SEL selector) noexcept;
-  
+
   CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept;
-  
+
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
   CKTypedComponentActionBase(SEL selector) noexcept;
-  
-  /** Allows conversion from NULL actions. */
-  CKTypedComponentActionBase(int s) noexcept;
-  CKTypedComponentActionBase(long s) noexcept;
-  CKTypedComponentActionBase(std::nullptr_t n) noexcept;
-  
+
   ~CKTypedComponentActionBase() {};
-  
+
   id initialTarget(CKComponent *sender) const;
   CKComponentActionSendBehavior defaultBehavior() const;
-  
+
   bool operator==(const CKTypedComponentActionBase& rhs) const;
-  
+
+private:
+  // Destroying this field calls objc_destroyWeak. Since this is the only field
+  // that runs code on destruction, making this field the first field of this
+  // object saves an offset calculation instruction in the destructor.
+  __weak id _targetOrScopeHandle;
   CKTypedComponentActionVariant _variant;
-  __weak id _target;
-  __weak CKComponentScopeHandle *_scopeHandle;
   SEL _selector;
-  
+
 public:
   explicit operator bool() const noexcept;
-  bool isEqual(const CKTypedComponentActionBase &rhs) const noexcept;
+  bool isEqual(const CKTypedComponentActionBase &rhs) const noexcept {
+    return *this == rhs;
+  }
   SEL selector() const noexcept;
   std::string identifier() const noexcept;
 };


### PR DESCRIPTION
The old layout involved two weak objc pointers, so the resulting destructor needs to call `objc_destroyWeak` twice (and associated offset calculations to find the fields). Since these objects are constructed (and destroyed) often, the inlined destruction cost is noticeable.

Since only one of the two weak fields are ever populated, I collapsed them into a single field, and use the enum to interpret it. I also moved the field to the start of the object so that no offset calculation is necessary. This makes the destructor effectively a single `objc_destroyWeak` call. I leave this inline-able since nothing would be gained by forcing another function call.

Here's an example of the destructor portion of the generated code of a function that creates 3 of these temporaries to pass to another function:

Before:
```
        add     r4, sp, #48
        add.w   r0, r4, #8
        bl      _objc_destroyWeak
        adds    r0, r4, #4
        bl      _objc_destroyWeak
        add.w   r0, r8, #8
        bl      _objc_destroyWeak
        add.w   r0, r8, #4
        bl      _objc_destroyWeak
        add     r4, sp, #80
        add.w   r0, r4, #8
        bl      _objc_destroyWeak
        adds    r0, r4, #4
        bl      _objc_destroyWeak
```

After:
```
        add     r0, sp, #48
        bl      _objc_destroyWeak
        add     r0, sp, #60
        bl      _objc_destroyWeak
        mov     r0, r8
        bl      _objc_destroyWeak
```