### PR TITLE
Fix memory management of actions

### DIFF
--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -139,5 +139,8 @@ static void CKComponentActionSendResponderChain(SEL selector, id target, CKCompo
   // We use a recursive argument unpack to unwrap the variadic arguments in-order on the invocation in a type-safe
   // manner.
   CKConfigureInvocationWithArguments(invocation, 3, args...);
+  // NSInvocation does not by default retain its target or object arguments. We have to manually call this to ensure
+  // that these arguments and target are not deallocated through the scope of the invocation.
+  [invocation retainArguments];
   [invocation invoke];
 }


### PR DESCRIPTION
Whelp, it turns out that when we moved this to NSInvocation, we stopped retaining the target of the action during the scope of the call. When I refactored scopes recently, I inadvertently weakified the only remaining strong references of some components internally, and this started firing.

Within the scope of the action call, the component can do anything... and one of the primary things that is done is updateState:. In truly synchronous (aka not transactional datasource updates) updates, that means that the component can actually be deallocated within the invocation! This causes the component itself to no longer be a valid object within the scope of one of its methods. This means any dereferences, etc. become undefined, and can crash with EXC_BAD_ACCESS.

So this diff returns the action code to strongly retaining the target and arguments for the scope of the call using NSInvocation's supported manual-retain API.

After calling this method, there is no need to manually release the arguments or target, they are automatically added to the autorelease pool on the current thread, which means they are deallocated when the autorelease pool is cleared.