### PR TITLE
Introduce the concept of fatal assertions and use them when encountering invalid changesets

### DIFF
--- a/ComponentKit/Base/CKAssert.h
+++ b/ComponentKit/Base/CKAssert.h
@@ -39,3 +39,6 @@
 
 #define CKFailAssert(description, ...) CKAssert(NO, nil, (description), ##__VA_ARGS__)
 #define CKCFailAssert(description, ...) CKCAssert(NO, nil, (description), ##__VA_ARGS__)
+
+#define CKFatalAssert(description, ...) CKAssert(NO, nil, (description), ##__VA_ARGS__)
+#define CKCFatalAssert(description, ...) CKCAssert(NO, nil, (description), ##__VA_ARGS__)

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -264,13 +264,9 @@ static void verifyChangeset(CKTransactionalComponentDataSourceChangeset *changes
 #if CK_ASSERTIONS_ENABLED
   const CKBadChangesetOperationType badChangesetOperationType = CKIsValidChangesetForState(changeset, state, pendingAsynchronousModifications);
   if (badChangesetOperationType != CKBadChangesetOperationTypeNone) {
-    NSString *(^badOperationDescriptionForType)(CKBadChangesetOperationType badChangesetOperationType) =
-    ^NSString *(CKBadChangesetOperationType badChangesetOperationType) {
-      NSString *const humanReadableBadChangesetOperationType = CKHumanReadableBadChangesetOperationType(badChangesetOperationType);
-      NSString *const humanReadablePendingAsynchronousModifications = readableStringForArray(pendingAsynchronousModifications);
-      return [NSString stringWithFormat:@"Invalid changeset: %@\n*** Changeset:\n%@\n*** Data source state:\n%@\n*** Pending data source modifications:\n%@", humanReadableBadChangesetOperationType, changeset, state, humanReadablePendingAsynchronousModifications];
-    };
-    CKCFatalAssert(@"%@", badOperationDescriptionForType(badChangesetOperationType));
+    NSString *const humanReadableBadChangesetOperationType = CKHumanReadableBadChangesetOperationType(badChangesetOperationType);
+    NSString *const humanReadablePendingAsynchronousModifications = readableStringForArray(pendingAsynchronousModifications);
+    CKCFatalAssert(@"Invalid changeset: %@\n*** Changeset:\n%@\n*** Data source state:\n%@\n*** Pending data source modifications:\n%@", humanReadableBadChangesetOperationType, changeset, state, humanReadablePendingAsynchronousModifications);
   }
 #endif
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSource.mm
@@ -47,7 +47,6 @@
   NSMutableArray<id<CKTransactionalComponentDataSourceStateModifying>> *_pendingAsynchronousModifications;
 
   NSThread *_workThreadOverride;
-  BOOL _crashOnBadChangesetOperation;
 }
 @end
 
@@ -62,7 +61,6 @@
     _workQueue = dispatch_queue_create("org.componentkit.CKTransactionalComponentDataSource", DISPATCH_QUEUE_SERIAL);
     _pendingAsynchronousModifications = [NSMutableArray array];
     _workThreadOverride = configuration.workThreadOverride;
-    _crashOnBadChangesetOperation = configuration.crashOnBadChangesetOperation;
     [CKComponentDebugController registerReflowListener:self];
   }
   return self;
@@ -79,7 +77,7 @@
               userInfo:(NSDictionary *)userInfo
 {
   CKAssertMainThread();
-  verifyChangeset(changeset, _state, _pendingAsynchronousModifications, _crashOnBadChangesetOperation);
+  verifyChangeset(changeset, _state, _pendingAsynchronousModifications);
   id<CKTransactionalComponentDataSourceStateModifying> modification =
   [[CKTransactionalComponentDataSourceChangesetModification alloc] initWithChangeset:changeset stateListener:self userInfo:userInfo];
   switch (mode) {
@@ -261,29 +259,20 @@
 
 static void verifyChangeset(CKTransactionalComponentDataSourceChangeset *changeset,
                             CKTransactionalComponentDataSourceState *state,
-                            NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *pendingAsynchronousModifications,
-                            const BOOL crashOnBadChangesetOperation)
+                            NSArray<id<CKTransactionalComponentDataSourceStateModifying>> *pendingAsynchronousModifications)
 {
-  NSString *(^badOperationDescriptionForType)(CKBadChangesetOperationType badChangesetOperationType) =
-  ^NSString *(CKBadChangesetOperationType badChangesetOperationType) {
-    NSString *const humanReadableBadChangesetOperationType = CKHumanReadableBadChangesetOperationType(badChangesetOperationType);
-    NSString *const humanReadablePendingAsynchronousModifications = readableStringForArray(pendingAsynchronousModifications);
-    return [NSString stringWithFormat:@"Bad operation: %@\n*** Changeset:\n%@\n*** Data source state:\n%@\n*** Pending data source modifications:\n%@", humanReadableBadChangesetOperationType, changeset, state, humanReadablePendingAsynchronousModifications];
-  };
-  if (crashOnBadChangesetOperation) {
-    const CKBadChangesetOperationType badChangesetOperationType = CKIsValidChangesetForState(changeset, state, pendingAsynchronousModifications);
-    if (badChangesetOperationType != CKBadChangesetOperationTypeNone) {
-      NSException *const exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                             reason:badOperationDescriptionForType(badChangesetOperationType)
-                                                           userInfo:nil];
-      [exception raise];
-    }
-  } else {
 #if CK_ASSERTIONS_ENABLED
-    const CKBadChangesetOperationType badChangesetOperationType = CKIsValidChangesetForState(changeset, state, pendingAsynchronousModifications);
-    CKCAssert(badChangesetOperationType == CKBadChangesetOperationTypeNone, @"%@", badOperationDescriptionForType(badChangesetOperationType));
-#endif
+  const CKBadChangesetOperationType badChangesetOperationType = CKIsValidChangesetForState(changeset, state, pendingAsynchronousModifications);
+  if (badChangesetOperationType != CKBadChangesetOperationTypeNone) {
+    NSString *(^badOperationDescriptionForType)(CKBadChangesetOperationType badChangesetOperationType) =
+    ^NSString *(CKBadChangesetOperationType badChangesetOperationType) {
+      NSString *const humanReadableBadChangesetOperationType = CKHumanReadableBadChangesetOperationType(badChangesetOperationType);
+      NSString *const humanReadablePendingAsynchronousModifications = readableStringForArray(pendingAsynchronousModifications);
+      return [NSString stringWithFormat:@"Invalid changeset: %@\n*** Changeset:\n%@\n*** Data source state:\n%@\n*** Pending data source modifications:\n%@", humanReadableBadChangesetOperationType, changeset, state, humanReadablePendingAsynchronousModifications];
+    };
+    CKCFatalAssert(@"%@", badOperationDescriptionForType(badChangesetOperationType));
   }
+#endif
 }
 
 static NSString *readableStringForArray(NSArray *array)

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceConfiguration.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceConfiguration.mm
@@ -26,22 +26,19 @@
   return [self initWithComponentProvider:componentProvider
                                  context:context
                                sizeRange:sizeRange
-                      workThreadOverride:nil
-            crashOnBadChangesetOperation:NO];
+                      workThreadOverride:nil];
 }
 
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
                                   context:(id<NSObject>)context
                                 sizeRange:(const CKSizeRange &)sizeRange
                        workThreadOverride:(NSThread *)workThreadOverride
