### PR TITLE
Fix Scoped Action Equality. Add Equality tests for all action types.

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -30,7 +30,10 @@ bool CKTypedComponentActionBase::operator==(const CKTypedComponentActionBase& rh
 {
   return (_variant == rhs._variant
           && CKObjectIsEqual(_target, rhs._target)
-          && _scopeIdentifierAndResponderGenerator == rhs._scopeIdentifierAndResponderGenerator
+          // If we are using a scoped action, we are only concerned that selector and the
+          // scoped responder match. Since the scoped responder is abstracted away to the block
+          // within in the pair, we provide a identifier to quickly verify the scoped responders are the same.
+          && _scopeIdentifierAndResponderGenerator.first == rhs._scopeIdentifierAndResponderGenerator.first
           && _selector == rhs._selector
           && _block == rhs._block);
 }
@@ -235,6 +238,8 @@ CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentA
           forControlEvents:controlEvents];
       },
       ^(UIControl *control, id value){
+        CKCAssert([control actionsForTarget:forwarder forControlEvent:controlEvents].count > 0,
+                 @"We are trying to remove an action from a view that never had it in the first place.");
         [control removeTarget:forwarder
                        action:@selector(handleControlEventFromSender:withEvent:)
              forControlEvents:controlEvents];

--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -30,7 +30,7 @@ bool CKTypedComponentActionBase::operator==(const CKTypedComponentActionBase& rh
 {
   return (_variant == rhs._variant
           && CKObjectIsEqual(_target, rhs._target)
-          // If we are using a scoped action, we are only concerned that selector and the
+          // If we are using a scoped action, we are only concerned that the selector and the
           // scoped responder match. Since the scoped responder is abstracted away to the block
           // within in the pair, we provide a identifier to quickly verify the scoped responders are the same.
           && _scopeIdentifierAndResponderGenerator.first == rhs._scopeIdentifierAndResponderGenerator.first
@@ -238,8 +238,6 @@ CKComponentViewAttributeValue CKComponentActionAttribute(const CKTypedComponentA
           forControlEvents:controlEvents];
       },
       ^(UIControl *control, id value){
-        CKCAssert([control actionsForTarget:forwarder forControlEvent:controlEvents].count > 0,
-                 @"We are trying to remove an action from a view that never had it in the first place.");
         [control removeTarget:forwarder
                        action:@selector(handleControlEventFromSender:withEvent:)
              forControlEvents:controlEvents];

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -509,4 +509,55 @@
   XCTAssertNotEqual(action1.identifier(), action2.identifier());
 }
 
+#pragma mark - Equality.
+
+- (void)testRawSelectorEquality
+{
+  const SEL selector = @selector(triggerAction:);
+  const CKComponentAction action1 = {selector};
+  const CKComponentAction action2 = {selector};
+  XCTAssertTrue(action1 == action2);
+
+  const CKComponentAction unequalAction = {@selector(stringWithFormat:)};
+  XCTAssertFalse(action1 == unequalAction);
+}
+
+- (void)testTargetSelectorActionEquality
+{
+  NSMutableArray *const target = [NSMutableArray new];
+  const SEL selector = @selector(removeLastObject);
+  const CKComponentAction action1 = {target, selector};
+  const CKComponentAction action2 = {target, selector};
+  XCTAssertTrue(action1 == action2);
+
+  const CKComponentAction actionWithUnequalTarget = {[NSMutableArray new], selector};
+  XCTAssertFalse(action1 == actionWithUnequalTarget);
+
+  const CKComponentAction actionWithUnequalSelector = {target, @selector(removeAllObjects)};
+  XCTAssertFalse(action1 == actionWithUnequalSelector);
+}
+
+- (void)testBlockActionEquality
+{
+  void (^block)(CKComponent *c, NSObject *passedArgument) {};
+  const CKTypedComponentAction<NSObject *> action = CKTypedComponentAction<NSObject *>::actionFromBlock(block);
+  XCTAssertTrue(action == CKTypedComponentAction<NSObject *>::actionFromBlock(block));
+  XCTAssertFalse(action == CKTypedComponentAction<NSObject *>::actionFromBlock(^(CKComponent *, NSObject *__strong) {}));
+}
+
+- (void)testScopedActionEquality
+{
+  CKThreadLocalComponentScope threadScope(CKComponentScopeRootWithDefaultPredicates(nil), {});
+
+  const SEL selector = @selector(triggerAction:);
+  CKComponentScope scope([CKTestScopeActionComponent class], @"Marty McFly");
+  const CKComponentAction action1 = {scope, selector};
+  const CKComponentAction action2 = {scope, selector};
+  XCTAssertTrue(action1 == action2);
+
+  CKComponentScope scope2([CKTestScopeActionComponent class], @"Biff Tannon");
+  const CKComponentAction unequalAction = {scope2, selector};
+  XCTAssertFalse(action1 == unequalAction);
+}
+
 @end


### PR DESCRIPTION
Equality was broken, this is causing some bad stuff to happen. Fix, commented, and added equality tests for all component action types.