### PR TITLE
Add a block interface for actions

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -133,16 +133,12 @@ public:
   /** We support promotion from actions that take no arguments. */
   template <typename... Ts>
   CKTypedComponentAction<Ts...>(const CKTypedComponentAction<> &action) noexcept : CKTypedComponentActionBase(action) {
-    if (_variant == CKTypedComponentActionVariant::Block) {
-      void (^oldBlock)(CKComponent *) = (void (^)(CKComponent *))action._block;
-      _block = ^(CKComponent *sender, Ts...) { oldBlock(sender); };
-    }
     // At runtime if we provide more arguments to a block on invocation than accepted by the block, the behavior is
     // undefined. If you hit this assert, it means somewhere in your code you're doing this:
     // CKTypedComponentAction<BOOL, int> = ^(CKComponent *sender) {
     // To fix the error, you must handle all arguments:
     // CKTypedComponentAction<BOOL, int> = ^(CKComponent *sender, BOOL foo, int bar) {
-    CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions should not be promoted, you will not receive arguments.");
+    CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions should not take fewer arguments than defined in the declaration of the action, you are depending on undefined behavior and will cause crashes.");
   };
 
   /**
@@ -151,7 +147,7 @@ public:
    */
   template<typename... Ts>
   explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action) noexcept : CKTypedComponentActionBase(action) {
-    CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions cannot be promoted, you are depending on undefined behavior and will cause crashes.");
+    CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions cannot take fewer arguments than provided in the declaration of the action, you are depending on undefined behavior and will cause crashes.");
   };
 
   ~CKTypedComponentAction() {};

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -72,10 +72,6 @@
              ...
              - (void)methodWithSender:(CKComponent *)sender {}
  
- Option 3 - (HIGHLY DISCOURAGED) Block action. We support passing blocks to actions through the actionForBlock() static
-            function, however it is likely to lead to retain cycles unless carefully managed. Avoid this unless there
-            is no other option.
- 
  When using the action, simply use the send() function with the sender, an optional behavior parameter, and the
  arguments defined in the declaration of the action.
 

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -72,6 +72,10 @@
              ...
              - (void)methodWithSender:(CKComponent *)sender {}
  
+ Option 3 - (HIGHLY DISCOURAGED) Block action. We support passing blocks to actions through the actionForBlock() static
+            function, however it is likely to lead to retain cycles unless carefully managed. Avoid this unless there
+            is no other option.
+ 
  When using the action, simply use the send() function with the sender, an optional behavior parameter, and the
  arguments defined in the declaration of the action.
 

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -95,7 +95,8 @@ class CKTypedComponentAction : public CKTypedComponentActionBase {
                 CKTypedComponentActionBoolPack<(std::is_trivially_constructible<T>::value || std::is_pointer<T>::value)...>,
                 CKTypedComponentActionBoolPack<(CKTypedComponentActionDenyType<T>::value)...>
                 >::value, "You must either use a pointer (like an NSObject) or a trivially constructible type. Complex types are not allowed as arguments of component actions.");
-  
+
+  /** This constructor is private to forbid direct usage. Use actionFromBlock. */
   CKTypedComponentAction<T...>(void(^block)(CKComponent *, T...)) noexcept : CKTypedComponentActionBase((dispatch_block_t)block) {};
   
 public:
