### PR TITLE
Make Nil Actions no-op, remove assert.

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -85,9 +85,9 @@
  }
 
 
- In the even that an action does not contain a target or a selector, it will no-op.
- As a result, it is the responsibility of the component to check (and possibly) assert
- when it has been given an invalid action.
+ In the event that an action does not contain a target or a selector, it will no-op.
+ As a result, it is the responsibility of the component to check (and possibly assert)
+ when it has been given an "invalid" action.
  */
 template<typename... T>
 class CKTypedComponentAction : public CKTypedComponentActionBase {

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -83,6 +83,11 @@
  {
    _action.send(self, @"hello", 4);
  }
+
+
+ In the even that an action does not contain a target or a selector, it will no-op.
+ As a result, it is the responsibility of the component to check (and possibly) assert
+ when it has been given an invalid action.
  */
 template<typename... T>
 class CKTypedComponentAction : public CKTypedComponentActionBase {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -73,14 +73,14 @@ std::string CKTypedComponentActionBase::identifier() const noexcept
 
 NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender) noexcept
 {
+  // If we have a nil selector, we bail early.
+  if (selector == nil) {
+    return nil;
+  }
+
   id responder = ([target respondsToSelector:@selector(targetForAction:withSender:)]
                   ? [target targetForAction:selector withSender:target]
                   : target);
-
-  // If we have no responder to start, bail early.
-  if (responder == nil) {
-    return nil;
-  }
 
   // This is not performance-sensitive, so we can just use an invocation here.
   NSMethodSignature *signature = [responder methodSignatureForSelector:selector];

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -76,8 +76,12 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
   id responder = ([target respondsToSelector:@selector(targetForAction:withSender:)]
                   ? [target targetForAction:selector withSender:target]
                   : target);
-  CKCAssertNotNil(responder, @"Unhandled component action %@ following responder chain %@",
-                  NSStringFromSelector(selector), _CKComponentResponderChainDebugResponderChain(target));
+
+  // If we have no responder to start, bail early.
+  if (responder == nil) {
+    return nil;
+  }
+
   // This is not performance-sensitive, so we can just use an invocation here.
   NSMethodSignature *signature = [responder methodSignatureForSelector:selector];
   while (!signature) {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -73,8 +73,7 @@ std::string CKTypedComponentActionBase::identifier() const noexcept
 
 NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender) noexcept
 {
-  // If we have a nil selector, we bail early.
-  if (selector == nil) {
+  if (selector == NULL) {
     return nil;
   }
 

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -451,7 +451,7 @@
   XCTAssertTrue(target.calledSomeMethod, @"Should have called the method on target");
 }
 
-- (void)testInvocationIsNilWhenSelectorAndTargetAreNil
+- (void)testInvocationIsNilWhenSelectorIsNil
 {
   XCTAssertNil(CKComponentActionSendResponderInvocationPrepare(nil, nil, nil));
 }

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -451,4 +451,9 @@
   XCTAssertTrue(target.calledSomeMethod, @"Should have called the method on target");
 }
 
+- (void)testInvocationIsNilWhenSelectorAndTargetAreNil
+{
+  XCTAssertNil(CKComponentActionSendResponderInvocationPrepare(nil, nil, nil));
+}
+
 @end

--- a/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
@@ -9,7 +9,6 @@
  */
 
 #import <XCTest/XCTest.h>
-#import <OCMock/OCMock.h>
 
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentInternal.h>

--- a/ComponentKitTests/CKComponentDelegateAttributeTests.mm
+++ b/ComponentKitTests/CKComponentDelegateAttributeTests.mm
@@ -10,8 +10,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <OCMock/OCMock.h>
-
 #import <ComponentKit/CKComponent+UIView.h>
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentDelegateAttribute.h>


### PR DESCRIPTION
Currently, if you have a component that takes an action like so

```
[CKFooComponent newWithAction:nil];
```

this will trigger multiple asserts within `CKComponentAction.mm`. This diffs removes those asserts, and simply causes the action to no-op. I've updated the docs, and added a test to verify the new behavior.