### PR TITLE
CKComponentController: erase iterator instead of redoing lookup

### DIFF
--- a/ComponentKit/Core/CKComponentController.mm
+++ b/ComponentKit/Core/CKComponentController.mm
@@ -62,7 +62,7 @@ static void eraseAnimation(CKAppliedComponentAnimationMap &map, CKComponentAnima
   if (it != map.end()) {
     const CKAppliedComponentAnimation &appliedAnim = it->second;
     appliedAnim.animation.cleanup(appliedAnim.context);
-    map.erase(animationID);
+    map.erase(it);
   }
 }
 


### PR DESCRIPTION
There's no reason to do a second hash lookup here.