### PR TITLE
CKGestureAction will not fire if the view has a nil ck_component

### DIFF
--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -179,8 +179,10 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
-  // If the action can be handled by the sender itself, send it there instead of looking up the chain.
-  [recognizer ck_componentAction].send(recognizer.view.ck_component, CKComponentActionSendBehaviorStartAtSender, recognizer);
+  if (recognizer.view.ck_component) {
+    // If the action can be handled by the sender itself, send it there instead of looking up the chain.
+    [recognizer ck_componentAction].send(recognizer.view.ck_component, CKComponentActionSendBehaviorStartAtSender, recognizer);
+  }
 }
 
 @end

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -73,6 +73,24 @@
   XCTAssertTrue([fakeParentComponent receivedTest], @"Expected handler to be called");
 }
 
+- (void)testThatTappingAViewWithoutAComponentAssociatedDoenNotSendComponentAction
+{
+  //For this test the view does not have any component associated
+  UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  id mockComponent = [OCMockObject mockForClass:[CKComponent class]];
+  CKFakeActionComponent *fakeParentComponent = [CKFakeActionComponent new];
+  [[[mockComponent stub] andReturn:fakeParentComponent] nextResponder];
+  [[[mockComponent stub] andReturn:fakeParentComponent] targetForAction:[OCMArg anySelector] withSender:[OCMArg any]];
+
+  CKComponentViewAttributeValue attr = CKComponentTapGestureAttribute(@selector(test:));
+  attr.first.applicator(view, attr.second);
+
+  UIGestureRecognizer *tapRecognizer = [view.gestureRecognizers firstObject];
+  [[CKComponentGestureActionForwarder sharedInstance] handleGesture:tapRecognizer];
+  XCTAssertFalse([fakeParentComponent receivedTest], @"Expected handler not to be called");
+}
+
+
 - (void)testThatApplyingATapRecognizerAttributeWithNoActionDoesNotAddRecognizerToView
 {
   CKComponentViewAttributeValue attr = CKComponentTapGestureAttribute(NULL);


### PR DESCRIPTION
It solves #622.

I went with solution number 1, because in this case it's quite effective.

Adding 2 new lifecycle blocks for attributes (solution 2) is, for me, not the way to go because interactions between applicator, unapplicator, updater, and the new blocks will be quite complex. (glad to be proven wrong on this)

Another approach that I would follow is to create a subclass (substruct??) of CKComponentViewAttribute (maybe CKComponentViewAttributeUnmountRemovable) that can is removed at unmount not when the view is remounted.
I cannot see any other obvious attribute that would benefit of this procedure (that's why it's more a proposal and i have not implemented), but if we found any other we should think about what's the best approach.

Please let me know what do you think about it.