### PR TITLE
Remove target/selector actions

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -50,18 +50,8 @@
                          newWithAction:{scope, @selector(methodWithSender:)}]];
              }
              - (void)methodWithSender:(CKComponent *)sender {}
- 
- Option 2 - Target/selector action. Ensures that the target responds to the given selector. Target must directly
-            respond to the selector. Targets are captured weakly by the action. Promotion, as in option 2 above is also
-            supported for target/selector actions. This constructor is useful for triggering actions on objects outside
-            of the component hierarchy like view controllers. Does not depend on the mount-based responder chain to
-            call on the target.
 
-             [MyComponent newWithAction:{[SomeObject sharedInstance], @selector(methodWithNoArguments)}];
-             ...
-             on SomeObject: - (void)methodWithNoArguments {}
-
- Option 3 - (Discouraged) Raw-selector component action. Uses a raw selector which traverses upwards looking for a
+ Option 2 - (Discouraged) Raw-selector component action. Uses a raw selector which traverses upwards looking for a
             parent that implements methodWithNoArguments, and calls that method without any arguments. The component
             responder chain is only present while the component is mounted, so you should use a target/selector action
             or a scope action if your action will be fired either before or after your component is mounted. We support
@@ -104,14 +94,6 @@ class CKTypedComponentAction : public CKTypedComponentActionBase {
   
 public:
   CKTypedComponentAction<T...>() noexcept : CKTypedComponentActionBase() {};
-  CKTypedComponentAction<T...>(id target, SEL selector) noexcept : CKTypedComponentActionBase(target, selector)
-  {
-#if DEBUG
-    std::vector<const char *> typeEncodings;
-    CKTypedComponentActionTypeVectorBuild(typeEncodings, CKTypedComponentActionTypelist<T...>{});
-    _CKTypedComponentDebugCheckTargetSelector(target, selector, typeEncodings);
-#endif
-  }
 
   CKTypedComponentAction<T...>(const CKComponentScope &scope, SEL selector) noexcept : CKTypedComponentActionBase(scope, selector)
   {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -274,21 +274,6 @@ void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SE
 #endif
 }
 
-void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings) noexcept
-{
-#if DEBUG
-  // In DEBUG mode, we want to do the minimum of type-checking for the action that's possible in Objective-C. We
-  // can't do exact type checking, but we can ensure that you're passing the right type of primitives to the right
-  // argument indices.
-  CKCAssert(selector == NULL || [target respondsToSelector:selector], @"Target does not respond to selector for component action. -[%@ %@]", [target class], NSStringFromSelector(selector));
-
-  NSMethodSignature *signature = [target methodSignatureForSelector:selector];
-
-  checkMethodSignatureAgainstTypeEncodings(selector, signature, typeEncodings);
-#endif
-}
-
-
 // This method returns a friendly-print of a responder chain. Used for debug purposes.
 NSString *_CKComponentResponderChainDebugResponderChain(id responder) noexcept {
   return (responder

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -30,7 +30,7 @@ void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger inde
 bool CKTypedComponentActionBase::operator==(const CKTypedComponentActionBase& rhs) const
 {
   return (_variant == rhs._variant
-          && CKObjectIsEqual(_targetOrScopeHandle, rhs._targetOrScopeHandle)
+          && CKObjectIsEqual(_scopeHandle, rhs._scopeHandle)
           && _selector == rhs._selector
           && _block == rhs._block);
 }
@@ -47,25 +47,21 @@ id CKTypedComponentActionBase::initialTarget(CKComponent *sender) const
   switch (_variant) {
     case CKTypedComponentActionVariant::RawSelector:
       return sender;
-    case CKTypedComponentActionVariant::TargetSelector:
-      return _targetOrScopeHandle;
     case CKTypedComponentActionVariant::ComponentScope:
-      return ((CKComponentScopeHandle *) _targetOrScopeHandle).responder;
+      return _scopeHandle.responder;
     case CKTypedComponentActionVariant::Block:
       CKCFailAssert(@"Should not be asking for target for block action.");
       return nil;
   }
 }
 
-CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _targetOrScopeHandle(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(nullptr) {}
+CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _scopeHandle(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(nullptr) {}
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) noexcept : _targetOrScopeHandle(target), _block(NULL), _variant(CKTypedComponentActionVariant::TargetSelector), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _scopeHandle(scope.scopeHandle()), _block(NULL), _variant(CKTypedComponentActionVariant::ComponentScope), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _targetOrScopeHandle(scope.scopeHandle()), _block(NULL), _variant(CKTypedComponentActionVariant::ComponentScope), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _scopeHandle(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _targetOrScopeHandle(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(selector) {};
-
-CKTypedComponentActionBase::CKTypedComponentActionBase(dispatch_block_t block) noexcept : _targetOrScopeHandle(nil), _block(block), _variant(CKTypedComponentActionVariant::Block), _selector(NULL) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(dispatch_block_t block) noexcept : _scopeHandle(nil), _block(block), _variant(CKTypedComponentActionVariant::Block), _selector(NULL) {};
 
 CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL || _block != NULL; };
 
@@ -73,7 +69,7 @@ SEL CKTypedComponentActionBase::selector() const noexcept { return _selector; };
 
 std::string CKTypedComponentActionBase::identifier() const noexcept
 {
-  return std::string(sel_getName(_selector)) + "-" + std::to_string((long)(_targetOrScopeHandle));
+  return std::string(sel_getName(_selector)) + "-" + std::to_string((long)(_scopeHandle));
 }
 
 dispatch_block_t CKTypedComponentActionBase::block() const noexcept { return _block; };

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -32,20 +32,13 @@ typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
 /** A base-class for typed components that doesn't use templates to avoid template bloat. */
 class CKTypedComponentActionBase {
   protected:
-  
-  /**
-   We support several different types of action variants. You don't need to use this value anywhere, it's set for you
-   by whatever initializer you end up using.
-   */
   enum class CKTypedComponentActionVariant {
     RawSelector,
-    TargetSelector,
     ComponentScope,
     Block
   };
 
   CKTypedComponentActionBase() noexcept;
-  CKTypedComponentActionBase(id target, SEL selector) noexcept;
 
   CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept;
 
@@ -64,7 +57,7 @@ class CKTypedComponentActionBase {
   // Destroying this field calls objc_destroyWeak. Since this is the only field
   // that runs code on destruction, making this field the first field of this
   // object saves an offset calculation instruction in the destructor.
-  __weak id _targetOrScopeHandle;
+  CKComponentScopeHandle *__weak _scopeHandle;
   dispatch_block_t _block;
   CKTypedComponentActionVariant _variant;
   SEL _selector;

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -118,8 +118,6 @@ void CKConfigureInvocationWithArguments(NSInvocation *invocation, NSInteger inde
 
 void _CKTypedComponentDebugCheckComponentScope(const CKComponentScope &scope, SEL selector, const std::vector<const char *> &typeEncodings) noexcept;
 
-void _CKTypedComponentDebugCheckTargetSelector(id target, SEL selector, const std::vector<const char *> &typeEncodings) noexcept;
-
 NSString *_CKComponentResponderChainDebugResponderChain(id responder) noexcept;
 
 #pragma mark - Sending

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -153,25 +153,6 @@
   CKUnmountComponents(mountedComponents);
 }
 
-- (void)testControlActionsWithEqualTargetsHasEqualIdentifiers
-{
-  CKComponentActionAttributeTestObject *obj1 = [CKComponentActionAttributeTestObject new];
-  CKComponentViewAttributeValue attr1 = CKComponentActionAttribute({obj1, @selector(someAction)});
-  CKComponentViewAttributeValue attr2 = CKComponentActionAttribute({obj1, @selector(someAction)});
-
-  XCTAssertEqual(attr1.first.identifier, attr2.first.identifier);
-}
-
-- (void)testControlActionsWithNonEqualTargetsHasNonEqualIdentifiers
-{
-  CKComponentActionAttributeTestObject *obj1 = [CKComponentActionAttributeTestObject new];
-  CKComponentActionAttributeTestObject *obj2 = [CKComponentActionAttributeTestObject new];
-  CKComponentViewAttributeValue attr1 = CKComponentActionAttribute({obj1, @selector(someAction)});
-  CKComponentViewAttributeValue attr2 = CKComponentActionAttribute({obj2, @selector(someAction)});
-
-  XCTAssertNotEqual(attr1.first.identifier, attr2.first.identifier);
-}
-
 - (void)testControlActionsWithRawSelectorActionsHaveEqualIdentifiers
 {
   CKComponentViewAttributeValue attr1 = CKComponentActionAttribute(@selector(someAction));

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -354,25 +354,6 @@
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
 }
 
-- (void)testTargetSelectorActionCallsOnTargetWithoutMounting
-{
-  __block BOOL calledBlock = NO;
-
-  CKComponent *innerComponent = [CKComponent new];
-  CKTestActionComponent *outerComponent =
-  [CKTestActionComponent
-   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ calledBlock = YES; }
-   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
-   primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
-   component:innerComponent];
-
-  CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
-  action.send(innerComponent, CKComponentActionSendBehaviorStartAtSender, @"hello");
-
-  XCTAssertTrue(calledBlock, @"Outer component should have received the action, even though the components are not mounted.");
-}
-
 - (void)testScopeActionCallsMethodOnScopedComponent
 {
   __block BOOL calledAction = NO;
@@ -424,33 +405,6 @@
   [component triggerAction:nil];
 
   XCTAssertTrue(calledAction, @"Should have called the action on the test component");
-}
-
-- (void)testDemotedTargetSelectorActionCallsMethodOnScopedComponent
-{
-  __block BOOL calledAction = NO;
-
-  // We have to use build component here to ensure the scopes are properly configured.
-  CKTestScopeActionComponent *component = (CKTestScopeActionComponent *)CKBuildComponent(CKComponentScopeRootWithDefaultPredicates(nil), {}, ^{
-    return [CKTestScopeActionComponent
-            newWithBlock:^(CKComponent *sender, id context) {
-              calledAction = YES;
-            }];
-  }).component;
-
-  CKComponentAction action = CKComponentAction(CKTypedComponentAction<id>(component, @selector(actionMethod:context:)));
-  action.send(component);
-
-  XCTAssertTrue(calledAction, @"Should have called the action on the test component");
-}
-
-- (void)testTargetSelectorActionCallsOnNormalNSObject
-{
-  CKTestObjectTarget *target = [CKTestObjectTarget new];
-  CKComponentAction action = CKComponentAction(CKTypedComponentAction<>(target, @selector(someMethod)));
-  action.send([CKComponent new]);
-
-  XCTAssertTrue(target.calledSomeMethod, @"Should have called the method on target");
 }
 
 - (void)testInvocationIsNilWhenSelectorIsNil

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -138,25 +138,6 @@
   XCTAssertNil(gesture.delegate, @"Gesture delegate should not be set");
 }
 
-- (void)testThatApplyingATapRecognizerAttributeWithDifferentTargetToViewWithExistingRecognizerUpdatesAction
-{
-  CKFakeActionComponent *fake1 = [CKFakeActionComponent new];
-  CKComponentViewAttributeValue attr1 = CKComponentTapGestureAttribute({fake1, @selector(test:)});
-
-  CKFakeActionComponent *fake2 = [CKFakeActionComponent new];
-  CKTypedComponentAction<UIGestureRecognizer *> action2 = {fake2, @selector(test:)};
-  CKComponentViewAttributeValue attr2 = CKComponentTapGestureAttribute(action2);
-  UIView *view = [UIView new];
-
-  attr1.first.applicator(view, attr1.second);
-  attr1.first.unapplicator(view, attr1.second);
-
-  attr2.first.applicator(view, attr2.second);
-  UITapGestureRecognizer *recognizer = [view.gestureRecognizers firstObject];
-  XCTAssert([recognizer ck_componentAction] == action2, @"Expected ck_componentAction to be set on the GR");
-  attr2.first.unapplicator(view, attr2.second);
-}
-
 @end
 
 @implementation CKFakeActionComponent


### PR DESCRIPTION
We just added support for blocks. Anything you can implement with target/selector actions can be implemented using blocks. Let's have less API's here.j

I have to rebase this after the scope diff merges so I can fix up the tests. Deleting them right now, but I'll bring most of 'em back once that lands.