### PR TITLE
Prevent Scoped Responder from returning an old component that is still alive.

### DIFF
--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -70,11 +70,20 @@
 @end
 
 typedef int32_t CKScopedResponderUniqueIdentifier;
+typedef int CKScopedResponderKey;
 
 @interface CKScopedResponder : NSObject
 
 @property (nonatomic, readonly, assign) CKScopedResponderUniqueIdentifier uniqueIdentifier;
 
-- (id)responder;
+/**
+ Returns the key needed to access the responder at a later time.
+ */
+- (CKScopedResponderKey)keyForHandle:(CKComponentScopeHandle *)handle;
+
+/**
+ Returns the proper responder based on the key provided.
+ */
+- (id)responderForKey:(CKScopedResponderKey)key;
 
 @end

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.mm
@@ -253,7 +253,7 @@
 
   const size_t numberOfHandles = _handles.size();
   if (key < 0 || key >= numberOfHandles) {
-    CKFailAssert(@"Invalid key \"%d\" for responder with %d handles", key, numberOfHandles);
+    CKFailAssert(@"Invalid key \"%d\" for responder with %zu handles", key, numberOfHandles);
     return nil;
   }
 

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -30,7 +30,7 @@ bool CKTypedComponentActionBase::operator==(const CKTypedComponentActionBase& rh
 {
   return (_variant == rhs._variant
           && CKObjectIsEqual(_target, rhs._target)
-          && _scopedResponder == rhs._scopedResponder
+          && _scopeIdentifierAndResponderGenerator == rhs._scopeIdentifierAndResponderGenerator
           && _selector == rhs._selector
           && _block == rhs._block);
 }
@@ -50,27 +50,46 @@ id CKTypedComponentActionBase::initialTarget(CKComponent *sender) const
     case CKTypedComponentActionVariant::TargetSelector:
       return _target;
     case CKTypedComponentActionVariant::Responder:
-      return _scopedResponder.responder;
+      return _scopeIdentifierAndResponderGenerator.second ? _scopeIdentifierAndResponderGenerator.second() : nil;
     case CKTypedComponentActionVariant::Block:
       CKCFailAssert(@"Should not be asking for target for block action.");
       return nil;
   }
 }
 
-CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _target(nil), _scopedResponder(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(nullptr) {}
+CKTypedComponentActionBase::CKTypedComponentActionBase() noexcept : _target(nil), _scopeIdentifierAndResponderGenerator({}), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(nullptr) {}
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) noexcept : _target(target), _scopedResponder(nil), _block(NULL), _variant(CKTypedComponentActionVariant::TargetSelector), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(id target, SEL selector) noexcept : _target(target), _scopeIdentifierAndResponderGenerator({}), _block(NULL), _variant(CKTypedComponentActionVariant::TargetSelector), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _target(nil), _scopedResponder([scope.scopeHandle() scopedResponder]),  _block(NULL), _variant(CKTypedComponentActionVariant::Responder), _selector(selector)
+CKTypedComponentActionBase::CKTypedComponentActionBase(const CKComponentScope &scope, SEL selector) noexcept : _target(nil), _block(NULL), _variant(CKTypedComponentActionVariant::Responder), _selector(selector)
 {
-  CKCAssert(_scopedResponder, @"You are creating an action that will not fire because you have an invalid scope handle.");
+  const auto handle = scope.scopeHandle();
+  CKCAssert(handle, @"You are creating an action that will not fire because you have an invalid scope handle.");
+
+  const auto scopedResponder = handle.scopedResponder;
+  const auto responderKey = [scopedResponder keyForHandle:handle];
+  _scopeIdentifierAndResponderGenerator = {
+    [handle globalIdentifier],
+    ^id(void) {
+
+      /** 
+       At one point in the history of ComponentKit, it was possible for a CKScopeResponder to
+       return a "stale" target for an action. This was often caused by retain cycles, or,
+       "old" component hierarchies with prolonged lifecycles.
+       
+       To prevent this from happening in the future we now provide a key which gives the 
+       scopeResponder the wisdom to ignore older generations.
+       */
+      return [scopedResponder responderForKey:responderKey];
+    }
+  };
 };
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _target(nil), _scopedResponder(nil), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(selector) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(SEL selector) noexcept : _target(nil), _scopeIdentifierAndResponderGenerator({}), _block(NULL), _variant(CKTypedComponentActionVariant::RawSelector), _selector(selector) {};
 
-CKTypedComponentActionBase::CKTypedComponentActionBase(dispatch_block_t block) noexcept : _target(nil), _scopedResponder(nil), _block(block), _variant(CKTypedComponentActionVariant::Block), _selector(NULL) {};
+CKTypedComponentActionBase::CKTypedComponentActionBase(dispatch_block_t block) noexcept : _target(nil), _scopeIdentifierAndResponderGenerator({}), _block(block), _variant(CKTypedComponentActionVariant::Block), _selector(NULL) {};
 
-CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL || _block != NULL || _scopedResponder != nil; };
+CKTypedComponentActionBase::operator bool() const noexcept { return _selector != NULL || _block != NULL || _scopeIdentifierAndResponderGenerator.second != nil; };
 
 SEL CKTypedComponentActionBase::selector() const noexcept { return _selector; };
 
@@ -78,7 +97,7 @@ std::string CKTypedComponentActionBase::identifier() const noexcept
 {
   const BOOL isResponderVariant = (_variant == CKTypedComponentActionVariant::Responder);
   const std::string identifier = isResponderVariant
-                                  ? std::to_string([_scopedResponder uniqueIdentifier])
+                                  ? std::to_string(_scopeIdentifierAndResponderGenerator.first)
                                   : std::to_string((long)(_target));
   
   return std::string(sel_getName(_selector)) + "-" + identifier;

--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -20,6 +20,7 @@
 
 @class CKComponent;
 
+typedef id (^CKResponderGenerationBlock)(void);
 typedef NS_ENUM(NSUInteger, CKComponentActionSendBehavior) {
   /** Starts searching at the sender's next responder. Usually this is what you want to prevent infinite loops. */
   CKComponentActionSendBehaviorStartAtSenderNextResponder,
@@ -65,7 +66,7 @@ class CKTypedComponentActionBase {
   // that runs code on destruction, making this field the first field of this
   // object saves an offset calculation instruction in the destructor.
   __weak id _target;
-  CKScopedResponder *_scopedResponder;
+  std::pair<CKScopedResponderUniqueIdentifier, CKResponderGenerationBlock> _scopeIdentifierAndResponderGenerator;
   dispatch_block_t _block;
   CKTypedComponentActionVariant _variant;
   SEL _selector;


### PR DESCRIPTION
We are seeing an issue where old component generations are still being kept around (whether from retain cycle, or some funny client code) that is causing us to choose an responder that is incorrect.

Here's a scenario:
Within `CKScopedResponder` we keep a vector of `__weak CKComponentScopeHandle *`

In the event an old component generation wasn't dealloced. We could see something like this:
```
{ ScopeHandleA, nil, nil, nil, nil, nil ScopeHandleF, ScopeHandleG }
```
Currently, we simply choose the oldest handle as a responder (`ScopeHandleA`), when in reality, we want `ScopeHandleF`.

Now, when we create a `CKComponentAction` we store a bookmark to the oldest possible component we would want to look at. So, after this commit lands we would create an action that says, "Give me the oldest ScopeHandle that is alive, but start at `ScopeHandleF`".

This fixes our bug internally.