### PR TITLE
Trivial blocks

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -92,7 +92,10 @@
 template<typename... T>
 class CKTypedComponentAction : public CKTypedComponentActionBase {
   static_assert(std::is_same<
-                CKTypedComponentActionBoolPack<(std::is_trivially_constructible<T>::value || std::is_pointer<T>::value)...>,
+                CKTypedComponentActionBoolPack<(std::is_reference<T>::value
+                                                || std::is_pointer<T>::value
+                                                || std::is_fundamental<T>::value
+                                                || std::is_convertible<T, id>::value)...>,
                 CKTypedComponentActionBoolPack<(CKTypedComponentActionDenyType<T>::value)...>
                 >::value, "You must either use a pointer (like an NSObject) or a trivially constructible type. Complex types are not allowed as arguments of component actions.");
 

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -94,7 +94,7 @@ class CKTypedComponentAction : public CKTypedComponentActionBase {
   static_assert(std::is_same<
                 CKTypedComponentActionBoolPack<(std::is_reference<T>::value
                                                 || std::is_pointer<T>::value
-                                                || std::is_fundamental<T>::value
+                                                || std::is_trivially_constructible<T>::value
                                                 || std::is_convertible<T, id>::value)...>,
                 CKTypedComponentActionBoolPack<(CKTypedComponentActionDenyType<T>::value)...>
                 >::value, "You must either use a pointer (like an NSObject) or a trivially constructible type. Complex types are not allowed as arguments of component actions.");


### PR DESCRIPTION
I used is_trivially_constructible, but really what we need here are things that work with NSInvocation. dispatch blocks should be totally fine to pass to NSInvocation, it has fully support in the language. Yet, is_trivially_constructible returns the false type.

This allows CKTypedComponentAction<dispatch_block_t>, but still forbids CKTypedComponentAction<std::vector<int>>, since that would result in undefined behavior when calling the method with a complex type. We allow references, pointers, things that convert to id, and trivially constructible types.