### PR TITLE
Implement promotion operator on CKTypedComponentAction

### DIFF
--- a/ComponentKit/Utilities/CKComponentAction.h
+++ b/ComponentKit/Utilities/CKComponentAction.h
@@ -154,6 +154,13 @@ public:
     });
   }
 
+  template<typename... U>
+  static CKTypedComponentAction<T..., U...> promotedFrom(CKTypedComponentAction<T...> action) {
+    return CKTypedComponentAction<T..., U...>::actionFromBlock(^(CKComponent* sender, T... argsT, U... argsU) {
+      action.send(sender, argsT...);
+    });
+  }
+
   /**
    Allows explicit null actions. NULL can cause ambiguity in constructor resolution and is best avoided where
    nullptr is available.
@@ -168,6 +175,7 @@ public:
     // CKTypedComponentAction<BOOL, int> = ^(CKComponent *sender) {
     // To fix the error, you must handle all arguments:
     // CKTypedComponentAction<BOOL, int> = ^(CKComponent *sender, BOOL foo, int bar) {
+    // You may also use the `promotedFrom` operator above.
     CKCAssert(_variant != CKTypedComponentActionVariant::Block, @"Block actions should not take fewer arguments than defined in the declaration of the action, you are depending on undefined behavior and will cause crashes.");
   };
 

--- a/ComponentKitTests/CKComponentActionTests.mm
+++ b/ComponentKitTests/CKComponentActionTests.mm
@@ -332,6 +332,36 @@ static CKTypedComponentAction<> createDemotedWithReference(void (^callback)(CKCo
   [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
 }
 
+- (void)testSendActionWithObjectArgumentsWithPromotedActionWithObjectArguments
+{
+  __block id actionContext = nil;
+  __block id actionContext2 = nil;
+  
+  CKComponent *innerComponent = [CKComponent new];
+  CKTestActionComponent *outerComponent =
+  [CKTestActionComponent
+   newWithSingleArgumentBlock:^(CKComponent *sender, id context){ XCTFail(@"Should not be called."); }
+   secondArgumentBlock:^(CKComponent *sender, id obj1, id obj2) { actionContext = obj1; actionContext2 = obj2; }
+   primitiveArgumentBlock:^(CKComponent *sender, int value) { XCTFail(@"Should not be called."); }
+   noArgumentBlock:^{ XCTFail(@"Should not be called."); }
+   component:innerComponent];
+  
+  // Must be mounted to send actions:
+  UIView *rootView = [UIView new];
+  NSSet *mountedComponents = CKMountComponentLayout([outerComponent layoutThatFits:{} parentSize:{}], rootView, nil, nil);
+  
+  id context = @"hello";
+  id context2 = @"morty";
+  
+  CKTypedComponentAction<id, id> action = { @selector(testAction2:context1:context2:) };
+  CKTypedComponentAction<id, id, id> promotedAction = CKTypedComponentAction<id, id>::promotedFrom<id>(action);
+  promotedAction.send(innerComponent, context, context2, @"rick");
+  
+  XCTAssert(actionContext == context && actionContext2 == context2, @"Contexts should match what was passed to CKComponentActionSend");
+  
+  [mountedComponents makeObjectsPerformSelector:@selector(unmount)];
+}
+
 - (void)testSendActionStartingAtSenderNextResponderReachesParentComponent
 {
   __block BOOL outerReceivedTestAction = NO;


### PR DESCRIPTION
Previously you had to manually wrap your action with fewer arguments in another closure with more arguments. This introduces a promotion operator in order to support a more declarative method of promotion.