### PR TITLE
Check viewClass being a subclass of a UIView

### DIFF
--- a/ComponentKit/Core/CKComponentViewConfiguration.mm
+++ b/ComponentKit/Core/CKComponentViewConfiguration.mm
@@ -20,7 +20,9 @@ CKComponentViewClass::CKComponentViewClass() noexcept : factory(nil) {}
 
 CKComponentViewClass::CKComponentViewClass(Class viewClass) noexcept :
 identifier(class_getName(viewClass)),
-factory(^{return [[viewClass alloc] init];}) {}
+factory(^{ return [[viewClass alloc] init]; }) {
+  CKCAssert([viewClass isSubclassOfClass:[UIView class]], @"%@ is not a subclass of UIView", viewClass);
+}
 
 static CKComponentViewReuseBlock blockFromSEL(SEL sel) noexcept
 {


### PR DESCRIPTION
This should help avoiding silly bugs like the one I had when I passed a `XComponent` instead instead of `XComponentView`.

I couldn't figure out if there's an earlier point where we can to assert on the `viewClass`?