### PR TITLE
Remove assert, make actions no-op when they have no target or selector.

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -83,6 +83,11 @@
  {
    _action.send(self, @"hello", 4);
  }
+
+
+ In the event that an action does not contain a target or a selector, it will no-op.
+ As a result, it is the responsibility of the component to check (and possibly assert)
+ when it has been given an "invalid" action.
  */
 template<typename... T>
 class CKTypedComponentAction : public CKTypedComponentActionBase {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -73,11 +73,15 @@ std::string CKTypedComponentActionBase::identifier() const noexcept
 
 NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id target, CKComponent *sender) noexcept
 {
+  // If we have a nil selector, we bail early.
+  if (selector == nil) {
+    return nil;
+  }
+
   id responder = ([target respondsToSelector:@selector(targetForAction:withSender:)]
                   ? [target targetForAction:selector withSender:target]
                   : target);
-  CKCAssertNotNil(responder, @"Unhandled component action %@ following responder chain %@",
-                  NSStringFromSelector(selector), _CKComponentResponderChainDebugResponderChain(target));
+
   // This is not performance-sensitive, so we can just use an invocation here.
   NSMethodSignature *signature = [responder methodSignatureForSelector:selector];
   while (!signature) {

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -451,4 +451,9 @@
   XCTAssertTrue(target.calledSomeMethod, @"Should have called the method on target");
 }
 
+- (void)testInvocationIsNilWhenSelectorIsNil
+{
+  XCTAssertNil(CKComponentActionSendResponderInvocationPrepare(nil, nil, nil));
+}
+
 @end

--- a/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
+++ b/ComponentKitTests/CKComponentDataSourceAttachControllerTests.mm
@@ -9,7 +9,6 @@
  */
 
 #import <XCTest/XCTest.h>
-#import <OCMock/OCMock.h>
 
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentInternal.h>

--- a/ComponentKitTests/CKComponentDelegateAttributeTests.mm
+++ b/ComponentKitTests/CKComponentDelegateAttributeTests.mm
@@ -10,8 +10,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <OCMock/OCMock.h>
-
 #import <ComponentKit/CKComponent+UIView.h>
 #import <ComponentKit/CKComponent.h>
 #import <ComponentKit/CKComponentDelegateAttribute.h>


### PR DESCRIPTION
This commit was landed/reverted, so our bot had trouble importing the updated/accepted diff. Putting up a clean patch to make it happy.

For previous info, see https://github.com/facebook/componentkit/pull/786