### PR TITLE
Gracefully handle a nil gesture recognizer class

### DIFF
--- a/ComponentKit/Utilities/CKComponentGestureActions.mm
+++ b/ComponentKit/Utilities/CKComponentGestureActions.mm
@@ -103,7 +103,7 @@ CKComponentViewAttributeValue CKComponentGestureAttribute(Class gestureRecognize
                                                           CKTypedComponentAction<UIGestureRecognizer *> action,
                                                           CKComponentForwardedSelectors delegateSelectors)
 {
-  if (!action) {
+  if (!action || gestureRecognizerClass == Nil) {
     return {
       {
         std::string(class_getName(gestureRecognizerClass)) + "-"

--- a/ComponentKitTests/CKComponentGestureActionsTests.mm
+++ b/ComponentKitTests/CKComponentGestureActionsTests.mm
@@ -138,6 +138,16 @@
   XCTAssertNil(gesture.delegate, @"Gesture delegate should not be set");
 }
 
+- (void)testThatApplyingANilRecognizerClassResultsInNoRecognizer
+{
+  CKComponentViewAttributeValue attr = CKComponentGestureAttribute(Nil, nullptr, @selector(test));
+  UIView *view = [UIView new];
+
+  attr.first.applicator(view, attr.second);
+  XCTAssertEqual([view.gestureRecognizers count], 0u, @"Expected no gesture recognizer to be attached");
+  attr.first.unapplicator(view, attr.second);
+}
+
 - (void)testThatApplyingATapRecognizerAttributeWithDifferentTargetToViewWithExistingRecognizerUpdatesAction
 {
   CKFakeActionComponent *fake1 = [CKFakeActionComponent new];


### PR DESCRIPTION
If you pass `Nil` for the gesture recognizer class, we should gracefully do nothing instead of crashing the app entirely. (`UIView addGestureRecognizer:` crashes with a nil input.)