### PR TITLE
Only create a scoped responder the first time we need it.

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -69,8 +69,8 @@
                  rootIdentifier:rootIdentifier
                  componentClass:componentClass
                           state:initialStateCreator ? initialStateCreator() : [componentClass initialState]
-                     controller:nil // controllers are built on resolution of the handle
-                scopedResponder:[CKScopedResponder new]];
+                     controller:nil  // Controllers are built on resolution of the handle.
+                scopedResponder:nil];// Scoped responders are created lazily. Once they exist, we use that reference for future handles.
 }
 
 - (instancetype)initWithListener:(id<CKComponentStateListener>)listener
@@ -190,6 +190,13 @@
 
 - (CKScopedResponder *)scopedResponder
 {
+  CKAssertFalse(_resolved);
+
+  if (!_scopedResponder) {
+    _scopedResponder = [CKScopedResponder new];
+    [_scopedResponder addHandleToChain:self];
+  }
+
   return _scopedResponder;
 }
 

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -190,9 +190,8 @@
 
 - (CKScopedResponder *)scopedResponder
 {
-  CKAssertFalse(_resolved);
-
   if (!_scopedResponder) {
+    CKAssertFalse(_resolved);
     _scopedResponder = [CKScopedResponder new];
     [_scopedResponder addHandleToChain:self];
   }


### PR DESCRIPTION
Great idea by @ocrickard. Instead of creating a responder when a handle with a new identifier is created, we wait until the first time someone requests a responder.

I tested this in News Feed, and it reduced the number of allocations by 8-10x (depending on the content in feed). Woot!