### PR TITLE
Add assert for crashy argument count in preparation for IMP migration

### DIFF
--- a/ComponentKit/Utilities/CKComponentActionInternal.h
+++ b/ComponentKit/Utilities/CKComponentActionInternal.h
@@ -171,6 +171,8 @@ NSInvocation *CKComponentActionSendResponderInvocationPrepare(SEL selector, id t
 template<typename... T>
 static void CKComponentActionSendResponderChain(SEL selector, id target, CKComponent *sender, T... args) {
   NSInvocation *invocation = CKComponentActionSendResponderInvocationPrepare(selector, target, sender);
+  CKCAssert(invocation.methodSignature.numberOfArguments <= sizeof...(args) + 3, @"Target invocation contains too many arguments");
+
   // We use a recursive argument unpack to unwrap the variadic arguments in-order on the invocation in a type-safe
   // manner.
   CKConfigureInvocationWithArguments(invocation, 3, args...);

--- a/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
+++ b/ComponentKitApplicationTests/CKComponentActionAttributeTests.mm
@@ -50,7 +50,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -80,7 +80,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -114,7 +114,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionCount++; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -148,7 +148,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:
@@ -178,7 +178,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ receivedAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
 
   // Must be mounted to send actions:

--- a/ComponentKitTestHelpers/CKTestActionComponent.h
+++ b/ComponentKitTestHelpers/CKTestActionComponent.h
@@ -15,10 +15,10 @@
 + (instancetype)newWithSingleArgumentBlock:(void (^)(CKComponent *sender, id context))singleArgumentBlock
                        secondArgumentBlock:(void (^)(CKComponent *sender, id obj1, id obj2))secondArgumentBlock
                     primitiveArgumentBlock:(void (^)(CKComponent *sender, int value))primitiveArgumentBlock
-                           noArgumentBlock:(void (^)(void))noArgumentBlock
+                           noArgumentBlock:(void (^)(CKComponent *sender))noArgumentBlock
                                  component:(CKComponent *)component;
 - (void)testAction:(CKComponent *)sender context:(id)context;
 - (void)testAction2:(CKComponent *)sender context1:(id)context1 context2:(id)context2;
 - (void)testPrimitive:(CKComponent *)sender integer:(int)integer;
-- (void)testNoArgumentAction;
+- (void)testNoArgumentAction:(CKComponent *)sender;
 @end

--- a/ComponentKitTestHelpers/CKTestActionComponent.mm
+++ b/ComponentKitTestHelpers/CKTestActionComponent.mm
@@ -15,13 +15,13 @@
   void (^_block)(CKComponent *, id);
   void (^_secondBlock)(CKComponent *, id, id);
   void (^_primitiveArgumentBlock)(CKComponent *, int);
-  void (^_noArgumentBlock)(void);
+  void (^_noArgumentBlock)(CKComponent *);
 }
 
 + (instancetype)newWithSingleArgumentBlock:(void (^)(CKComponent *sender, id context))singleArgumentBlock
                        secondArgumentBlock:(void (^)(CKComponent *sender, id obj1, id obj2))secondArgumentBlock
                     primitiveArgumentBlock:(void (^)(CKComponent *sender, int value))primitiveArgumentBlock
-                           noArgumentBlock:(void (^)(void))noArgumentBlock
+                           noArgumentBlock:(void (^)(CKComponent *sender))noArgumentBlock
                                  component:(CKComponent *)component
 {
   CKTestActionComponent *c = [super newWithComponent:component];
@@ -49,9 +49,9 @@
   _primitiveArgumentBlock(sender, integer);
 }
 
-- (void)testNoArgumentAction
+- (void)testNoArgumentAction:(CKComponent *)sender
 {
-  _noArgumentBlock();
+  _noArgumentBlock(sender);
 }
 
 @end

--- a/ComponentKitTests/CKComponentAccessibilityCustomActionsAttributeTests.mm
+++ b/ComponentKitTests/CKComponentAccessibilityCustomActionsAttributeTests.mm
@@ -30,16 +30,16 @@
   [CKComponent
    newWithView:{
      [UIView class],
-     {CKComponentAccessibilityCustomActionsAttribute({{@"Test", @selector(testAction:context:)}})}
+     {CKComponentAccessibilityCustomActionsAttribute({{@"Test", @selector(testNoArgumentAction:)}})}
    }
    size:{}];
   
   CKTestActionComponent *outerComponent =
   [CKTestActionComponent
-   newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context) { }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { actionSender = sender; }
    component:controlComponent];
   
   // Must be mounted to send actions:
@@ -76,7 +76,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
   
   // Must be mounted to send actions:
