### PR TITLE
Convert invocations to IMPs

### DIFF
--- a/ComponentKit/Components/CKButtonComponent.mm
+++ b/ComponentKit/Components/CKButtonComponent.mm
@@ -159,13 +159,18 @@ typedef std::array<CKStateConfiguration, 8> CKStateConfigurationArray;
     contentEdgeInsets = [it->second UIEdgeInsetsValue];
   }
 
+  CKTypedComponentAction<UIEvent *> capturedAction = action;
+  CKComponentAction accessibilityAction = CKComponentAction::actionFromBlock(^(CKComponent *sender) {
+    capturedAction.send(sender, nil);
+  });
+
   CKButtonComponent *b = [super
                           newWithView:{
                             [UIButton class],
                             std::move(attributes),
                             {
                               .accessibilityLabel = accessibilityConfiguration.accessibilityLabel,
-                              .accessibilityComponentAction = enabled ? CKComponentAction(action) : nullptr
+                              .accessibilityComponentAction = enabled ? accessibilityAction : nullptr
                             }
                           }
                           size:size];

--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -84,24 +84,15 @@
    _action.send(self, @"hello", 4);
  }
 
-
  In the event that an action does not contain a target or a selector, it will no-op.
  As a result, it is the responsibility of the component to check (and possibly assert)
  when it has been given an "invalid" action.
  */
 template<typename... T>
 class CKTypedComponentAction : public CKTypedComponentActionBase {
-  static_assert(std::is_same<
-                CKTypedComponentActionBoolPack<(std::is_reference<T>::value
-                                                || std::is_pointer<T>::value
-                                                || std::is_trivially_constructible<T>::value
-                                                || std::is_convertible<T, id>::value)...>,
-                CKTypedComponentActionBoolPack<(CKTypedComponentActionDenyType<T>::value)...>
-                >::value, "You must either use a pointer (like an NSObject) or a trivially constructible type. Complex types are not allowed as arguments of component actions.");
-
   /** This constructor is private to forbid direct usage. Use actionFromBlock. */
   CKTypedComponentAction<T...>(void(^block)(CKComponent *, T...)) noexcept : CKTypedComponentActionBase((dispatch_block_t)block) {};
-  
+
 public:
   CKTypedComponentAction<T...>() noexcept : CKTypedComponentActionBase() {};
   CKTypedComponentAction<T...>(id target, SEL selector) noexcept : CKTypedComponentActionBase(target, selector)
@@ -148,15 +139,6 @@ public:
     // To fix the error, you must handle all arguments:
     // CKTypedComponentAction<BOOL, int> = ^(CKComponent *sender, BOOL foo, int bar) {
     CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions should not take fewer arguments than defined in the declaration of the action, you are depending on undefined behavior and will cause crashes.");
-  };
-
-  /**
-   We allow demotion from actions with types to untyped actions, but only when explicit. This means arguments to the
-   method specified here will have nil values at runtime. Used for interoperation with older API's.
-   */
-  template<typename... Ts>
-  explicit CKTypedComponentAction<>(const CKTypedComponentAction<Ts...> &action) noexcept : CKTypedComponentActionBase(action) {
-    CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions cannot take fewer arguments than provided in the declaration of the action, you are depending on undefined behavior and will cause crashes.");
   };
 
   ~CKTypedComponentAction() {};

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -50,7 +50,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -80,7 +80,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -110,7 +110,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -140,7 +140,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:

--- a/ComponentKitTestHelpers/CKTestActionComponent.h
+++ b/ComponentKitTestHelpers/CKTestActionComponent.h
@@ -15,10 +15,10 @@
 + (instancetype)newWithSingleArgumentBlock:(void (^)(CKComponent *sender, id context))singleArgumentBlock
                        secondArgumentBlock:(void (^)(CKComponent *sender, id obj1, id obj2))secondArgumentBlock
                     primitiveArgumentBlock:(void (^)(CKComponent *sender, int value))primitiveArgumentBlock
-                           noArgumentBlock:(void (^)(void))noArgumentBlock
+                           noArgumentBlock:(void (^)(CKComponent *sender))noArgumentBlock
                                  component:(CKComponent *)component;
 - (void)testAction:(CKComponent *)sender context:(id)context;
 - (void)testAction2:(CKComponent *)sender context1:(id)context1 context2:(id)context2;
 - (void)testPrimitive:(CKComponent *)sender integer:(int)integer;
-- (void)testNoArgumentAction;
+- (void)testNoArgumentAction:(CKComponent *)sender;
 @end

--- a/ComponentKitTestHelpers/CKTestActionComponent.mm
+++ b/ComponentKitTestHelpers/CKTestActionComponent.mm
@@ -15,13 +15,13 @@
   void (^_block)(CKComponent *, id);
   void (^_secondBlock)(CKComponent *, id, id);
   void (^_primitiveArgumentBlock)(CKComponent *, int);
-  void (^_noArgumentBlock)(void);
+  void (^_noArgumentBlock)(CKComponent *sender);
 }
 
 + (instancetype)newWithSingleArgumentBlock:(void (^)(CKComponent *sender, id context))singleArgumentBlock
                        secondArgumentBlock:(void (^)(CKComponent *sender, id obj1, id obj2))secondArgumentBlock
                     primitiveArgumentBlock:(void (^)(CKComponent *sender, int value))primitiveArgumentBlock
