### PR TITLE
Upgrade the iOS version to fix Travis CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ function ci() {
 }
 
 function ios_ci() {
-  ci $1 $2 iphonesimulator10.3 "platform=iOS Simulator,OS=10.3,name=iPhone 5s" $3
+  ci $1 $2 iphonesimulator10.3 "platform=iOS Simulator,OS=10.3.1,name=iPhone 5s" $3
 }
 
 function tvos_ci() {


### PR DESCRIPTION
I guess Travis CI replaced the iOS 10.3 simulator with 10.3.1?