@@ -122,8 +123,8 @@ public:
   CKTypedComponentAction(SEL selector) noexcept : CKTypedComponentActionBase(selector) {};
 
   /** 
-   Allows passing a block as an action since it is easy to create retain cycles with this API. Always prefer scoped
-   actions over this if possible.
+   Allows passing a block as an action. It is easy to create retain cycles with this API, always prefer scoped actions
+   over this if possible.
    */
   static CKTypedComponentAction<T...> actionFromBlock(void(^block)(CKComponent *, T...)) {
     return CKTypedComponentAction<T...>(block);

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -124,7 +124,11 @@ public:
 
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
   CKTypedComponentAction(SEL selector) noexcept : CKTypedComponentActionBase(selector) {};
-  
+
+  /** 
+   Allows passing a block as an action since it is easy to create retain cycles with this API. Always prefer scoped
+   actions over this if possible.
+   */
   static CKTypedComponentAction<T...> actionFromBlock(void(^block)(CKComponent *, T...)) {
     return CKTypedComponentAction<T...>(block);
   }

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -36,7 +36,6 @@ bool CKTypedComponentActionBase::operator==(const CKTypedComponentActionBase& rh
 
 CKComponentActionSendBehavior CKTypedComponentActionBase::defaultBehavior() const
 {
-  CKCAssertTrue(_variant != CKTypedComponentActionVariant::Block);
   return (_variant == CKTypedComponentActionVariant::RawSelector
           ? CKComponentActionSendBehaviorStartAtSenderNextResponder
           : CKComponentActionSendBehaviorStartAtSender);
@@ -75,6 +74,8 @@ std::string CKTypedComponentActionBase::identifier() const noexcept
 {
   return std::string(sel_getName(_selector)) + "-" + std::to_string((long)(_targetOrScopeHandle));
 }
+
+dispatch_block_t CKTypedComponentActionBase::block() const noexcept { return _block; };
 
 #pragma mark - Sending
 

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -30,11 +30,13 @@ bool CKTypedComponentActionBase::operator==(const CKTypedComponentActionBase& rh
 {
   return (_variant == rhs._variant
           && CKObjectIsEqual(_targetOrScopeHandle, rhs._targetOrScopeHandle)
-          && _selector == rhs._selector);
+          && _selector == rhs._selector
+          && _block == rhs._block);
 }
 
 CKComponentActionSendBehavior CKTypedComponentActionBase::defaultBehavior() const
 {
+  CKCAssertTrue(_variant != CKTypedComponentActionVariant::Block);
   return (_variant == CKTypedComponentActionVariant::RawSelector
           ? CKComponentActionSendBehaviorStartAtSenderNextResponder
           : CKComponentActionSendBehaviorStartAtSender);
@@ -49,18 +51,23 @@ id CKTypedComponentActionBase::initialTarget(CKComponent *sender) const
       return _targetOrScopeHandle;
     case CKTypedComponentActionVariant::ComponentScope:
       return ((CKComponentScopeHandle *) _targetOrScopeHandle).responder;
+    case CKTypedComponentActionVariant::Block:
+      CKCFailAssert(@"Should not be asking for target for block action.");
+      return nil;
   }
 }
 
-CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _targetOrScopeHandle(nil), _variant(CKTypedComponentActionVariant::RawSelector), _selector(nullptr) {}
+CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _targetOrScopeHandle(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(nullptr) {}
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) noexcept : _targetOrScopeHandle(target), _variant(CKTypedComponentActionVariant::TargetSelector), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) noexcept : _targetOrScopeHandle(target), _block(NULL), _variant(CKTypedComponentActionVariant::TargetSelector), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _targetOrScopeHandle(scope.scopeHandle()), _variant(CKTypedComponentActionVariant::ComponentScope), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _targetOrScopeHandle(scope.scopeHandle()), _block(NULL), _variant(CKTypedComponentActionVariant::ComponentScope), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _targetOrScopeHandle(nil), _variant(CKTypedComponentActionVariant::RawSelector), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _targetOrScopeHandle(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(selector) {};
 
-CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL; };
+CKTypedComponentActionBase::CKTypedComponentActionBase(dispatch_block_t block) noexcept : _targetOrScopeHandle(nil), _block(block), _variant(CKTypedComponentActionVariant::Block), _selector(NULL) {};
+
+CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL || _block != NULL; };
 
 SEL CKTypedComponentActionBase::selector() const noexcept { return _selector; };
 

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -75,6 +75,7 @@ public:
     return *this == rhs;
   }
   SEL selector() const noexcept;