@@ -109,7 +109,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context) { actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { }
-   noArgumentBlock:^{ }
+   noArgumentBlock:^(CKComponent *sender) { }
    component:controlComponent];
   
   // Must be mounted to send actions:

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -143,14 +143,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionSender = sender; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKComponentActionSend(@selector(testAction:context:), innerComponent);
+  CKComponentActionSend(@selector(testAction:context:), innerComponent, nil);
 
   XCTAssert(actionSender == innerComponent, @"Sender should be inner component");
 
@@ -167,7 +167,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ actionContext = context; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -194,7 +194,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { actionContext = obj1; actionContext2 = obj2; }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -222,7 +222,7 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { actionInteger = value; }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -249,14 +249,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ calledNoArgumentBlock = YES; }
+   noArgumentBlock:^(CKComponent *sender) { calledNoArgumentBlock = YES; }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKTypedComponentAction<> action = { @selector(testNoArgumentAction) };
+  CKTypedComponentAction<> action = { @selector(testNoArgumentAction:) };
   action.send(innerComponent);
 
   XCTAssert(calledNoArgumentBlock, @"Contexts should match what was passed to CKComponentActionSend");
@@ -274,14 +274,14 @@
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ calledNoArgumentBlock = YES; }
+   noArgumentBlock:^(CKComponent *sender) { calledNoArgumentBlock = YES; }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKTypedComponentAction<id> action = { @selector(testNoArgumentAction) };
+  CKTypedComponentAction<id> action = { @selector(testNoArgumentAction:) };
   action.send(innerComponent, @"hello");
 
   XCTAssert(calledNoArgumentBlock, @"Contexts should match what was passed to CKComponentActionSend");
@@ -307,7 +307,7 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { actionContext = obj1; actionContext2 = obj2; }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -342,7 +342,7 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ innerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:[CKComponent new]];
 
   CKTestActionComponent *outerComponent =
@@ -350,14 +350,14 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ outerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
   UIView *rootView = [UIView new];
   NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
 
-  CKComponentActionSend(@selector(testAction:context:), innerComponent);
+  CKComponentActionSend(@selector(testAction:context:), innerComponent, nullptr);
 
   XCTAssertTrue(outerReceivedTestAction, @"Outer component should have received action sent by inner component");
   XCTAssertFalse(innerReceivedTestAction, @"Inner component should not have received action sent from it");
@@ -375,7 +375,7 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ innerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:[CKComponent new]];
 
   CKTestActionComponent *outerComponent =
@@ -383,7 +383,7 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ outerReceivedTestAction = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   // Must be mounted to send actions:
@@ -408,7 +408,7 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
    newWithSingleArgumentBlock:^(CKComponent *sender, id context){ calledBlock = YES; }
    secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { XCTFail(@"Should not be called."); }
    primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
-   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   noArgumentBlock:^(CKComponent *sender) { XCTFail(@"Should not be called."); }
    component:innerComponent];
 
   CKTypedComponentAction<id> action { outerComponent, @selector(testAction:context:) };
@@ -466,24 +466,6 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
   }).component;
 
   [component triggerAction:nil];
-
-  XCTAssertTrue(calledAction, @"Should have called the action on the test component");
-}
-
-- (void)testDemotedTargetSelectorActionCallsMethodOnScopedComponent
-{
-  __block BOOL calledAction = NO;
-
-  // We have to use build component here to ensure the scopes are properly configured.
-  CKTestScopeActionComponent *component = (CKTestScopeActionComponent *)CKBuildComponent(CKComponentScopeRootWithDefaultPredicates(nil), {}, ^{
-    return [CKTestScopeActionComponent
-            newWithBlock:^(CKComponent *sender, id context) {
-              calledAction = YES;
-            }];
-  }).component;
-
-  CKComponentAction action = CKComponentAction(CKTypedComponentAction<id>(component, @selector(actionMethod:context:)));
-  action.send(component);
 
   XCTAssertTrue(calledAction, @"Should have called the action on the test component");
 }


### PR DESCRIPTION
Summary:
When we migrate to IMPs to support complex C++ types, we'll lose NSInvocation's argument nilling. The migration is necessary because with those complex C++ types, the compiler may have trouble understanding the proper way to handle arguments, and will result in crashy or undefined behavior if the wrong target is selected. Previously, we would just reject those complex argument types and simply lean on NSInvocation to handle the automatic nilling for those arguments we did not set, but this approach doesn't extend to IMPs.

The first step in addressing this is to assert when previously undefined-but-not-crashy behavior is detected. (This revision)

The second step will probably be to get logs and farm out the work to affected teams to fix their actions.

Next, we'll want to perform the migration to IMPs, and turn argument mismatches into asserting no-ops, after teams have had the opportunity to fix their low-hanging fruit, and gather logging on actions which are broken by this migration.

Lastly, we will want to evaluate the utility of performing argument typechecking with the NSMethodSignature for extra safety. Given the infrequent firing of actions the expected performance impact of this is likely negligible.

Reviewed By: ocrickard

Differential Revision: D5625064