-             crashOnBadChangesetOperation:(BOOL)crashOnBadChangesetOperation
 {
   if (self = [super init]) {
     _componentProvider = componentProvider;
     _context = context;
     _sizeRange = sizeRange;
     _workThreadOverride = workThreadOverride;
-    _crashOnBadChangesetOperation = crashOnBadChangesetOperation;
   }
   return self;
 }
@@ -60,8 +57,7 @@
     return (_componentProvider == obj.componentProvider
             && (_context == obj.context || [_context isEqual:obj.context])
             && _sizeRange == obj.sizeRange
-            && _workThreadOverride == obj.workThreadOverride
-            && _crashOnBadChangesetOperation == obj.crashOnBadChangesetOperation);
+            && _workThreadOverride == obj.workThreadOverride);
   }
 }
 

--- a/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceConfigurationInternal.h
+++ b/ComponentKit/TransactionalDataSources/Common/CKTransactionalComponentDataSourceConfigurationInternal.h
@@ -18,15 +18,12 @@
  @param sizeRange Used for the root layout.
  @param workThreadOverride The optional thread used by the data source to perform its work instead of the internal
                            dispatch queue; if provided this thread must be executing.
- @param crashOnBadChangesetOperation If YES the data source will crash when encountering an invalid changeset.
  */
 - (instancetype)initWithComponentProvider:(Class<CKComponentProvider>)componentProvider
                                   context:(id<NSObject>)context
                                 sizeRange:(const CKSizeRange &)sizeRange
-                       workThreadOverride:(NSThread *)workThreadOverride
-             crashOnBadChangesetOperation:(BOOL)crashOnBadChangesetOperation;
+                       workThreadOverride:(NSThread *)workThreadOverride;
 
 @property (nonatomic, strong, readonly) NSThread *workThreadOverride;
-@property (nonatomic, assign, readonly) BOOL crashOnBadChangesetOperation;
 
 @end

--- a/ComponentKit/Utilities/CKBadChangesetOperationType.mm
+++ b/ComponentKit/Utilities/CKBadChangesetOperationType.mm
@@ -14,19 +14,19 @@ NSString *CKHumanReadableBadChangesetOperationType(CKBadChangesetOperationType t
 {
   switch (type) {
     case CKBadChangesetOperationTypeUpdate:
-      return @"Bad Update";
+      return @"Update";
     case CKBadChangesetOperationTypeRemoveRow:
-      return @"Bad Row Removal";
+      return @"Row Removal";
     case CKBadChangesetOperationTypeRemoveSection:
-      return @"Bad Section Removal";
+      return @"Section Removal";
     case CKBadChangesetOperationTypeInsertSection:
-      return @"Bad Section Insertion";
+      return @"Section Insertion";
     case CKBadChangesetOperationTypeMoveSection:
-      return @"Bad Section Move";
+      return @"Section Move";
     case CKBadChangesetOperationTypeInsertRow:
-      return @"Bad Row Insertion";
+      return @"Row Insertion";
     case CKBadChangesetOperationTypeMoveRow:
-      return @"Bad Row Move";
+      return @"Row Move";
     case CKBadChangesetOperationTypeNone:
       return @"No Issue";
   }


### PR DESCRIPTION
This pull request essentially reverts #755, though it allows us to internally map invalid changeset assertions to crashes for employees only.

The gist of these changes is pretty straightforward: introduce a new flavor of `CKAssert`/`CKCAssert` for "fatal" assertions. Externally`CKFatalAssert` and `CKCFatalAssert` act just like `NSAssert` and `NSCAssert`, respectively. Differentiating `CKAssert` and `CKFatalAssert` allows us to rely on internal tools to help us collect a bit more debugging information for employee-only builds.