### PR TITLE
Allow component subclasses to obtain a reference to the view used to render animations

### DIFF
--- a/ComponentKit/Core/CKComponentAnimation.mm
+++ b/ComponentKit/Core/CKComponentAnimation.mm
@@ -10,7 +10,7 @@
 
 #import "CKComponentAnimation.h"
 
-#import "CKComponentInternal.h"
+#import "CKComponentSubclass.h"
 
 @interface CKAppliedAnimationContext : NSObject
 - (instancetype)initWithTargetLayer:(CALayer *)layer key:(NSString *)key;

--- a/ComponentKit/Core/CKComponentInternal.h
+++ b/ComponentKit/Core/CKComponentInternal.h
@@ -58,9 +58,6 @@
 /** Called when the component and all its children have been mounted. */
 - (void)childrenDidMount;
 
-/** Called by the animation machinery. Do not access this externally. */
-- (UIView *)viewForAnimation;
-
 /** Used to get the root component in the responder chain; don't touch this. */
 @property (nonatomic, weak) UIView *rootComponentMountedView;
 

--- a/ComponentKit/Core/CKComponentSubclass.h
+++ b/ComponentKit/Core/CKComponentSubclass.h
@@ -146,6 +146,8 @@ extern CGSize const kCKComponentParentSizeUndefined;
    2. CKComponent subclasses not backed by a view will return nil
    3. CKCompositeComponent subclasses backed by a view will return the backing view
    4. CKCompositeComponent subclasses not backed by a view will return the animatable view of its descendant
+
+ This method may be overridden in rare situations where a more suitable view should be used for rendering animations.
  */
 - (UIView *)viewForAnimation;
 

--- a/ComponentKit/Core/CKComponentSubclass.h
+++ b/ComponentKit/Core/CKComponentSubclass.h
@@ -136,6 +136,19 @@ extern CGSize const kCKComponentParentSizeUndefined;
  */
 - (CKComponentBoundsAnimation)boundsAnimationFromPreviousComponent:(CKComponent *)previousComponent;
 
+/**
+ Attempts to return a view suitable for rendering an animation.
+
+ Since a component may or may not be backed by a view nil may be returned. Composite components may, given the fact
+ they are composed of other components, return the animatable view of its descendant. As a rule of thumb:
+
+   1. CKComponent subclasses backed by a view will return the backing view
+   2. CKComponent subclasses not backed by a view will return nil
+   3. CKCompositeComponent subclasses backed by a view will return the backing view
+   4. CKCompositeComponent subclasses not backed by a view will return the animatable view of its descendant
+ */
+- (UIView *)viewForAnimation;
+
 /** Returns the component's controller, if any. */
 - (CKComponentController *)controller;
 


### PR DESCRIPTION
`-[CKComponent viewForAnimation]` and `-[CKCompositeComponent viewForAnimation]` can, and often are, used to support more complex animations in a component hierarchy. Given this reality move the declaration of this method out of `CKComponentInternal.h` and into `CKComponentSubclass.h`.