### PR TITLE
Fix Scoped Component Actions so that they have unique identifiers.

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -69,6 +69,11 @@
 
 @end
 
+typedef int32_t CKScopedResponderUniqueIdentifier;
+
 @interface CKScopedResponder : NSObject
+
+@property (nonatomic, readonly) CKScopedResponderUniqueIdentifier uniqueIdentifier;
+
 - (id)responder;
 @end

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -73,7 +73,8 @@ typedef int32_t CKScopedResponderUniqueIdentifier;
 
 @interface CKScopedResponder : NSObject
 
-@property (nonatomic, readonly) CKScopedResponderUniqueIdentifier uniqueIdentifier;
+@property (nonatomic, readonly, assign) CKScopedResponderUniqueIdentifier uniqueIdentifier;
 
 - (id)responder;
+
 @end

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -201,6 +201,16 @@
   std::mutex _mutex;
 }
 
+- (instancetype)init
+{
+  if (self = [super init]) {
+    static CKScopedResponderUniqueIdentifier nextIdentifier = 0;
+    _uniqueIdentifier = OSAtomicIncrement32(&nextIdentifier);
+  }
+  
+  return self;
+}
+
 - (void)addHandleToChain:(CKComponentScopeHandle *)handle
 {
   if (!handle) {

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -70,13 +70,18 @@ CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : 
 
 CKTypedComponentActionBase::CKTypedComponentActionBase(dispatch_block_t block) noexcept : _target(nil), _scopedResponder(nil), _block(block), _variant(CKTypedComponentActionVariant::Block), _selector(NULL) {};
 
-CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL || _block != NULL; };
+CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL || _block != NULL || _scopedResponder != nil; };
 
 SEL CKTypedComponentActionBase::selector() const noexcept { return _selector; };
 
 std::string CKTypedComponentActionBase::identifier() const noexcept
 {
-  return std::string(sel_getName(_selector)) + "-" + std::to_string((long)(_target));
+  const BOOL isResponderVariant = (_variant == CKTypedComponentActionVariant::Responder);
+  const std::string identifier = isResponderVariant
+                                  ? std::to_string([_scopedResponder uniqueIdentifier])
+                                  : std::to_string((long)(_target));
+  
+  return std::string(sel_getName(_selector)) + "-" + identifier;
 }
 
 dispatch_block_t CKTypedComponentActionBase::block() const noexcept { return _block; };

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -22,6 +22,7 @@
 #import <ComponentKit/CKComponentScopeRoot.h>
 #import <ComponentKit/CKComponentScopeRootFactory.h>
 #import <ComponentKit/CKComponentController.h>
+#import <ComponentKit/CKThreadLocalComponentScope.h>
 
 @interface CKTestScopeActionComponent : CKComponent
 
@@ -493,6 +494,19 @@
 
   action.send([CKComponent new], arg);
   XCTAssertTrue(equalArguments);
+}
+
+- (void)testThatScopeActionWithSameSelectorHaveUniqueIdentifiers
+{
+  CKThreadLocalComponentScope threadScope(CKComponentScopeRootWithDefaultPredicates(nil), {});
+  
+  CKComponentScope scope([CKTestScopeActionComponent class], @"moose");
+  const CKComponentAction action1 = {scope, @selector(triggerAction:)};
+  
+  CKComponentScope scope2([CKTestScopeActionComponent class], @"cat");
+  const CKComponentAction action2 = {scope2, @selector(triggerAction:)};
+
+  XCTAssertNotEqual(action1.identifier(), action2.identifier());
 }
 
 @end


### PR DESCRIPTION
We are seeing a problem in the Facebook app because Scoped Component Actions that use the same selector are overriding each other within `CKComponentAttributeValueMap`. This fixes that!