### PR TITLE
Add ability to demote CKTypedComponentAction, use it in CKButtonComponent

### DIFF
--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -165,7 +165,9 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
                             std::move(attributes),
                             {
                               .accessibilityLabel = accessibilityConfiguration.accessibilityLabel,
-                              .accessibilityComponentAction = enabled ? CKComponentAction(action) : nullptr
+                              .accessibilityComponentAction = enabled
+                                ? CKComponentAction::demotedFrom(action, static_cast<UIEvent*>(nil))
+                                : nullptr
                             }
                           }
                           size:size];

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -16,11 +16,11 @@
 @class CKComponent;
 
 namespace detail {
-  template<class...> struct any_are_reference : std::false_type {};
-  template<class T> struct any_are_reference<T> : std::is_reference<T> {};
+  template<class...> struct any_references : std::false_type {};
+  template<class T> struct any_references<T> : std::is_reference<T> {};
   template<class T, class... Ts>
-  struct any_are_reference<T, Ts...>
-    : std::conditional<std::is_reference<T>::value, std::true_type, any_are_reference<Ts...>>::type {};
+  struct any_references<T, Ts...>
+    : std::conditional<std::is_reference<T>::value, std::true_type, any_references<Ts...>>::type {};
 }
 
 /**
@@ -144,8 +144,9 @@ public:
   /**
    Allows demoting an action to a simpler action while supplying defaults for the values that won't be passed in.
    */
