### PR TITLE
Expose the scope enumerator provider in CKComponentHostingView.mm

### DIFF
--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -149,6 +149,11 @@ struct CKComponentHostingViewInputs {
   return _mountedLayout;
 }
 
+- (id<CKComponentScopeEnumeratorProvider>)scopeEnumeratorProvider
+{
+  return _pendingInputs.scopeRoot;
+}
+
 #pragma mark - Appearance
 
 - (void)hostingViewWillAppear

--- a/ComponentKit/HostingView/CKComponentHostingViewInternal.h
+++ b/ComponentKit/HostingView/CKComponentHostingViewInternal.h
@@ -11,6 +11,7 @@
 #import <ComponentKit/CKComponentHostingView.h>
 #import <ComponentKit/CKDimension.h>
 #import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentScopeTypes.h>
 
 @interface CKComponentHostingView ()
 
@@ -18,5 +19,8 @@
 
 /** Returns the layout that's currently mounted. Main thread only. */
 - (const CKComponentLayout &)mountedLayout;
+
+/** Returns the current scope enumerator provider. Main thread only. */
+- (id<CKComponentScopeEnumeratorProvider>)scopeEnumeratorProvider;
 
 @end


### PR DESCRIPTION
Now that the scope root conforms to the new 'CKComponentScopeEnumeratorProvider' protocol , we are adding an access to the enumerator from 'CKComponentHostingView'.