+  dispatch_block_t block() const noexcept;
   std::string identifier() const noexcept;
 };
 

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -31,6 +31,8 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
 
 /** A base-class for typed components that doesn't use templates to avoid template bloat. */
 class CKTypedComponentActionBase {
+  protected:
+  
   /**
    We support several different types of action variants. You don't need to use this value anywhere, it's set for you
    by whatever initializer you end up using.
@@ -38,10 +40,10 @@ class CKTypedComponentActionBase {
   enum class CKTypedComponentActionVariant {
     RawSelector,
     TargetSelector,
-    ComponentScope
+    ComponentScope,
+    Block
   };
 
-protected:
   CKTypedComponentActionBase() noexcept;
   CKTypedComponentActionBase(id target, SEL selector) noexcept;
 
@@ -49,6 +51,8 @@ protected:
 
   /** Legacy constructor for raw selector actions. Traverse up the mount responder chain. */
   CKTypedComponentActionBase(SEL selector) noexcept;
+  
+  CKTypedComponentActionBase(dispatch_block_t block) noexcept;
 
   ~CKTypedComponentActionBase() {};
 
@@ -57,11 +61,11 @@ protected:
 
   bool operator==(const CKTypedComponentActionBase& rhs) const;
 
-private:
   // Destroying this field calls objc_destroyWeak. Since this is the only field
   // that runs code on destruction, making this field the first field of this
   // object saves an offset calculation instruction in the destructor.
   __weak id _targetOrScopeHandle;
+  dispatch_block_t _block;
   CKTypedComponentActionVariant _variant;
   SEL _selector;
 

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -444,7 +444,7 @@
 
 - (void)testTargetSelectorActionCallsOnNormalNSObject
 {
-  CKTestObjectTarget *target =[CKTestObjectTarget new];
+  CKTestObjectTarget *target = [CKTestObjectTarget new];
   CKComponentAction action = CKComponentAction(CKTypedComponentAction<>(target, @selector(someMethod)));
   action.send([CKComponent new]);
 
@@ -454,6 +454,43 @@
 - (void)testInvocationIsNilWhenSelectorIsNil
 {
   XCTAssertNil(CKComponentActionSendResponderInvocationPrepare(nil, nil, nil));
+}
+
+- (void)testBlockActionFires
+{
+  __block BOOL firedAction = NO;
+  CKComponentAction action = CKComponentAction::actionFromBlock(^(CKComponent *) {
+    firedAction = YES;
+  });
+
+  action.send([CKComponent new]);
+
+  XCTAssertTrue(firedAction);
+}
+
+- (void)testBlockActionFiresAndDeliversComponentAsSender
+{
+  __block BOOL equalComponents = NO;
+  CKComponent *c = [CKComponent new];
+  CKComponentAction action = CKComponentAction::actionFromBlock(^(CKComponent *passedComponent) {
+    equalComponents = (passedComponent == c);
+  });
+
+  action.send(c);
+
+  XCTAssertTrue(equalComponents);
+}
+
+- (void)testBlockActionFiresAndDeliversAdditionalParameterAsArgument
+{
+  __block BOOL equalArguments = NO;
+  NSObject *arg = [NSObject new];
+  CKTypedComponentAction<NSObject *> action = CKTypedComponentAction<NSObject *>::actionFromBlock(^(CKComponent *c, NSObject *passedArgument) {
+    equalArguments = (passedArgument == arg);
+  });
+
+  action.send([CKComponent new], arg);
+  XCTAssertTrue(equalArguments);
 }
 
 @end

--- a/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.mm
@@ -44,7 +44,9 @@ static NSString *const oscarWilde = @"Oscar Wilde";
    [CKStackLayoutComponent
     newWithView:{
       [UIView class],
-      {CKComponentTapGestureAttribute(@selector(didTap))}
+      {CKComponentTapGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *>::actionFromBlock(^(CKComponent *sender, UIGestureRecognizer *recognizer) {
+        NSLog(@"action!");
+      }))}
     }
     size:{}
     style:{

--- a/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.mm
@@ -44,9 +44,7 @@ static NSString *const oscarWilde = @"Oscar Wilde";
    [CKStackLayoutComponent
     newWithView:{
       [UIView class],
-      {CKComponentTapGestureAttribute(CKTypedComponentAction<UIGestureRecognizer *>::actionFromBlock(^(CKComponent *sender, UIGestureRecognizer *recognizer) {
-        NSLog(@"action!");
-      }))}
+      {CKComponentTapGestureAttribute(@selector(didTap))}
     }
     size:{}
     style:{


### PR DESCRIPTION
We originally had an interface like this for JS interop, but we removed it due to binary size. Let's try adding this back and see what it does since @ashwinb needs this for JS interop in CK.

This is a test diff to see binary size impact. I'm mostly concerned about additional objc_storeStrong in every receiving callsite of a component action.

BTW, using templates we can actually handle the block promotion/demotion relatively nicely, since each time the block is converted, we know the number of arguments before/after so we can wrap the blocks with a new template pack.... however at the cost of additional code bloat at the conversion callsites, and unlike selectors when promoting/demoting we actually slice off the values as you convert.

Thus, I think it's probably safer/better in the long-run to remove the option to promote block actions, and a necessity to delete the demotion side. I've added asserts so we can know where this happens, and I was considering just nilling out the block when this happens to avoid undefined behavior at runtime.