### PR TITLE
[ComponentTextKit] Optimize TextKit Renderer to Only Draw Supplied Bounds

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRenderer.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRenderer.mm
@@ -110,7 +110,7 @@ static NSCharacterSet *_defaultAvoidTruncationCharacterSet()
   UIGraphicsPushContext(context);
 
   [_context performBlockWithLockedTextKitComponents:^(NSLayoutManager *layoutManager, NSTextStorage *textStorage, NSTextContainer *textContainer) {
-    NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
+    NSRange glyphRange = [layoutManager glyphRangeForBoundingRect:bounds inTextContainer:textContainer];
     [layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:shadowInsetBounds.origin];
     [layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:shadowInsetBounds.origin];
   }];


### PR DESCRIPTION
This attempts to fix #809. Not entirely sure if there could be any side effects in exchange for a performance boost… but all the tests pass! ¯\_(ツ)_/¯ 