### PR TITLE
Update 38-why-cpp.md

### DIFF
--- a/_docs/38-why-cpp.md
+++ b/_docs/38-why-cpp.md
@@ -55,7 +55,7 @@ In the previous example the C++ would fail to compile if we inserted a child of 
 
 ## Efficiency
 
-Being fully declarative and immutable means you use a *lot* of objects. C++ objects are far more efficient to create because they can be stack-allocated, [emplaced](http://stackoverflow.com/questions/4303513/push-back-vs-emplace-back | emplaced), [moved](http://www.cprogramming.com/c++11/rvalue-references-and-move-semantics-in-c++11.html), etc.
+Being fully declarative and immutable means you use a *lot* of objects. C++ objects are far more efficient to create because they can be stack-allocated, [emplaced](http://stackoverflow.com/questions/4303513/push-back-vs-emplace-back), [moved](http://www.cprogramming.com/c++11/rvalue-references-and-move-semantics-in-c++11.html), etc.
 
 ## Nil Safety
 


### PR DESCRIPTION
Modified "emplaced" link to not trigger a table display.

Before:
<img width="684" alt="screen shot 2017-12-21 at 10 41 43 am" src="https://user-images.githubusercontent.com/2627001/34252451-9addccb4-e63b-11e7-8851-4661cff02819.png">

After:
<img width="681" alt="screen shot 2017-12-21 at 10 40 59 am" src="https://user-images.githubusercontent.com/2627001/34252453-9f000690-e63b-11e7-8f7b-0e3bf135a97e.png">
