### PR TITLE
Fix bug with block-based CKComponentActions

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.mm
+++ b/ComponentKit/Utilities/CKComponentAction.mm
@@ -98,12 +98,16 @@ SEL CKTypedComponentActionBase::selector() const noexcept { return _selector; };
 
 std::string CKTypedComponentActionBase::identifier() const noexcept
 {
-  const BOOL isResponderVariant = (_variant == CKTypedComponentActionVariant::Responder);
-  const std::string identifier = isResponderVariant
-                                  ? std::to_string(_scopeIdentifierAndResponderGenerator.first)
-                                  : std::to_string((long)(_target));
-  
-  return std::string(sel_getName(_selector)) + "-" + identifier;
+  switch (_variant) {
+    case CKTypedComponentActionVariant::RawSelector:
+      return std::string(sel_getName(_selector)) + "-Selector";
+    case CKTypedComponentActionVariant::TargetSelector:
+      return std::string(sel_getName(_selector)) + "-TargetSelector-" + std::to_string((long)_target);
+    case CKTypedComponentActionVariant::Responder:
+      return std::string(sel_getName(_selector)) + "-Responder-" + std::to_string(_scopeIdentifierAndResponderGenerator.first);
+    case CKTypedComponentActionVariant::Block:
+      return std::string(sel_getName(_selector)) + "-Block-" + std::to_string((long)_block);
+  }
 }
 
 dispatch_block_t CKTypedComponentActionBase::block() const noexcept { return _block; };

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -552,6 +552,17 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
   XCTAssertNotEqual(action1.identifier(), action2.identifier());
 }
 
+- (void)testThatBlockActionsWithDistinctBlocksHaveUniqueIdentifiers
+{
+  const CKComponentAction action1 = CKTypedComponentAction<>::actionFromBlock(^(CKComponent *sender){
+    exit(1);
+  });
+  const CKComponentAction action2 = CKTypedComponentAction<>::actionFromBlock(^(CKComponent *sender){
+    exit(2);
+  });
+  XCTAssertNotEqual(action1.identifier(), action2.identifier());
+}
+
 #pragma mark - Equality.
 
 - (void)testRawSelectorEquality


### PR DESCRIPTION
The invariant is that if two CKComponentActions are not equal (according to `operator==`) they must have distinct identifiers. This was not true for block-based actions. Make it so.