### PR TITLE
Remove int+long CKTypedComponentAction constructors

### DIFF
--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -165,7 +165,7 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                             std::move(attributes),
                             {
                               .accessibilityLabel = accessibilityConfiguration.accessibilityLabel,
-                              .accessibilityComponentAction = enabled ? CKComponentAction(action) : NULL
+                              .accessibilityComponentAction = enabled ? CKComponentAction(action) : nullptr
                             }
                           }
                           size:size];

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -133,9 +133,10 @@ public:
     return CKTypedComponentAction<T...>(block);
   }
 
-  /** Allows conversion from NULL actions. */
-  CKTypedComponentAction(int s) noexcept : CKTypedComponentActionBase() {};
-  CKTypedComponentAction(long s) noexcept : CKTypedComponentActionBase() {};
+  /**
+   Allows explicit null actions. NULL can cause ambiguity in constructor resolution and is best avoided where
+   nullptr is available.
+   */
   CKTypedComponentAction(std::nullptr_t n) noexcept : CKTypedComponentActionBase() {};
 
   /** We support promotion from actions that take no arguments. */

--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -149,7 +149,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
         UIGestureRecognizer *recognizer = recognizerForAction(view, blockAction);
         CKCAssertNotNil(recognizer, @"Expected to find recognizer for %@ on teardown", NSStringFromSelector(blockAction.selector()));
         [view removeGestureRecognizer:recognizer];
-        [recognizer ck_setComponentAction:NULL];
+        [recognizer ck_setComponentAction:nullptr];
         
         // Tear down delegate proxying if applicable
         if (delegateSelectors.size() > 0) {

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -131,7 +131,7 @@
   [CKComponent
    newWithView:{
      [UIButton class],
-     {CKComponentActionAttribute(NULL)}
+     {CKComponentActionAttribute(nullptr)}
    }
    size:{}];
 

--- a/ComponentKitTests/CKComponentAccessibilityCustomActionsAttributeTests.mm
+++ b/ComponentKitTests/CKComponentAccessibilityCustomActionsAttributeTests.mm
@@ -98,7 +98,7 @@
    newWithView:{
      [UIView class],
      {CKComponentAccessibilityCustomActionsAttribute({
-       {@"Test", NULL},
+       {@"Test", nullptr},
        {@"Test 2", @selector(testAction:context:)},
      })}
    }

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -93,7 +93,7 @@
 
 - (void)testThatApplyingATapRecognizerAttributeWithNoActionDoesNotAddRecognizerToView
 {
-  CKComponentViewAttributeValue attr = CKComponentTapGestureAttribute(NULL);
+  CKComponentViewAttributeValue attr = CKComponentTapGestureAttribute(nullptr);
   UIView *view = [UIView new];
 
   attr.first.applicator(view, attr.second);

--- a/ComponentKitTests/CKOptimisticViewMutationsTests.mm
+++ b/ComponentKitTests/CKOptimisticViewMutationsTests.mm
@@ -85,7 +85,7 @@
    titleFont:nil
    selected:NO
    enabled:YES
-   action:NULL
+   action:nullptr
    size:{}
    attributes:{}
    accessibilityConfiguration:{}];


### PR DESCRIPTION
* `NULL` can possibly be `0`, `0L`, or `nullptr_t`, depending on implementation or whether using C or C++.
* `CKTypedComponentAction` has multiple constructors which accept one parameter:
  * `SEL`: essentially `char *`, which is pointer-sized
  * `int`: probably pointer sized
  * `long`: pointer sized
  * `dispatch_block_t`: IIRC, either an object (Obj-C) or a lambda (C++).
  * `std::nullptr_t`: typesafe `NULL`

A `NULL` result in a ternary expression that provides a value to a struct with a `CKTypedComponentAction<CKComponent *>` field is seemingly allowed by clang but may result in undefined behavior.

Basically: the ternary was supposed to return a `CKTypedComponentAction<CKComponent *>`, i.e. a value, not a pointer. Sensibly, the non-`NULL` case calls the copy constructor, so it makes sense that the `NULL` case would call a constructor appropriate for `NULL`. The question is...which one? There are several which are pointer-sized, including two numeric.

The answer is that the constructor that takes `long` is chosen. I don't think that this is a satisfying result. The conclusion of this is that it seems prudent to remove the `int` and `long` constructors (as they serve no purpose other to accept `NULL` for convenience), preserve the `std::nullptr_t` constructor, and modify all `CKComponentAction` parameters to use `nullptr` instead of `NULL`.

This may be a slightly breaking change for the API in two ways:

* `NULL` is no longer accepted as an explicit action argument
  * However, the remediation is very easy - change that `NULL` to a `nullptr`.
* Some arguments may be ambiguous
  * It's not a bug, it's a feature! ;) The ambiguity should surface the previously-undefined behavior, allowing developer judgment to resolve it with a cast, `nullptr` replacement, or other modification.