### PR TITLE
Remove line that contradicts the steps before it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ If you're interested in viewing only the ComponentKit source code in Xcode:
 open ComponentKit.xcodeproj
 ```
 
-There is no need to run any special commands prior to opening either Xcode project.
-
 ### Learn more
 
 * Read the [Getting Started guide](http://www.componentkit.org/docs/getting-started.html)


### PR DESCRIPTION
In the README Quickstart section, it states in bold: "Before you open any of the Xcode projects in this repo, make sure you run...". Then at the end of the same section it states: "There is no need to run any special commands prior to opening either Xcode project.", which contradicts the previous statement which can lead to confusion.