### PR TITLE
Introduce concept of nested thread local scopes.

### DIFF
--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
@@ -31,5 +31,5 @@ public:
   std::stack<std::vector<id<NSObject>>> keys;
 
 private:
-  CKThreadLocalComponentScope *previousScope;
+  CKThreadLocalComponentScope *const previousScope;
 };

--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.h
@@ -29,17 +29,7 @@ public:
   const CKComponentStateUpdateMap stateUpdates;
   std::stack<CKComponentScopeFramePair> stack;
   std::stack<std::vector<id<NSObject>>> keys;
-};
-
-/**
- Temporarily overrides the current thread's component scope.
- Use for testing and advanced integration purposes only.
- */
-class CKThreadLocalComponentScopeOverride {
-public:
-  CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope) noexcept;
-  ~CKThreadLocalComponentScopeOverride();
 
 private:
-  CKThreadLocalComponentScope *const previousScope;
+  CKThreadLocalComponentScope *previousScope;
 };

--- a/ComponentKit/Core/Scope/CKThreadLocalComponentScope.mm
+++ b/ComponentKit/Core/Scope/CKThreadLocalComponentScope.mm
@@ -34,9 +34,8 @@ CKThreadLocalComponentScope *CKThreadLocalComponentScope::currentScope() noexcep
 
 CKThreadLocalComponentScope::CKThreadLocalComponentScope(CKComponentScopeRoot *previousScopeRoot,
                                                          const CKComponentStateUpdateMap &updates)
-: newScopeRoot([previousScopeRoot newRoot]), stateUpdates(updates), stack()
+: newScopeRoot([previousScopeRoot newRoot]), stateUpdates(updates), stack(), previousScope(CKThreadLocalComponentScope::currentScope())
 {
-  CKCAssert(CKThreadLocalComponentScope::currentScope() == nullptr, @"CKThreadLocalComponentScope already exists");
   stack.push({[newScopeRoot rootFrame], [previousScopeRoot rootFrame]});
   keys.push({});
   pthread_setspecific(_threadKey(), this);
@@ -47,16 +46,5 @@ CKThreadLocalComponentScope::~CKThreadLocalComponentScope()
   stack.pop();
   CKCAssert(stack.empty(), @"Didn't expect stack to contain anything in destructor");
   CKCAssert(keys.size() == 1 && keys.top().empty(), @"Expected keys to be at initial state in destructor");
-  pthread_setspecific(_threadKey(), nullptr);
-}
-
-CKThreadLocalComponentScopeOverride::CKThreadLocalComponentScopeOverride(CKThreadLocalComponentScope *scope) noexcept
-: previousScope(CKThreadLocalComponentScope::currentScope())
-{
-  pthread_setspecific(_threadKey(), scope);
-}
-
-CKThreadLocalComponentScopeOverride::~CKThreadLocalComponentScopeOverride()
-{
   pthread_setspecific(_threadKey(), previousScope);
 }


### PR DESCRIPTION
If another `CKThreadLocalComponentScope` is created while another is in scope, it is overridden. This changes behavior so that the newly created scope takes precedence as `currentScope` for the duration of its' lifecycle. When it is destructed, the previous `currentScope` is restored.