-  template<typename... U, bool separator = false, class = typename std::enable_if<!detail::any_are_reference<U...>::value>::type>
+  template<typename... U>
   static CKTypedComponentAction<T...> demotedFrom(CKTypedComponentAction<T..., U...> action, U... defaults) {
+    static_assert(!detail::any_references<U...>::value, "Demoting an action with reference defaults is not allowed");
     return CKTypedComponentAction<T...>::actionFromBlock(^(CKComponent *sender, T... args) {
       action.send(sender, args..., defaults...);
     });

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -15,6 +15,14 @@
 
 @class CKComponent;
 
+namespace detail {
+  template<class...> struct any_are_reference : std::false_type {};
+  template<class T> struct any_are_reference<T> : std::is_reference<T> {};
+  template<class T, class... Ts>
+  struct any_are_reference<T, Ts...>
+    : std::conditional<std::is_reference<T>::value, std::true_type, any_are_reference<Ts...>>::type {};
+}
+
 /**
  CKTypedComponentAction is a struct that represents a method invocation that can be passed to a child component to
  trigger a method invocation on a target.
@@ -136,7 +144,7 @@ public:
   /**
    Allows demoting an action to a simpler action while supplying defaults for the values that won't be passed in.
    */
-  template<typename... U>
+  template<typename... U, bool separator = false, class = typename std::enable_if<!detail::any_are_reference<U...>::value>::type>
   static CKTypedComponentAction<T...> demotedFrom(CKTypedComponentAction<T..., U...> action, U... defaults) {
     return CKTypedComponentAction<T...>::actionFromBlock(^(CKComponent *sender, T... args) {
       action.send(sender, args..., defaults...);

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -15,12 +15,14 @@
 
 @class CKComponent;
 
-namespace detail {
-  template<class...> struct any_references : std::false_type {};
-  template<class T> struct any_references<T> : std::is_reference<T> {};
-  template<class T, class... Ts>
-  struct any_references<T, Ts...>
-    : std::conditional<std::is_reference<T>::value, std::true_type, any_references<Ts...>>::type {};
+namespace CK {
+  namespace detail {
+    template<class...> struct any_references : std::false_type {};
+    template<class T> struct any_references<T> : std::is_reference<T> {};
+    template<class T, class... Ts>
+    struct any_references<T, Ts...>
+      : std::conditional<std::is_reference<T>::value, std::true_type, any_references<Ts...>>::type {};
+  }
 }
 
 /**
@@ -146,7 +148,7 @@ public:
    */
   template<typename... U>
   static CKTypedComponentAction<T...> demotedFrom(CKTypedComponentAction<T..., U...> action, U... defaults) {
-    static_assert(!detail::any_references<U...>::value, "Demoting an action with reference defaults is not allowed");
+    static_assert(!CK::detail::any_references<U...>::value, "Demoting an action with reference defaults is not allowed");
     return CKTypedComponentAction<T...>::actionFromBlock(^(CKComponent *sender, T... args) {
       action.send(sender, args..., defaults...);
     });

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -134,6 +134,16 @@ public:
   }
 
   /**
+   Allows demoting an action to a simpler action while supplying defaults for the values that won't be passed in.
+   */
+  template<typename... U>
+  static CKTypedComponentAction<T...> demotedFrom(CKTypedComponentAction<T..., U...> action, U... defaults) {
+    return CKTypedComponentAction<T...>::actionFromBlock(^(CKComponent *sender, T... args) {
+      action.send(sender, args..., defaults...);
+    });
+  }
+
+  /**
    Allows explicit null actions. NULL can cause ambiguity in constructor resolution and is best avoided where
    nullptr is available.
    */

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -289,6 +289,13 @@
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
 }
 
+static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKComponent*, int), int value) {
+  int& ref = value;
+  CKTypedComponentAction<int> action = CKTypedComponentAction<int>::actionFromBlock(callback);
+  CKTypedComponentAction<> d = CKTypedComponentAction<>::demotedFrom(action, ref);
+  return d;
+}
+
 - (void)testSendActionWithObjectArgumentsWithDemotedActionWithoutArguments
 {
   __block id actionContext = nil;
@@ -314,7 +321,13 @@
   CKTypedComponentAction<> demotedAction = CKTypedComponentAction<>::demotedFrom(action, context, context2);
   demotedAction.send(innerComponent);
 
-  XCTAssert(actionContext == context && actionContext2 == context2, @"Contexts should match what was passed to CKComponentActionSend");
+  __block int value;
+  int expectedValue = 5;
+  createDemotedWithReference(^(CKComponent *sender, int b) {
+    value = b;
+  }, expectedValue).send(innerComponent);
+
+  XCTAssert(actionContext == context && actionContext2 == context2 && value == expectedValue, @"Contexts should match what was passed to CKComponentActionSend");
 
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
 }

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -289,6 +289,36 @@
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
 }
 
+- (void)testSendActionWithObjectArgumentsWithDemotedActionWithoutArguments
+{
+  __block id actionContext = nil;
+  __block id actionContext2 = nil;
+
+  CKComponent *innerComponent = [CKComponent new];
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
+   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { actionContext = obj1; actionContext2 = obj2; }
+   primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
+   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   component:innerComponent];
+
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
+
+  id context = @"hello";
+  id context2 = @"morty";
+
+  CKTypedComponentAction<id, id> action = { @selector(testAction2:context1:context2:) };
+  CKTypedComponentAction<> demotedAction = CKTypedComponentAction<>::demotedFrom(action, context, context2);
+  demotedAction.send(innerComponent);
+
+  XCTAssert(actionContext == context && actionContext2 == context2, @"Contexts should match what was passed to CKComponentActionSend");
+
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
 - (void)testSendActionStartingAtSenderNextResponderReachesParentComponent
 {
   __block BOOL outerReceivedTestAction = NO;

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -291,9 +291,9 @@
 
 static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKComponent*, int), int value) {
   int& ref = value;
-  CKTypedComponentAction<int> action = CKTypedComponentAction<int>::actionFromBlock(callback);
-  CKTypedComponentAction<> d = CKTypedComponentAction<>::demotedFrom(action, ref);
-  return d;
+  auto action = CKTypedComponentAction<int>::actionFromBlock(callback);
+  auto demoted = CKTypedComponentAction<>::demotedFrom(action, ref);
+  return demoted;
 }
 
 - (void)testSendActionWithObjectArgumentsWithDemotedActionWithoutArguments


### PR DESCRIPTION
Previously demoting an object would call `CKTypedComponentAction<>(const CKTypedComponentAction<T...>&)` and error if the supplied action was a block. This provides a safe way to demote via currying.

Test added to demonstrate that demoting works as expected.