### PR TITLE
Add appearance API on hosting views

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.h
+++ b/ComponentKit/HostingView/CKComponentHostingView.h
@@ -33,6 +33,10 @@
 /** Updates the context used to render the component. */
 - (void)updateContext:(id<NSObject>)context mode:(CKUpdateMode)mode;
 
+/** Appearance events to be funneled to the component tree. */
+- (void)hostingViewWillAppear;
+- (void)hostingViewDidDisappear;
+
 - (instancetype)init CK_NOT_DESIGNATED_INITIALIZER_ATTRIBUTE;
 - (instancetype)initWithFrame:(CGRect)frame CK_NOT_DESIGNATED_INITIALIZER_ATTRIBUTE;
 

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -146,6 +146,18 @@ struct CKComponentHostingViewInputs {
   return _mountedLayout;
 }
 
+#pragma mark - Appearance
+
+- (void)hostingViewWillAppear
+{
+  [_pendingInputs.scopeRoot announceEventToControllers:CKComponentAnnouncedEventTreeWillAppear];
+}
+
+- (void)hostingViewDidDisappear
+{
+  [_pendingInputs.scopeRoot announceEventToControllers:CKComponentAnnouncedEventTreeDidDisappear];
+}
+
 #pragma mark - CKComponentStateListener
 
 - (void)componentScopeHandleWithIdentifier:(CKComponentScopeHandleIdentifier)globalIdentifier


### PR DESCRIPTION
Currently appearance callbacks (`componentTreeWillAppear` and `componentTreeDidDisappear`) on the component controller are not called when a component is hosted in a hosting view. This change provides a way for users to explicitly trigger appearance events on the hosting view, which will then be funneled to the component controller.

This has to be done manually since there is no easy way to infer the visibility change of a view (there are so many factors like alpha value of ancestor, covered by other views etc)