-                           noArgumentBlock:(void (^)(void))noArgumentBlock
+                           noArgumentBlock:(void (^)(CKComponent *sender))noArgumentBlock
                                  component:(CKComponent *)component
 {
   CKTestActionComponent *c = [super newWithComponent:component];
@@ -49,9 +49,9 @@
   _primitiveArgumentBlock(sender, integer);
 }
 
-- (void)testNoArgumentAction
+- (void)testNoArgumentAction:(CKComponent *)sender
 {
-  _noArgumentBlock();
+  _noArgumentBlock(sender);
 }
 
 @end

--- a/ComponentKitTests/CKComponentAccessibilityCustomActionsAttributeTests.mm
+++ b/ComponentKitTests/CKComponentAccessibilityCustomActionsAttributeTests.mm
@@ -30,16 +30,16 @@
   [CKComponent
    newWithView:{
      [UIView class],
-     {CKComponentAccessibilityCustomActionsAttribute({{@"Test", @selector(testAction:context:)}})}
+     {CKComponentAccessibilityCustomActionsAttribute({{@"Test", @selector(testNoArgumentAction:)}})}
    }
    size:{}];
   
   CKTestActionComponent *outerComponent =
   [CKTestActionComponent
-   newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context) { }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { actionSender = sender; }
    component:controlComponent];
   
   // Must be mounted to send actions:
@@ -76,7 +76,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
   
   // Must be mounted to send actions:
@@ -109,7 +109,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
   
   // Must be mounted to send actions:

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -143,14 +143,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKComponentActionSend(@selector(testAction:context:), innerComponent);
+  CKComponentActionSend(@selector(testAction:context:), innerComponent, nil);
 
   XCTAssert(actionSender == innerComponent, @"Sender should be inner component");
 
@@ -167,7 +167,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionContext = context; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -194,7 +194,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { actionContext = obj1; actionContext2 = obj2; }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -222,7 +222,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { actionInteger = value; }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -249,14 +249,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ calledNoArgumentBlock = YES; }
+   noArgumentBlock:^(CKComponent *sender) { calledNoArgumentBlock = YES; }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKTypedComponentAction<> action = { @selector(testNoArgumentAction) };
+  CKTypedComponentAction<> action = { @selector(testNoArgumentAction:) };
   action.send(innerComponent);
 
   XCTAssert(calledNoArgumentBlock, @"Contexts should match what was passed to CKComponentActionSend");
@@ -274,14 +274,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ calledNoArgumentBlock = YES; }
+   noArgumentBlock:^(CKComponent *sender) { calledNoArgumentBlock = YES; }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKTypedComponentAction<id> action = { @selector(testNoArgumentAction) };
+  CKTypedComponentAction<id> action = { @selector(testNoArgumentAction:) };
   action.send(innerComponent, @"hello");
 
   XCTAssert(calledNoArgumentBlock, @"Contexts should match what was passed to CKComponentActionSend");
@@ -299,7 +299,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ innerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:[CKComponent new]];
 
   CKTestActionComponent *outerComponent =
@@ -307,14 +307,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ outerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKComponentActionSend(@selector(testAction:context:), innerComponent);
+  CKComponentActionSend(@selector(testAction:context:), innerComponent, nil);
 
   XCTAssertTrue(outerReceivedTestAction, @"Outer component should have received action sent by inner component");
   XCTAssertFalse(innerReceivedTestAction, @"Inner component should not have received action sent from it");
@@ -332,7 +332,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ innerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:[CKComponent new]];
 
   CKTestActionComponent *outerComponent =
@@ -340,7 +340,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ outerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -365,7 +365,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ calledBlock = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
@@ -427,24 +427,6 @@
   XCTAssertTrue(calledAction, @"Should have called the action on the test component");
 }
 
-- (void)testDemotedTargetSelectorActionCallsMethodOnScopedComponent
-{
-  __block BOOL calledAction = NO;
-
-  // We have to use build component here to ensure the scopes are properly configured.
-  CKTestScopeActionComponent *component = (CKTestScopeActionComponent *)CKBuildComponent(CKComponentScopeRootWithDefaultPredicates(nil), {}, ^{
-    return [CKTestScopeActionComponent
-            newWithBlock:^(CKComponent *sender, id context) {
-              calledAction = YES;
-            }];
-  }).component;
-
-  CKComponentAction action = CKComponentAction(CKTypedComponentAction<id>(component, @selector(actionMethod:context:)));
-  action.send(component);
-
-  XCTAssertTrue(calledAction, @"Should have called the action on the test component");
-}
-
 - (void)testTargetSelectorActionCallsOnNormalNSObject
 {
   CKTestObjectTarget *target = [CKTestObjectTarget new];
@@ -456,7 +438,7 @@
 
 - (void)testInvocationIsNilWhenSelectorIsNil
 {
-  XCTAssertNil(CKComponentActionSendResponderInvocationPrepare(nil, nil, nil));
+  XCTAssertNil(_CKComponentActionSendResponderInvocationPrepare(nil, nil, nil).target);
 }
 
 - (void)testBlockActionFires


### PR DESCRIPTION
NSInvocation chokes on certain types of complex C++ references. I don't know exactly why yet, since it works for certain types, but not others. The memory in the receiving callsite gets garbage with some of our most complex C++ classes internally.

Converting to directly use an IMP has some major problems though: NSInvocation nils out any parameters you don't provide. We can no longer support that. Thus, we HAVE to move to a formal demotion mechanism instead of implicitly handling it for you.

The failure mode for this is awful, it crashes at runtime. Ugh. I plan to add some more checking code in the constructor of the component to validate that the selector looks right. We'll also have to do a huge search/codemod internally to make this happen. I'm not looking forward to this...