### PR TITLE
Fix for ComponentKit.podspec and command line details to push 0.20 to trunk

### DIFF
--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/facebook/ComponentKit.git', :tag => s.version.to_s }
   s.ios.deployment_target = '8.1'
   s.requires_arc = true
+
   s.source_files = 'ComponentKit/**/*', 'ComponentTextKit/**/*'
   s.frameworks = 'UIKit', 'CoreText'
   s.library = 'c++'
@@ -16,7 +17,5 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++14',
     'CLANG_CXX_LIBRARY' => 'libc++',
   }
-  s.dependency 'OCMock', '~> 3.4'
-  s.dependency 'FBSnapshotTestCase', '~> 2.1.4'
-  s.dependency 'Yoga', '~> 1.6.0' 
+  s.dependency 'Yoga', '~> 1.6.0'
 end


### PR DESCRIPTION
Remove test frameworks from the podspec
Test frameworks should never be linked to production code

There is a workaround since CocoaPods 1.2.1 that allows pushing of C++ pods again. The command line and fixes to podspec give:
```
Analyzed 1 podspec.

ComponentKit.podspec passed validation.
```

Here is the full command line
`pod spec lint ComponentKit.podspec --allow-warnings --skip-import-validation`

I am looking forward to see ComponentKit supporting CocoaPods again.