### PR TITLE
RFC: Render Method in ComponentKit

### DIFF
--- a/ComponentKit.xcodeproj/project.pbxproj
+++ b/ComponentKit.xcodeproj/project.pbxproj
@@ -265,6 +265,24 @@
 		18644AE51B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE11B3CB8E60028AF87 /* CKStatefulViewComponentControllerTests.mm */; };
 		18644AE61B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */; };
 		18644AE71B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */; };
+		23479E732029BAA1004A8396 /* CKSingleChildComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 23479E712029BAA1004A8396 /* CKSingleChildComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		23479E742029BAA1004A8396 /* CKSingleChildComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 23479E722029BAA1004A8396 /* CKSingleChildComponent.mm */; };
+		23560F2120346B20009CF531 /* CKTreeNodeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 23560F2020346B20009CF531 /* CKTreeNodeTests.mm */; };
+		237FB0302029BD4E007A6C73 /* CKSingleChildComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 23479E712029BAA1004A8396 /* CKSingleChildComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		237FB03D2029C1C4007A6C73 /* CKGroupComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB03B2029C1C4007A6C73 /* CKGroupComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		237FB03E2029C1C4007A6C73 /* CKGroupComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB03B2029C1C4007A6C73 /* CKGroupComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		237FB03F2029C1C4007A6C73 /* CKGroupComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 237FB03C2029C1C4007A6C73 /* CKGroupComponent.mm */; };
+		237FB0402029C1C4007A6C73 /* CKGroupComponent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 237FB03C2029C1C4007A6C73 /* CKGroupComponent.mm */; };
+		237FB0FF202B7A33007A6C73 /* CKTreeNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 237FB0F1202B7A33007A6C73 /* CKTreeNode.mm */; };
+		237FB100202B7A33007A6C73 /* CKTreeNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 237FB0F1202B7A33007A6C73 /* CKTreeNode.mm */; };
+		237FB101202B7A33007A6C73 /* CKTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB0F2202B7A33007A6C73 /* CKTreeNode.h */; };
+		237FB102202B7A33007A6C73 /* CKTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB0F2202B7A33007A6C73 /* CKTreeNode.h */; };
+		237FB103202B7A33007A6C73 /* CKBaseTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB0F3202B7A33007A6C73 /* CKBaseTreeNode.h */; };
+		237FB104202B7A33007A6C73 /* CKBaseTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB0F3202B7A33007A6C73 /* CKBaseTreeNode.h */; };
+		237FB105202B7A33007A6C73 /* CKBaseTreeNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 237FB0F4202B7A33007A6C73 /* CKBaseTreeNode.mm */; };
+		237FB106202B7A33007A6C73 /* CKBaseTreeNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = 237FB0F4202B7A33007A6C73 /* CKBaseTreeNode.mm */; };
+		237FB135202DCFD2007A6C73 /* CKComponentOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB134202DCFD2007A6C73 /* CKComponentOwner.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		237FB136202DCFD2007A6C73 /* CKComponentOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 237FB134202DCFD2007A6C73 /* CKComponentOwner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		238507AD1FE05A6E00534B93 /* CKComponentProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 238695671FE0571D00D4DAE2 /* CKComponentProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		238507AE1FE05A7000534B93 /* CKComponentControllerProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 238695661FE0571D00D4DAE2 /* CKComponentControllerProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		238695681FE0571D00D4DAE2 /* CKComponentControllerProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 238695661FE0571D00D4DAE2 /* CKComponentControllerProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -822,6 +840,16 @@
 		18644AE21B3CB8E60028AF87 /* CKStatefulViewReusePoolTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKStatefulViewReusePoolTests.mm; sourceTree = "<group>"; };
 		18644AE31B3CB8E60028AF87 /* CKTestStatefulViewComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTestStatefulViewComponent.h; sourceTree = "<group>"; };
 		18644AE41B3CB8E60028AF87 /* CKTestStatefulViewComponent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTestStatefulViewComponent.mm; sourceTree = "<group>"; };
+		23479E712029BAA1004A8396 /* CKSingleChildComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKSingleChildComponent.h; sourceTree = "<group>"; };
+		23479E722029BAA1004A8396 /* CKSingleChildComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CKSingleChildComponent.mm; sourceTree = "<group>"; };
+		23560F2020346B20009CF531 /* CKTreeNodeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTreeNodeTests.mm; sourceTree = "<group>"; };
+		237FB03B2029C1C4007A6C73 /* CKGroupComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKGroupComponent.h; sourceTree = "<group>"; };
+		237FB03C2029C1C4007A6C73 /* CKGroupComponent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CKGroupComponent.mm; sourceTree = "<group>"; };
+		237FB0F1202B7A33007A6C73 /* CKTreeNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKTreeNode.mm; sourceTree = "<group>"; };
+		237FB0F2202B7A33007A6C73 /* CKTreeNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKTreeNode.h; sourceTree = "<group>"; };
+		237FB0F3202B7A33007A6C73 /* CKBaseTreeNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKBaseTreeNode.h; sourceTree = "<group>"; };
+		237FB0F4202B7A33007A6C73 /* CKBaseTreeNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKBaseTreeNode.mm; sourceTree = "<group>"; };
+		237FB134202DCFD2007A6C73 /* CKComponentOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CKComponentOwner.h; sourceTree = "<group>"; };
 		238695661FE0571D00D4DAE2 /* CKComponentControllerProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CKComponentControllerProtocol.h; path = ComponentKit/Core/CKComponentControllerProtocol.h; sourceTree = SOURCE_ROOT; };
 		238695671FE0571D00D4DAE2 /* CKComponentProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CKComponentProtocol.h; path = ComponentKit/Core/CKComponentProtocol.h; sourceTree = SOURCE_ROOT; };
 		23FE1F012020A67D0036F727 /* CKComponentLayoutCache.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CKComponentLayoutCache.mm; sourceTree = "<group>"; };
@@ -1277,6 +1305,18 @@
 			path = StatefulViews;
 			sourceTree = "<group>";
 		};
+		237FB0F0202B7A33007A6C73 /* ComponentTree */ = {
+			isa = PBXGroup;
+			children = (
+				237FB0F3202B7A33007A6C73 /* CKBaseTreeNode.h */,
+				237FB0F4202B7A33007A6C73 /* CKBaseTreeNode.mm */,
+				237FB0F2202B7A33007A6C73 /* CKTreeNode.h */,
+				237FB0F1202B7A33007A6C73 /* CKTreeNode.mm */,
+				237FB134202DCFD2007A6C73 /* CKComponentOwner.h */,
+			);
+			path = ComponentTree;
+			sourceTree = "<group>";
+		};
 		7F6BAF741F1F71A700600828 /* yoga */ = {
 			isa = PBXGroup;
 			children = (
@@ -1360,7 +1400,6 @@
 				991DE3401B3B308900AA05B2 /* CKComponentMemoizerTests.mm */,
 				B342DC581AC23EA900ACAC53 /* CKComponentMountContextLayoutGuideTests.mm */,
 				B342DC591AC23EA900ACAC53 /* CKComponentMountTests.mm */,
-				B342DC5C1AC23EA900ACAC53 /* CKComponentSizeTests.mm */,
 				B342DC5D1AC23EA900ACAC53 /* CKComponentViewAttributeTests.mm */,
 				B342DC5E1AC23EA900ACAC53 /* CKComponentViewContextTests.mm */,
 				B342DC601AC23EA900ACAC53 /* CKComponentViewReuseTests.mm */,
@@ -1369,6 +1408,8 @@
 				B342DC621AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm */,
 				A22FE3041AF2CF0C00EC30B8 /* CKStateExposingComponent.h */,
 				A22FE3051AF2CF0C00EC30B8 /* CKStateExposingComponent.mm */,
+				23560F2020346B20009CF531 /* CKTreeNodeTests.mm */,
+				B342DC5C1AC23EA900ACAC53 /* CKComponentSizeTests.mm */,
 				B7E2E59E1D077098002A4442 /* CKVectorHelperTests.mm */,
 				B342DC661AC23EA900ACAC53 /* ComponentKitTests-Info.plist */,
 				B342DC671AC23EA900ACAC53 /* Scope */,
@@ -1552,6 +1593,7 @@
 		D0B47AD41CBD926700BB33CE /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				237FB0F0202B7A33007A6C73 /* ComponentTree */,
 				238695671FE0571D00D4DAE2 /* CKComponentProtocol.h */,
 				238695661FE0571D00D4DAE2 /* CKComponentControllerProtocol.h */,
 				40AB33C71FC39196005D3CE9 /* CKStateUpdateMetadata.h */,
@@ -1563,6 +1605,10 @@
 				D0B47AF11CBD926700BB33CE /* CKComponent+UIView.mm */,
 				D0B47AD51CBD926700BB33CE /* CKComponent.h */,
 				D0B47AD61CBD926700BB33CE /* CKComponent.mm */,
+				23479E712029BAA1004A8396 /* CKSingleChildComponent.h */,
+				23479E722029BAA1004A8396 /* CKSingleChildComponent.mm */,
+				237FB03B2029C1C4007A6C73 /* CKGroupComponent.h */,
+				237FB03C2029C1C4007A6C73 /* CKGroupComponent.mm */,
 				D0B47AD71CBD926700BB33CE /* CKComponentAnimation.h */,
 				D0B47AD81CBD926700BB33CE /* CKComponentAnimation.mm */,
 				D0B47AD91CBD926700BB33CE /* CKComponentAnimationHooks.h */,
@@ -1951,6 +1997,7 @@
 			files = (
 				A2A89C3C2011C110009D0377 /* CKInspectableView.h in Headers */,
 				9092AE9C1DFA4853009878B2 /* CKAvailability.h in Headers */,
+				237FB03E2029C1C4007A6C73 /* CKGroupComponent.h in Headers */,
 				A29D85791D80D37F00913E60 /* CKComponentContextHelper.h in Headers */,
 				2D7A98291DB571700064FC6D /* CKInvalidChangesetOperationType.h in Headers */,
 				03B8B4D21D2A346F00EDFF59 /* CKComponentRootView.h in Headers */,
@@ -1962,6 +2009,7 @@
 				03B8B4D81D2A346F00EDFF59 /* CKComponentProvider.h in Headers */,
 				03B8B4D91D2A346F00EDFF59 /* CKComponentAnnouncerBase.h in Headers */,
 				03B8B4DA1D2A346F00EDFF59 /* CKComponentLayout.h in Headers */,
+				237FB136202DCFD2007A6C73 /* CKComponentOwner.h in Headers */,
 				03B8B4DB1D2A346F00EDFF59 /* CKDataSourceAppliedChanges.h in Headers */,
 				03B8B4DC1D2A346F00EDFF59 /* CKStatefulViewComponentController.h in Headers */,
 				03B8B4DF1D2A346F00EDFF59 /* CKComponent.h in Headers */,
@@ -2023,6 +2071,7 @@
 				03B8B5241D2A346F00EDFF59 /* CKRatioLayoutComponent.h in Headers */,
 				03B8B5251D2A346F00EDFF59 /* CKNetworkImageComponent.h in Headers */,
 				03B8B5271D2A346F00EDFF59 /* CKImageComponent.h in Headers */,
+				237FB104202B7A33007A6C73 /* CKBaseTreeNode.h in Headers */,
 				03B8B5291D2A346F00EDFF59 /* CKStaticLayoutComponent.h in Headers */,
 				B1E3068C1E8B11AA004864CF /* CKComponentBoundsAnimationPredicates.h in Headers */,
 				2D03A6611D3869C700E4F890 /* CKDetectComponentScopeCollisions.h in Headers */,
@@ -2046,6 +2095,7 @@
 				03B8B53C1D2A346F00EDFF59 /* CKComponentAnimationHooks.h in Headers */,
 				03B8B53D1D2A346F00EDFF59 /* ComponentMountContext.h in Headers */,
 				03B8B53E1D2A346F00EDFF59 /* CKAsyncLayer.h in Headers */,
+				237FB0302029BD4E007A6C73 /* CKSingleChildComponent.h in Headers */,
 				03B8B53F1D2A346F00EDFF59 /* CKTextKitShadower.h in Headers */,
 				03B8B5401D2A346F00EDFF59 /* CKComponentScopeRoot.h in Headers */,
 				2DCA4E731D889D1500AAB2B3 /* CKDataSourceConfigurationInternal.h in Headers */,
@@ -2078,6 +2128,7 @@
 				03B8B5581D2A346F00EDFF59 /* CKTextKitRendererCache.h in Headers */,
 				03B8B5591D2A346F00EDFF59 /* CKAsyncTransactionContainer+Private.h in Headers */,
 				03B8B55A1D2A346F00EDFF59 /* CKComponentSubclass.h in Headers */,
+				237FB102202B7A33007A6C73 /* CKTreeNode.h in Headers */,
 				03B8B55B1D2A346F00EDFF59 /* CKTextKitTailTruncater.h in Headers */,
 				03B8B55C1D2A346F00EDFF59 /* CKAsyncTransactionContainer.h in Headers */,
 				03B8B55D1D2A346F00EDFF59 /* CKMacros.h in Headers */,
@@ -2174,8 +2225,10 @@
 				D0B47D4A1CBD948E00BB33CE /* CKDataSourceChange.h in Headers */,
 				D0B47CF01CBD948E00BB33CE /* CKComponentAnimation.h in Headers */,
 				D0B47D311CBD948E00BB33CE /* CKBackgroundLayoutComponent.h in Headers */,
+				237FB135202DCFD2007A6C73 /* CKComponentOwner.h in Headers */,
 				D0B47D4B1CBD948E00BB33CE /* CKDataSourceChangesetModification.h in Headers */,
 				A2E5BDC21EB9303D00444CD9 /* CKComponentKey.h in Headers */,
+				237FB103202B7A33007A6C73 /* CKBaseTreeNode.h in Headers */,
 				D0B47D0C1CBD948E00BB33CE /* CKComponentScopeHandle.h in Headers */,
 				D0B47D021CBD948E00BB33CE /* CKDimension.h in Headers */,
 				D0B47D631CBD948E00BB33CE /* CKTextComponentLayerHighlighter.h in Headers */,
@@ -2193,6 +2246,7 @@
 				D0B47D351CBD948E00BB33CE /* CKRatioLayoutComponent.h in Headers */,
 				D0B47CED1CBD948E00BB33CE /* CKNetworkImageComponent.h in Headers */,
 				D0B47CEC1CBD948E00BB33CE /* CKImageComponent.h in Headers */,
+				237FB03D2029C1C4007A6C73 /* CKGroupComponent.h in Headers */,
 				D0B47D3A1CBD948E00BB33CE /* CKStaticLayoutComponent.h in Headers */,
 				D0B47CF21CBD948E00BB33CE /* CKComponentBoundsAnimation.h in Headers */,
 				D0B47D121CBD948E00BB33CE /* CKCollectionViewDataSourceCell.h in Headers */,
@@ -2224,6 +2278,8 @@
 				7F6BAF7F1F1F71A700600828 /* YGEnums.h in Headers */,
 				7FB5C1EC1F865BEB00D2726B /* CKComponentDescriptionHelper.h in Headers */,
 				D0B47D791CBD948E00BB33CE /* CKFunctor.h in Headers */,
+				23479E732029BAA1004A8396 /* CKSingleChildComponent.h in Headers */,
+				237FB101202B7A33007A6C73 /* CKTreeNode.h in Headers */,
 				D0B47CE71CBD948E00BB33CE /* CKArgumentPrecondition.h in Headers */,
 				D0B47D771CBD948E00BB33CE /* CKAsyncTransactionGroup.h in Headers */,
 				D0B47D701CBD948E00BB33CE /* CKTextKitTruncating.h in Headers */,
@@ -2701,6 +2757,7 @@
 				03B8B4A71D2A346F00EDFF59 /* CKDataSourceItem.mm in Sources */,
 				03B8B4A81D2A346F00EDFF59 /* CKDataSourceListenerAnnouncer.mm in Sources */,
 				03B8B4A91D2A346F00EDFF59 /* CKDataSourceState.mm in Sources */,
+				237FB100202B7A33007A6C73 /* CKTreeNode.mm in Sources */,
 				03B8B4AA1D2A346F00EDFF59 /* CKDataSourceChange.m in Sources */,
 				03B8B4AB1D2A346F00EDFF59 /* CKDataSourceChangesetModification.mm in Sources */,
 				2D640D5E1DB7FD7800271CB4 /* CKInvalidChangesetOperationType.mm in Sources */,
@@ -2713,6 +2770,7 @@
 				03B8B4B21D2A346F00EDFF59 /* CKComponentDelegateForwarder.mm in Sources */,
 				03B8B4B31D2A346F00EDFF59 /* CKComponentGestureActions.mm in Sources */,
 				03B8B4B41D2A346F00EDFF59 /* CKEqualityHashHelpers.mm in Sources */,
+				237FB106202B7A33007A6C73 /* CKBaseTreeNode.mm in Sources */,
 				03B8B4B51D2A346F00EDFF59 /* CKInternalHelpers.mm in Sources */,
 				03B8B4B61D2A346F00EDFF59 /* CKOptimisticViewMutations.mm in Sources */,
 				B1E3068E1E8B11AA004864CF /* CKComponentBoundsAnimationPredicates.mm in Sources */,
@@ -2740,6 +2798,7 @@
 				03B8B4CB1D2A346F00EDFF59 /* CKAsyncTransactionContainer.m in Sources */,
 				03B8B4CC1D2A346F00EDFF59 /* CKAsyncTransactionGroup.m in Sources */,
 				03B8B4CD1D2A346F00EDFF59 /* CKHighlightOverlayLayer.mm in Sources */,
+				237FB0402029C1C4007A6C73 /* CKGroupComponent.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2814,6 +2873,7 @@
 				B342DC771AC23EA900ACAC53 /* CKComponentMountContextLayoutGuideTests.mm in Sources */,
 				994EF6FB1B1FD77700E2236F /* CKComponentDelegateAttributeTests.mm in Sources */,
 				B342DC6C1AC23EA900ACAC53 /* CKComponentBoundsAnimationTests.mm in Sources */,
+				23560F2120346B20009CF531 /* CKTreeNodeTests.mm in Sources */,
 				B342DC811AC23EA900ACAC53 /* CKOptimisticViewMutationsTests.mm in Sources */,
 				A241C6A51AFCFFDB00D4F661 /* CKComponentActionTests.mm in Sources */,
 				B342DC6B1AC23EA900ACAC53 /* CKComponentAccessibilityTests.mm in Sources */,
@@ -2905,6 +2965,7 @@
 			files = (
 				D0B47C851CBD943400BB33CE /* CKComponentAccessibility.mm in Sources */,
 				D0B47C861CBD943400BB33CE /* CKButtonComponent.mm in Sources */,
+				23479E742029BAA1004A8396 /* CKSingleChildComponent.mm in Sources */,
 				D0B47C871CBD943400BB33CE /* CKImageComponent.mm in Sources */,
 				D0B47C881CBD943400BB33CE /* CKNetworkImageComponent.mm in Sources */,
 				D0B47C891CBD943400BB33CE /* CKComponent.mm in Sources */,
@@ -2915,6 +2976,7 @@
 				D0B47C8F1CBD943400BB33CE /* CKComponentMemoizer.mm in Sources */,
 				D0B47C901CBD943400BB33CE /* CKComponentSize.mm in Sources */,
 				7FB5C1EB1F865BEB00D2726B /* CKComponentDescriptionHelper.mm in Sources */,
+				237FB0FF202B7A33007A6C73 /* CKTreeNode.mm in Sources */,
 				D0B47C911CBD943400BB33CE /* CKComponentViewAttribute.mm in Sources */,
 				7F6BAF851F1F71A700600828 /* Yoga.c in Sources */,
 				D0B47C921CBD943400BB33CE /* CKComponentViewConfiguration.mm in Sources */,
@@ -2944,6 +3006,7 @@
 				D0B47CAE1CBD943400BB33CE /* CKComponentRootView.mm in Sources */,
 				D0B47CAF1CBD943400BB33CE /* CKBackgroundLayoutComponent.mm in Sources */,
 				A2E5BDC31EB9303D00444CD9 /* CKComponentKey.mm in Sources */,
+				237FB03F2029C1C4007A6C73 /* CKGroupComponent.mm in Sources */,
 				D0B47CB01CBD943400BB33CE /* CKCenterLayoutComponent.mm in Sources */,
 				D0B47CB11CBD943400BB33CE /* CKInsetComponent.mm in Sources */,
 				D0B47CB21CBD943400BB33CE /* CKOverlayLayoutComponent.mm in Sources */,
@@ -2960,6 +3023,7 @@
 				7F6BAF6B1F1F6E5200600828 /* CKFlexboxComponent.mm in Sources */,
 				D0B47CBE1CBD943400BB33CE /* CKDataSourceConfiguration.mm in Sources */,
 				D0B47CBF1CBD943400BB33CE /* CKDataSourceItem.mm in Sources */,
+				237FB105202B7A33007A6C73 /* CKBaseTreeNode.mm in Sources */,
 				D0B47CC01CBD943400BB33CE /* CKDataSourceListenerAnnouncer.mm in Sources */,
 				D0B47CC11CBD943400BB33CE /* CKDataSourceState.mm in Sources */,
 				B167C7101DD38E4200769084 /* CKMemoizingComponent.mm in Sources */,

--- a/ComponentKit/ComponentKit.h
+++ b/ComponentKit/ComponentKit.h
@@ -19,6 +19,8 @@
 #import <ComponentKit/CKMemoizingComponent.h>
 //Core
 #import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKSingleChildComponent.h>
+#import <ComponentKit/CKGroupComponent.h>
 #import <ComponentKit/CKComponentAnimation.h>
 #import <ComponentKit/CKComponentAnimationHooks.h>
 #import <ComponentKit/CKComponentBoundsAnimation.h>

--- a/ComponentKit/Core/CKBuildComponent.mm
+++ b/ComponentKit/Core/CKBuildComponent.mm
@@ -17,6 +17,7 @@
 #import "CKComponentScopeRoot.h"
 #import "CKComponentSubclass.h"
 #import "CKThreadLocalComponentScope.h"
+#import "CKTreeNode.h"
 
 CKBuildComponentResult CKBuildComponent(CKComponentScopeRoot *previousRoot,
                                         const CKComponentStateUpdateMap &stateUpdates,
@@ -28,6 +29,12 @@ CKBuildComponentResult CKBuildComponent(CKComponentScopeRoot *previousRoot,
   CKThreadLocalComponentScope threadScope(previousRoot, stateUpdates);
   // Order of operations matters, so first store into locals and then return a struct.
   CKComponent *const component = componentFactory();
+  // Build the component tree from the render function.
+  [component buildComponentTree:threadScope.newScopeRoot.rootNode
+                  previousOwner:previousRoot.rootNode
+                      scopeRoot:threadScope.newScopeRoot
+                   stateUpdates:stateUpdates];
+
   CKComponentScopeRoot *newScopeRoot = threadScope.newScopeRoot;
   [analyticsListener didBuildComponentTreeWithScopeRoot:newScopeRoot component:component];
   return {

--- a/ComponentKit/Core/CKComponentInternal.h
+++ b/ComponentKit/Core/CKComponentInternal.h
@@ -15,6 +15,9 @@
 #import <ComponentKit/CKComponentLayout.h>
 #import <ComponentKit/CKComponentScopeEnumeratorProvider.h>
 
+@class CKComponentScopeRoot;
+@class CKTreeNode;
+
 @interface CKComponent ()
 
 /**
@@ -41,6 +44,14 @@
                                         size:(const CGSize)size
                                     children:(std::shared_ptr<const std::vector<CKComponentLayoutChild>>)children
                               supercomponent:(CKComponent *)supercomponent NS_REQUIRES_SUPER;
+
+/**
+ For internal use only; don't use this initializer.
+
+ This initializer will not try to acquire the scope handle from the thread local store.
+ */
++ (instancetype)newWithViewWithoutScopeHandle:(const CKComponentViewConfiguration &)view
+                                         size:(const CKComponentSize &)size;
 
 /**
  Unmounts the component:
@@ -72,5 +83,22 @@
 
 /** Indicates that a scope conflict has been found and either this component or an ancestor is involved in the conflict */
 @property (nonatomic, readonly) BOOL componentOrAncestorHasScopeConflict;
+
+/** For internal use only; don't touch this. */
+@property (nonatomic, strong, readonly) CKComponentScopeHandle *scopeHandle;
+
+/** For internal use only; don't touch this. */
+- (void)aquireScopeHandle:(CKComponentScopeHandle *)scopeHandle;
+
+/**
+ For internal use only; don't touch this.
+
+ This method translates the component render method into a 'CKBaseTreeNode'; a component tree.
+ It's being called by the infra during the component tree creation.
+ */
+- (void)buildComponentTree:(CKTreeNode *)owner
+             previousOwner:(CKTreeNode *)previousOwner
+                 scopeRoot:(CKComponentScopeRoot *)scopeRoot
+              stateUpdates:(const CKComponentStateUpdateMap &)stateUpdates;
 
 @end

--- a/ComponentKit/Core/CKCompositeComponent.mm
+++ b/ComponentKit/Core/CKCompositeComponent.mm
@@ -16,6 +16,7 @@
 #import "CKInternalHelpers.h"
 #import "CKComponentInternal.h"
 #import "CKComponentSubclass.h"
+#import "CKBaseTreeNode.h"
 
 @interface CKCompositeComponent ()
 {
@@ -62,6 +63,26 @@
 + (instancetype)newWithView:(const CKComponentViewConfiguration &)view size:(const CKComponentSize &)size
 {
   CK_NOT_DESIGNATED_INITIALIZER();
+}
+
+- (void)buildComponentTree:(CKTreeNode *)owner
+             previousOwner:(CKTreeNode *)previousOwner
+                 scopeRoot:(CKComponentScopeRoot *)scopeRoot
+              stateUpdates:(const CKComponentStateUpdateMap &)stateUpdates
+{
+  __unused auto const node = [[CKBaseTreeNode alloc]
+                              initWithComponent:self
+                              owner:owner
+                              previousOwner:previousOwner
+                              scopeRoot:scopeRoot
+                              stateUpdates:stateUpdates];
+
+  if (_component) {
+    [_component buildComponentTree:owner
+                     previousOwner:previousOwner // We pass here the previous parent, as we would CKCompositeComponent it's not an owner component.
+                         scopeRoot:scopeRoot
+                      stateUpdates:stateUpdates];
+  }
 }
 
 - (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize

--- a/ComponentKit/Core/CKGroupComponent.h
+++ b/ComponentKit/Core/CKGroupComponent.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentLayout.h>
+#import <ComponentKit/CKComponentOwner.h>
+
+@interface CKGroupComponent : CKComponent <CKComponentOwner>
+
+/*
+ Returns a vector of 'CKComponent' children that will be render to the screen.
+
+ If you override this method, you must override the `computeLatoutThatFits:children:` and provide a layout for these components.
+ If you don't need a custom layout, you can just use CKFlexboxComponent instead.
+
+ @param state The current state of the component.
+ */
+- (std::vector<CKComponent *>)renderGroup:(id)state;
+
+@end

--- a/ComponentKit/Core/CKGroupComponent.mm
+++ b/ComponentKit/Core/CKGroupComponent.mm
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKGroupComponent.h"
+
+#import "CKBuildComponent.h"
+#import "CKTreeNode.h"
+#import "CKComponentInternal.h"
+
+@implementation CKGroupComponent
+
++ (instancetype)newWithView:(const CKComponentViewConfiguration &)view
+                       size:(const CKComponentSize &)size
+{
+  // As we are going to retrieve the state from the `CKBaseTreeNode`
+  // We don't need to acuire the scope handle from 'CKThreadLocalComponentScope::currentScope'.
+  return [super newWithViewWithoutScopeHandle:view size:size];
+}
+
+- (std::vector<CKComponent *>)renderGroup:(id)state
+{
+  return {};
+}
+
+- (void)buildComponentTree:(CKTreeNode *)owner
+             previousOwner:(CKTreeNode *)previousOwner
+                 scopeRoot:(CKComponentScopeRoot *)scopeRoot
+              stateUpdates:(const CKComponentStateUpdateMap &)stateUpdates
+{
+  auto const ownerComponent = [self ownerComponent];
+  Class nodeClass = ownerComponent ? [CKTreeNode class] : [CKBaseTreeNode class];
+  CKBaseTreeNode*node = [[nodeClass alloc]
+                         initWithComponent:self
+                         owner:owner
+                         previousOwner:previousOwner
+                         scopeRoot:scopeRoot
+                         stateUpdates:stateUpdates];
+  
+  CKTreeNode * ownerForChild = (ownerComponent ? (CKTreeNode *)node : owner);
+  CKTreeNode * previousOwnerForChild = (ownerComponent ? (CKTreeNode *)[previousOwner childForComponentKey:[node componentKey]] : previousOwner);
+
+  auto const componentKey = [node componentKey];
+  auto const children = [self renderGroup:node.state];
+  for (auto const child : children) {
+    if (child) {
+      [child buildComponentTree:ownerForChild
+                  previousOwner:previousOwnerForChild
+                      scopeRoot:scopeRoot
+                   stateUpdates:stateUpdates];
+    }
+  }
+}
+
+#pragma mark - CKComponentTreeOwner
+
+- (BOOL)ownerComponent
+{
+  return NO;
+}
+
+@end

--- a/ComponentKit/Core/CKSingleChildComponent.h
+++ b/ComponentKit/Core/CKSingleChildComponent.h
@@ -8,14 +8,17 @@
  *
  */
 
-#import <ComponentKit/CKGroupComponent.h>
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentOwner.h>
+
+@interface CKSingleChildComponent : CKComponent <CKComponentOwner>
 
 /**
- This component lays out a single component and then overlays a component on top of it streched to its size
- */
-@interface CKOverlayLayoutComponent : CKGroupComponent
+ Returns a child component that needs to be rendered from this component.
 
-+ (instancetype)newWithComponent:(CKComponent *)component
-                         overlay:(CKComponent *)overlay;
+ @param state The current state of the component.
+ */
+- (CKComponent *)render:(id)state;
 
 @end

--- a/ComponentKit/Core/CKSingleChildComponent.mm
+++ b/ComponentKit/Core/CKSingleChildComponent.mm
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+
+#import "CKSingleChildComponent.h"
+
+#import "CKBuildComponent.h"
+#import "CKComponentInternal.h"
+#import "CKComponentSubclass.h"
+#import "CKTreeNode.h"
+
+@implementation CKSingleChildComponent
+{
+  CKComponent *_childComponent;
+}
+
++ (instancetype)newWithView:(const CKComponentViewConfiguration &)view
+                       size:(const CKComponentSize &)size
+{
+  // As we are going to retrieve the state from the `CKBaseTreeNode`
+  // We don't need to acuire the scope handle from 'CKThreadLocalComponentScope::currentScope'.
+  return [super newWithViewWithoutScopeHandle:view size:size];
+}
+
+- (CKComponent *)render:(id)state
+{
+  return nil;
+}
+
+- (void)buildComponentTree:(CKTreeNode *)owner
+             previousOwner:(CKTreeNode *)previousOwner
+                 scopeRoot:(CKComponentScopeRoot *)scopeRoot
+              stateUpdates:(const CKComponentStateUpdateMap &)stateUpdates
+{
+  auto const ownerComponent = [self ownerComponent];
+  Class nodeClass = ownerComponent ? [CKTreeNode class] : [CKBaseTreeNode class];
+  CKBaseTreeNode *node = [[nodeClass alloc]
+                          initWithComponent:self
+                          owner:owner
+                          previousOwner:previousOwner
+                          scopeRoot:scopeRoot
+                          stateUpdates:stateUpdates];
+
+  auto const child = [self render:node.state];
+  if (child) {
+    _childComponent = child;
+    [child buildComponentTree:(ownerComponent ? (CKTreeNode *)node : owner)
+                previousOwner:(ownerComponent ? (CKTreeNode *)[previousOwner childForComponentKey:[node componentKey]] : previousOwner)
+                    scopeRoot:scopeRoot
+                 stateUpdates:stateUpdates];
+  }
+}
+
+- (CKComponentLayout)computeLayoutThatFits:(CKSizeRange)constrainedSize
+                          restrictedToSize:(const CKComponentSize &)size
+                      relativeToParentSize:(CGSize)parentSize
+{
+  CKAssert(size == CKComponentSize(),
+           @"CKSingleChildComponent only passes size {} to the super class initializer, but received size %@ "
+           "(component=%@)", size.description(), _childComponent);
+
+  CKComponentLayout l = [_childComponent layoutThatFits:constrainedSize parentSize:parentSize];
+  return {self, l.size, {{{0,0}, l}}};
+}
+
+#pragma mark - CKComponentTreeOwner
+
+- (BOOL)ownerComponent
+{
+  return YES;
+}
+
+@end

--- a/ComponentKit/Core/ComponentTree/CKBaseTreeNode.h
+++ b/ComponentKit/Core/ComponentTree/CKBaseTreeNode.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <ComponentKit/CKComponentScopeTypes.h>
+#import <ComponentKit/CKComponentScopeRoot.h>
+#import <ComponentKit/CKComponentScopeHandle.h>
+
+typedef int32_t CKTreeNodeIdentifier;
+typedef std::tuple<Class, NSUInteger> CKComponentKey;
+
+@class CKTreeNode;
+
+/**
+ This object represents a node in the component tree.
+
+ Each component has a corsponding CKBaseTreeNode; this node holds the state of the component and its children nodes.
+
+ CKBaseTreeNodeis the base class of a tree node. It will be atatched to leaf components only (CKComponent).
+ */
+@interface CKBaseTreeNode: NSObject
+
+- (instancetype)initWithComponent:(CKComponent *)component
+                            owner:(CKTreeNode *)owner
+                    previousOwner:(CKTreeNode *)previousOwner
+                        scopeRoot:(CKComponentScopeRoot *)scopeRoot
+                     stateUpdates:(const CKComponentStateUpdateMap &)stateUpdates;
+
+@property (nonatomic, strong, readonly) CKComponent *component;
+@property (nonatomic, strong, readonly) CKComponentScopeHandle *handle;
+@property (nonatomic, assign, readonly) CKTreeNodeIdentifier nodeIdentifier;
+
+/** Returns the component's state */
+- (id)state;
+
+/** Returns the componeny key according to its current owner */
+- (const CKComponentKey &)componentKey;
+
+@end

--- a/ComponentKit/Core/ComponentTree/CKBaseTreeNode.mm
+++ b/ComponentKit/Core/ComponentTree/CKBaseTreeNode.mm
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKBaseTreeNode.h"
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import <ComponentKit/CKInternalHelpers.h>
+
+#include <tuple>
+
+#import "CKMutex.h"
+#import "CKThreadLocalComponentScope.h"
+#import "CKTreeNode.h"
+
+@class CKTreeNode;
+
+@implementation CKBaseTreeNode
+{
+  CKComponentKey _componentKey;
+}
+
+- (instancetype)initWithComponent:(CKComponent *)component
+                            owner:(CKTreeNode *)owner
+                    previousOwner:(CKTreeNode *)previousOwner
+                        scopeRoot:(CKComponentScopeRoot *)scopeRoot
+                     stateUpdates:(const CKComponentStateUpdateMap &)stateUpdates
+{
+
+  static int32_t nextGlobalIdentifier = 0;
+
+  if (self = [super init]) {
+
+    _component = component;
+
+    Class componentClass = [component class];
+    _componentKey = [owner createComponentKeyForChildWithClass:componentClass];
+    CKBaseTreeNode *previousNode = [previousOwner childForComponentKey:_componentKey];
+
+    if (previousNode) {
+      _nodeIdentifier = previousNode.nodeIdentifier;
+    } else {
+      _nodeIdentifier = OSAtomicIncrement32(&nextGlobalIdentifier);
+    }
+
+    if (component.scopeHandle) {
+      _handle = component.scopeHandle;
+    }
+    else {
+      // In case we already had a component tree before.
+      if (previousNode) {
+        _handle = [previousNode.handle newHandleWithStateUpdates:stateUpdates
+                                              componentScopeRoot:scopeRoot
+                                                          parent:owner.handle];
+      }
+      else {
+        // We need a scope handle only if there is a controller or a state.
+        id initialState = [componentClass initialState];
+        if (initialState || [componentClass controllerClass]) {
+        _handle = [[CKComponentScopeHandle alloc] initWithListener:scopeRoot.listener
+                                                    rootIdentifier:scopeRoot.globalIdentifier
+                                                    componentClass:componentClass
+                                                      initialState:initialState
+                                                            parent:owner.handle];
+        }
+      }
+
+      if (_handle) {
+        [component aquireScopeHandle:_handle];
+        [_handle resolve];
+      }
+    }
+
+    // Set the link between the parent and the child.
+    [owner setChild:self forComponentKey:_componentKey];
+    
+  }
+  return self;
+}
+
+- (id)state
+{
+  return _handle.state;
+}
+
+- (const CKComponentKey &)componentKey
+{
+  return _componentKey;
+}
+
+@end

--- a/ComponentKit/Core/ComponentTree/CKComponentOwner.h
+++ b/ComponentKit/Core/ComponentTree/CKComponentOwner.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ This protocol defines how a component behaves when the component tree is being constructed by infrastructure:
+ 'buildComponentTree:previousOwner:scopeRootstateUpdates'.
+
+ Each component has a corsponding CKBaseTreeNode; this node holds the state of the component and its children nodes.
+ If a component is an owner component, its children nodes (CKBaseTreeNode) will be attached to its corsponding node.
+ Otherwise, they will be atatched to the same owner as the component itself.
+ */
+@protocol CKComponentOwner <NSObject>
+
+/*
+ Return yes in case your component is the owner of its children components.
+ Owner means that your component creates its children directly in its render method.
+
+ For example:
+ CKSingleChildComponent is an owner component.
+ CKFlexboxComponent isn't; it receives its children as props in its constructor.
+
+ Default values:
+ CKSingleChildComponent returns YES
+ CKGroupComponent returns NO
+ */
+- (BOOL)ownerComponent;
+
+@end

--- a/ComponentKit/Core/ComponentTree/CKTreeNode.h
+++ b/ComponentKit/Core/ComponentTree/CKTreeNode.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKBaseTreeNode.h"
+
+#include <vector>
+
+/**
+ This object represents a node with multiple children in the component tree.
+
+ Each component that is an owner component will have a corsponding CKOwnerTreeNode.
+ */
+
+@interface CKTreeNode : CKBaseTreeNode
+
+- (std::vector<CKComponent *>)children;
+
+/** Returns a component tree node according to its component key */
+- (CKBaseTreeNode *)childForComponentKey:(const CKComponentKey &)key;
+
+/** Creates a compoent key for a child node according to its component class; this method is being callded once during the component tree creation */
+- (CKComponentKey)createComponentKeyForChildWithClass:(id<CKComponentProtocol>)componentClass;
+
+/** Save a child node in the parent node according to its component key; this method is being callded once during the component tree creation */
+- (void)setChild:(CKBaseTreeNode *)child forComponentKey:(const CKComponentKey &)componentKey;
+
+@end

--- a/ComponentKit/Core/ComponentTree/CKTreeNode.mm
+++ b/ComponentKit/Core/ComponentTree/CKTreeNode.mm
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import "CKTreeNode.h"
+
+#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKComponentInternal.h>
+#import "CKThreadLocalComponentScope.h"
+#import <ComponentKit/CKInternalHelpers.h>
+
+#include <tuple>
+
+#import "CKMutex.h"
+
+struct CKTreeNodeComparator {
+  bool operator() (const CKComponentKey &lhs, const CKComponentKey &rhs) const
+  {
+    return std::get<0>(lhs) == std::get<0>(rhs) && std::get<1>(lhs) == std::get<1>(rhs);
+  }
+};
+
+struct CKTreeNodeHasher {
+  std::size_t operator() (const CKComponentKey &n) const
+  {
+    return [std::get<0>(n) hash] ^ std::get<1>(n);
+  }
+};
+
+typedef std::unordered_map<CKComponentKey, CKBaseTreeNode *, CKTreeNodeHasher, CKTreeNodeComparator> CKScopeNodeMap;
+
+@implementation CKTreeNode
+{
+  CKScopeNodeMap _children;
+  std::unordered_map<Class, NSUInteger> _classTypeIdentifier;
+}
+
+- (std::vector<CKComponent *>)children
+{
+  return CK::map(_children, [](const auto &n) {
+    return n.second.component;
+  });
+}
+
+- (CKBaseTreeNode *)childForComponentKey:(const CKComponentKey &)key
+{
+  return _children[key];
+}
+
+- (CKComponentKey)createComponentKeyForChildWithClass:(id<CKComponentProtocol>)componentClass
+{
+  return std::make_tuple(componentClass, _classTypeIdentifier[componentClass]++);
+}
+
+- (void)setChild:(CKBaseTreeNode*)child forComponentKey:(const CKComponentKey &)componentKey
+{
+  _children[componentKey] = child;
+}
+
+@end

--- a/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeFrame.mm
@@ -178,7 +178,7 @@ namespace std {
   : [[CKComponentScopeHandle alloc] initWithListener:newRoot.listener
                                       rootIdentifier:newRoot.globalIdentifier
                                       componentClass:componentClass
-                                 initialStateCreator:initialStateCreator
+                                        initialState:(initialStateCreator ? initialStateCreator() : [componentClass initialState])
                                               parent:pair.frame.handle];
 
   CKComponentScopeFrame *newChild = [[CKComponentScopeFrame alloc] initWithHandle:newHandle];

--- a/ComponentKit/Core/Scope/CKComponentScopeHandle.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeHandle.h
@@ -35,7 +35,7 @@
 - (instancetype)initWithListener:(id<CKComponentStateListener>)listener
                   rootIdentifier:(CKComponentScopeRootIdentifier)rootIdentifier
                   componentClass:(Class<CKComponentProtocol>)componentClass
-             initialStateCreator:(id (^)(void))initialStateCreator
+                    initialState:(id)initialState
                           parent:(CKComponentScopeHandle *)parent;
 
 /** Creates a new instance of the scope handle that incorporates the given state updates. */
@@ -56,6 +56,9 @@
 
 /** Informs the scope handle that it should complete its configuration. This will generate the controller */
 - (void)resolve;
+
+/** Aquire component, assert if the scope handle is wrong */
+- (void)aquireFromComponentAssertIfWrong:(id<CKComponentProtocol>)component;
 
 /**
  Should not be called until after handleForComponent:. The controller will assert (if assertions are compiled), and

--- a/ComponentKit/Core/Scope/CKComponentScopeRoot.h
+++ b/ComponentKit/Core/Scope/CKComponentScopeRoot.h
@@ -25,6 +25,7 @@
 
 @class CKComponentScopeFrame;
 @class CKComponentScopeRoot;
+@class CKTreeNode;
 
 /** Component state announcements will always be made on the main thread. */
 @protocol CKComponentStateListener <NSObject>
@@ -65,5 +66,6 @@
 @property (nonatomic, weak, readonly) id<CKAnalyticsListener> analyticsListener;
 @property (nonatomic, readonly) CKComponentScopeRootIdentifier globalIdentifier;
 @property (nonatomic, strong, readonly) CKComponentScopeFrame *rootFrame;
+@property (nonatomic, strong, readonly) CKTreeNode *rootNode;
 
 @end

--- a/ComponentKit/Core/Scope/CKComponentScopeRoot.mm
+++ b/ComponentKit/Core/Scope/CKComponentScopeRoot.mm
@@ -16,6 +16,7 @@
 #import "CKComponentControllerProtocol.h"
 #import "CKInternalHelpers.h"
 #import "CKThreadLocalComponentScope.h"
+#import "CKTreeNode.h"
 
 #if !defined(NO_PROTOCOLS_IN_OBJCPP)
 typedef std::unordered_map<CKComponentScopePredicate, NSHashTable<id<CKComponentProtocol>> *> _CKRegisteredComponentsMap;
@@ -67,6 +68,7 @@ typedef std::unordered_map<CKComponentControllerScopePredicate, NSHashTable<id> 
     _analyticsListener = analyticsListener;
     _globalIdentifier = globalIdentifier;
     _rootFrame = [[CKComponentScopeFrame alloc] initWithHandle:nil];
+    _rootNode = [[CKTreeNode alloc] init];
     _componentPredicates = componentPredicates;
     _componentControllerPredicates = componentControllerPredicates;
   }

--- a/ComponentKit/LayoutComponents/CKBackgroundLayoutComponent.h
+++ b/ComponentKit/LayoutComponents/CKBackgroundLayoutComponent.h
@@ -8,12 +8,12 @@
  *
  */
 
-#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKGroupComponent.h>
 
 /**
  Lays out a single child component, then lays out a background component behind it stretched to its size.
  */
-@interface CKBackgroundLayoutComponent : CKComponent
+@interface CKBackgroundLayoutComponent : CKGroupComponent
 
 /**
  @param component A child that is laid out to determine the size of this component. If this is nil, then this method

--- a/ComponentKit/LayoutComponents/CKBackgroundLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKBackgroundLayoutComponent.mm
@@ -40,6 +40,11 @@
   CK_NOT_DESIGNATED_INITIALIZER();
 }
 
+- (std::vector<CKComponent *>)renderGroup:(id)state
+{
+  return {_component, _background};
+}
+
 /**
  First layout the contents, then fit the background image.
  */

--- a/ComponentKit/LayoutComponents/CKFlexboxComponent.h
+++ b/ComponentKit/LayoutComponents/CKFlexboxComponent.h
@@ -20,7 +20,7 @@
 
 #import <vector>
 
-#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKGroupComponent.h>
 #import <ComponentKit/CKContainerWrapper.h>
 
 typedef NS_ENUM(NSUInteger, CKFlexboxDirection) {
@@ -341,7 +341,7 @@ extern const struct CKStackComponentLayoutExtraKeys {
  - If the sum of the childrens' heights is greater than 500 even after flexShrink-able components are flexed,
  justifyContent determines how children are laid out.
  */
-@interface CKFlexboxComponent : CKComponent
+@interface CKFlexboxComponent : CKGroupComponent
 
 /**
  @param view A view configuration, or {} for no view.

--- a/ComponentKit/LayoutComponents/CKFlexboxComponent.mm
+++ b/ComponentKit/LayoutComponents/CKFlexboxComponent.mm
@@ -17,6 +17,8 @@
 #import "CKInternalHelpers.h"
 #import "CKComponentLayout.h"
 #import "CKComponentLayoutBaseline.h"
+#import "CKThreadLocalComponentScope.h"
+#import "ComponentUtilities.h"
 
 const struct CKStackComponentLayoutExtraKeys CKStackComponentLayoutExtraKeys = {
   .hadOverflow = @"hadOverflow"
@@ -77,6 +79,13 @@ template class std::vector<CKFlexboxComponentChild>;
     component->_reuseOnlyExactSizeSpecs = CKComponentContext<CKFlexboxComponentContext>::get().reuseOnlyExactSizeSpecs;
   }
   return component;
+}
+
+- (std::vector<CKComponent *>)renderGroup:(id)state
+{
+  return  CK::map(_children, [](CKFlexboxComponentChild child) {
+    return child.component;
+  });
 }
 
 static YGConfigRef ckYogaDefaultConfig()

--- a/ComponentKit/LayoutComponents/CKInsetComponent.h
+++ b/ComponentKit/LayoutComponents/CKInsetComponent.h
@@ -10,7 +10,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <ComponentKit/CKComponent.h>
+#import <ComponentKit/CKSingleChildComponent.h>
 
 /**
  A component that wraps another component, applying insets around it.
@@ -29,7 +29,7 @@
  An infinite inset is resolved as an inset equal to all remaining space after applying the other insets and child size.
  @example An CKInsetComponent with an infinite left inset and 10px for all other edges will position it's child 10px from the right edge.
  */
-@interface CKInsetComponent : CKComponent
+@interface CKInsetComponent : CKSingleChildComponent
 
 /** Convenience that calls +newWithView:insets:component: with {} for view. */
 + (instancetype)newWithInsets:(UIEdgeInsets)insets component:(CKComponent *)child;

--- a/ComponentKit/LayoutComponents/CKInsetComponent.mm
+++ b/ComponentKit/LayoutComponents/CKInsetComponent.mm
@@ -69,6 +69,11 @@ static CGFloat centerInset(CGFloat outer, CGFloat inner)
   CK_NOT_DESIGNATED_INITIALIZER();
 }
 
+- (CKComponent *)render:(id)state
+{
+  return _component;
+}
+
 /**
  Inset will compute a new constrained size for it's child after applying insets and re-positioning
  the child to respect the inset.

--- a/ComponentKit/LayoutComponents/CKOverlayLayoutComponent.mm
+++ b/ComponentKit/LayoutComponents/CKOverlayLayoutComponent.mm
@@ -40,6 +40,11 @@
   CK_NOT_DESIGNATED_INITIALIZER();
 }
 
+- (std::vector<CKComponent *>)renderGroup:(id)state
+{
+  return {_component, _overlay};
+}
+
 /**
  First layout the contents, then fit the overlay on top of it.
  */

--- a/ComponentKitTests/CKTreeNodeTests.mm
+++ b/ComponentKitTests/CKTreeNodeTests.mm
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "CKComponent.h"
+#import "CKButtonComponent.h"
+#import "CKBaseTreeNode.h"
+#import "CKTreeNode.h"
+#import "CKThreadLocalComponentScope.h"
+
+@interface CKTreeNodeTestComponentWithState : CKComponent
+@end
+
+@implementation CKTreeNodeTestComponentWithState
++ (id)initialState
+{
+  return @1;
+}
+@end
+
+@interface CKTreeNodeTests : XCTestCase
+
+@end
+
+@implementation CKTreeNodeTests
+
+#pragma mark - CKTreeNode
+
+- (void)test_CKTreeNode_childForComponentKey_betweenGenerations {
+  // Simulate first component tree creation
+  CKTreeNode *root1 = [[CKTreeNode alloc] init];
+  auto const component1 = [CKComponent newWithView:{} size:{}];
+  CKBaseTreeNode *childNode1 = [[CKBaseTreeNode alloc] initWithComponent:component1
+                                                                   owner:root1
+                                                           previousOwner:nil
+                                                               scopeRoot:nil
+                                                            stateUpdates:{}];
+
+  // Simulate a component tree creation due to a state update
+  CKTreeNode *root2 = [[CKTreeNode alloc] init];
+  auto const component2 = [CKComponent newWithView:{} size:{}];
+  CKBaseTreeNode *childNode2 = [[CKBaseTreeNode alloc] initWithComponent:component2
+                                                                   owner:root2
+                                                           previousOwner:root1
+                                                               scopeRoot:nil
+                                                            stateUpdates:{}];
+
+  XCTAssertTrue(verifyChildToParentConnection(root1, childNode1, component1));
+  XCTAssertTrue(verifyChildToParentConnection(root2, childNode2, component2));
+}
+
+- (void)test_CKTreeNode_nodeIdentifier_betweenGenerations {
+  // Simulate first component tree creation
+  CKTreeNode *root1 = [[CKTreeNode alloc] init];
+  auto const component1 = [CKComponent newWithView:{} size:{}];
+  CKBaseTreeNode *childNode1 = [[CKBaseTreeNode alloc] initWithComponent:component1
+                                                                   owner:root1
+                                                           previousOwner:nil
+                                                               scopeRoot:nil
+                                                            stateUpdates:{}];
+
+  // Simulate a component tree creation due to a state update
+  CKTreeNode *root2 = [[CKTreeNode alloc] init];
+  auto const component2 = [CKComponent newWithView:{} size:{}];
+  CKBaseTreeNode *childNode2 = [[CKBaseTreeNode alloc] initWithComponent:component2
+                                                                   owner:root2
+                                                           previousOwner:root1
+                                                               scopeRoot:nil
+                                                            stateUpdates:{}];
+
+  XCTAssertEqual(childNode1.nodeIdentifier, childNode2.nodeIdentifier);
+}
+
+- (void)test_CKTreeNode_childForComponentKey_signleChild {
+  CKTreeNode *root = [[CKTreeNode alloc] init];
+
+  auto const component = [CKComponent newWithView:{} size:{}];
+  CKBaseTreeNode *childNode = [[CKBaseTreeNode alloc] initWithComponent:component
+                                                                  owner:root
+                                                          previousOwner:nil
+                                                              scopeRoot:nil
+                                                           stateUpdates:{}];
+
+  XCTAssertTrue(verifyChildToParentConnection(root, childNode, component));
+}
+
+- (void)test_CKTreeNode_childForComponentKey_multipleChildren {
+  CKTreeNode *root = [[CKTreeNode alloc] init];
+
+  // Create 4 children components
+  NSArray<CKComponent *> *components = @[[CKComponent newWithView:{} size:{}],
+                                         [CKComponent newWithView:{} size:{}],
+                                         [CKButtonComponent newWithView:{} size:{}],
+                                         [CKComponent newWithView:{} size:{}]];
+
+  // Creaste a childNode for each.
+  NSMutableArray<CKBaseTreeNode*> *nodes = [NSMutableArray array];
+  for (CKComponent *component in components) {
+    CKBaseTreeNode *childNode = [[CKBaseTreeNode alloc] initWithComponent:component
+                                                                    owner:root
+                                                            previousOwner:nil
+                                                                scopeRoot:nil
+                                                             stateUpdates:{}];
+    [nodes addObject:childNode];
+  }
+
+  // Make sure the connections between the parent to the child node are correct
+  for (NSUInteger i=0; i<components.count; i++) {
+    CKBaseTreeNode *childNode = nodes[i];
+    CKComponent *component = components[i];
+    XCTAssertTrue(verifyChildToParentConnection(root, childNode, component));
+  }
+}
+
+#pragma mark - State
+
+- (void)test_CKTreeNode_state
+{
+  // The 'resolve' method in CKComponentScopeHandle requires a CKThreadLocalComponentScope.
+  // We should get rid of this assert once we move to the render method only.
+  CKThreadLocalComponentScope threadScope(nil, {});
+
+  // Simulate first component tree creation
+  CKTreeNode *root1 = [[CKTreeNode alloc] init];
+  auto const component1 = [CKTreeNodeTestComponentWithState newWithView:{} size:{}];
+  CKBaseTreeNode *childNode = [[CKBaseTreeNode alloc] initWithComponent:component1
+                                                                  owner:root1
+                                                          previousOwner:nil
+                                                              scopeRoot:nil
+                                                           stateUpdates:{}];
+
+  // Verify that the initial state is correct.
+  XCTAssertTrue([childNode.state isEqualToNumber:[[component1 class] initialState]]);
+
+  // Simulate a component tree creation due to a state update
+  CKTreeNode *root2 = [[CKTreeNode alloc] init];
+  auto const component2 = [CKTreeNodeTestComponentWithState newWithView:{} size:{}];
+
+  // Simulate a state update
+  auto const newState = @2;
+  auto const scopeHandle = childNode.handle;
+  CKComponentStateUpdateMap stateUpdates;
+  stateUpdates[scopeHandle].push_back(^(id){
+    return newState;
+  });
+  CKBaseTreeNode *childNode2 = [[CKBaseTreeNode alloc] initWithComponent:component2
+                                                                   owner:root2
+                                                           previousOwner:root1
+                                                               scopeRoot:nil
+                                                            stateUpdates:stateUpdates];
+
+  XCTAssertTrue([childNode2.state isEqualToNumber:newState]);
+}
+
+static BOOL verifyChildToParentConnection(CKTreeNode * parentNode, CKBaseTreeNode *childNode, CKComponent *c) {
+  auto const componentKey = [childNode componentKey];
+  auto const childComponent = [parentNode childForComponentKey:componentKey].component;
+  return [childComponent isEqual:c];
+}
+
+@end

--- a/Examples/WildeGuess/WildeGuess/Components/FrostedQuoteComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/FrostedQuoteComponent.h
@@ -16,7 +16,7 @@
 /**
  A frosted quote component vertically stacks a quote and a " symbol and places it on a background.
  */
-@interface FrostedQuoteComponent : CKCompositeComponent
+@interface FrostedQuoteComponent : CKSingleChildComponent
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context;
 

--- a/Examples/WildeGuess/WildeGuess/Components/FrostedQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/FrostedQuoteComponent.mm
@@ -15,54 +15,67 @@
 #import "QuoteContext.h"
 
 @implementation FrostedQuoteComponent
+{
+  NSString *_text;
+  QuoteContext *_context;
+}
 
 + (instancetype)newWithText:(NSString *)text
                     context:(QuoteContext *)context
 {
-  return [super newWithComponent:
-          [QuoteWithBackgroundComponent
-           newWithBackgroundImage:[context imageNamed:@"LosAngeles"]
-           quoteComponent:
-           [CKInsetComponent
-            newWithInsets:{.top = 70, .bottom = 25, .left = 20, .right = 20}
-            component:
-            [CKFlexboxComponent
-             newWithView:{}
-             size:{}
-             style:{}
-             children:{
-               {
+  auto const c = [super new];
+  if (c) {
+    c->_text = text;
+    c->_context = context;
+  }
+  return c;
+}
+
+- (CKComponent *)render:(id)state
+{
+  return [QuoteWithBackgroundComponent
+          newWithBackgroundImage:[_context imageNamed:@"LosAngeles"]
+          quoteComponent:
+          [CKInsetComponent
+           newWithInsets:{.top = 70, .bottom = 25, .left = 20, .right = 20}
+           component:
+           [CKFlexboxComponent
+            newWithView:{}
+            size:{}
+            style:{}
+            children:{
+              {
+                [CKLabelComponent
+                 newWithLabelAttributes:{
+                   .string = _text,
+                   .font = [UIFont fontWithName:@"Baskerville" size:30]
+                 }
+                 viewAttributes:{
+                   {@selector(setBackgroundColor:), [UIColor clearColor]},
+                   {@selector(setUserInteractionEnabled:), @NO},
+                 }
+                 size:{ }],
+                .alignSelf = CKFlexboxAlignSelfCenter
+              },
+              {
+                // A semi-transparent end quote (") symbol placed below the quote.
+                [CKInsetComponent
+                 newWithInsets:{.right = 5}
+                 component:
                  [CKLabelComponent
                   newWithLabelAttributes:{
-                    .string = text,
-                    .font = [UIFont fontWithName:@"Baskerville" size:30]
+                    .string = @"\u201D",
+                    .color = [UIColor colorWithWhite:1 alpha:0.5],
+                    .font = [UIFont fontWithName:@"Baskerville" size:140]
                   }
                   viewAttributes:{
                     {@selector(setBackgroundColor:), [UIColor clearColor]},
                     {@selector(setUserInteractionEnabled:), @NO},
                   }
-                  size:{ }],
-                 .alignSelf = CKFlexboxAlignSelfCenter
-               },
-               {
-                 // A semi-transparent end quote (") symbol placed below the quote.
-                 [CKInsetComponent
-                  newWithInsets:{.right = 5}
-                  component:
-                  [CKLabelComponent
-                   newWithLabelAttributes:{
-                     .string = @"\u201D",
-                     .color = [UIColor colorWithWhite:1 alpha:0.5],
-                     .font = [UIFont fontWithName:@"Baskerville" size:140]
-                   }
-                   viewAttributes:{
-                     {@selector(setBackgroundColor:), [UIColor clearColor]},
-                     {@selector(setUserInteractionEnabled:), @NO},
-                   }
-                   size:{ }]],
-                 .alignSelf = CKFlexboxAlignSelfEnd, // Right aligned
-               }
-             }]]]];
+                  size:{ }]],
+                .alignSelf = CKFlexboxAlignSelfEnd, // Right aligned
+              }
+            }]]];
 }
 
 @end

--- a/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/InteractiveQuoteComponent.h
@@ -18,7 +18,7 @@
  An InteractiveQuoteComponent renders a Quote, adding the ability to tap to see whether the
  quote is actually by Oscar Wilde or not.
  */
-@interface InteractiveQuoteComponent : CKCompositeComponent
+@interface InteractiveQuoteComponent : CKSingleChildComponent
 
 + (instancetype)newWithQuote:(Quote *)quote context:(QuoteContext *)context;
 

--- a/Examples/WildeGuess/WildeGuess/Components/MonochromeQuoteComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/MonochromeQuoteComponent.h
@@ -17,7 +17,7 @@
  A monochrome quote component creates a left-aligned transucent white box on which it places a small bookmark-like gray
  box and the quote, horizontally stacked. This is placed on top of a monochrome background.
  */
-@interface MonochromeQuoteComponent : CKCompositeComponent
+@interface MonochromeQuoteComponent : CKSingleChildComponent
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context;
 

--- a/Examples/WildeGuess/WildeGuess/Components/MonochromeQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/MonochromeQuoteComponent.mm
@@ -15,8 +15,22 @@
 #import "QuoteContext.h"
 
 @implementation MonochromeQuoteComponent
+{
+  NSString *_text;
+  QuoteContext *_context;
+}
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context
+{
+  auto const c = [super new];
+  if (c) {
+    c->_text = text;
+    c->_context = context;
+  }
+  return c;
+}
+
+- (CKComponent *)render:(id)state
 {
   CKComponent *quoteTextComponent =
   [CKInsetComponent
@@ -24,7 +38,7 @@
    component:
    [CKLabelComponent
     newWithLabelAttributes:{
-      .string = text,
+      .string = _text,
       .color = [UIColor darkGrayColor],
       .font = [UIFont fontWithName:@"HoeflerText-Italic" size:25.0]
     }
@@ -60,23 +74,22 @@
      }
    }];
 
-  return [super newWithComponent:
-          [QuoteWithBackgroundComponent
-           newWithBackgroundImage:[context imageNamed:@"Drops"]
-           quoteComponent:
-           [CKInsetComponent
-            newWithInsets:{.top = 40, .bottom = 40}
-            component:
-            [CKBackgroundLayoutComponent
-             newWithComponent:quoteTextWithBookmarkComponent
-             background:
-             // Add a translucent white background for the text.
-             [CKComponent
-              newWithView:{
-                [UIView class],
-                {{@selector(setBackgroundColor:), [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:0.7]}}
-              }
-              size:{}]]]]];
+  return [QuoteWithBackgroundComponent
+          newWithBackgroundImage:[_context imageNamed:@"Drops"]
+          quoteComponent:
+          [CKInsetComponent
+           newWithInsets:{.top = 40, .bottom = 40}
+           component:
+           [CKBackgroundLayoutComponent
+            newWithComponent:quoteTextWithBookmarkComponent
+            background:
+            // Add a translucent white background for the text.
+            [CKComponent
+             newWithView:{
+               [UIView class],
+               {{@selector(setBackgroundColor:), [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:0.7]}}
+             }
+             size:{}]]]];
 }
 
 @end

--- a/Examples/WildeGuess/WildeGuess/Components/QuoteComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/QuoteComponent.h
@@ -17,7 +17,7 @@
 /**
  A QuoteComponent formats a quote based on the quote style.
  */
-@interface QuoteComponent : CKCompositeComponent
+@interface QuoteComponent : CKSingleChildComponent
 
 + (instancetype)newWithQuote:(Quote *)quote context:(QuoteContext *)context;
 

--- a/Examples/WildeGuess/WildeGuess/Components/QuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/QuoteComponent.mm
@@ -19,10 +19,24 @@
 #import "WarmQuoteComponent.h"
 
 @implementation QuoteComponent
+{
+  Quote *_quote;
+  QuoteContext *_context;
+}
 
 + (instancetype)newWithQuote:(Quote *)quote context:(QuoteContext *)context
 {
-  return [super newWithComponent:quoteComponent(quote, context)];
+  auto const c = [super new];
+  if (c) {
+    c->_quote = quote;
+    c->_context = context;
+  }
+  return c;
+}
+
+- (CKComponent *)render:(id)state
+{
+  return quoteComponent(_quote, _context);
 }
 
 static CKComponent *quoteComponent(Quote *quote, QuoteContext *context)

--- a/Examples/WildeGuess/WildeGuess/Components/QuoteWithBackgroundComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/QuoteWithBackgroundComponent.h
@@ -11,7 +11,7 @@
 
 #import <ComponentKit/ComponentKit.h>
 
-@interface QuoteWithBackgroundComponent : CKCompositeComponent
+@interface QuoteWithBackgroundComponent : CKSingleChildComponent
 
 + (instancetype)newWithBackgroundImage:(UIImage *)backgroundImage
                         quoteComponent:(CKComponent *)quoteComponent;

--- a/Examples/WildeGuess/WildeGuess/Components/QuoteWithBackgroundComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/QuoteWithBackgroundComponent.mm
@@ -12,25 +12,37 @@
 #import "QuoteWithBackgroundComponent.h"
 
 @implementation QuoteWithBackgroundComponent
+{
+  UIImage *_backgroundImage;
+  CKComponent *_quoteComponent;
+}
 
 + (instancetype)newWithBackgroundImage:(UIImage *)backgroundImage
                         quoteComponent:(CKComponent *)quoteComponent
-
 {
-  return [super newWithComponent:
-          [CKBackgroundLayoutComponent
-           newWithComponent:quoteComponent
-           background:
-           [CKComponent
-            newWithView:{
-              [UIImageView class],
-              {
-                {@selector(setImage:), backgroundImage},
-                {@selector(setContentMode:), @(UIViewContentModeScaleAspectFill)},
-                {@selector(setClipsToBounds:), @YES},
-              }
-            }
-            size:{}]]];
+  auto const c = [super new];
+  if (c) {
+    c->_backgroundImage = backgroundImage;
+    c->_quoteComponent = quoteComponent;
+  }
+  return c;
+}
+
+- (CKComponent *)render:(id)state
+{
+  return [CKBackgroundLayoutComponent
+          newWithComponent:_quoteComponent
+          background:
+          [CKComponent
+           newWithView:{
+             [UIImageView class],
+             {
+               {@selector(setImage:), _backgroundImage},
+               {@selector(setContentMode:), @(UIViewContentModeScaleAspectFill)},
+               {@selector(setClipsToBounds:), @YES},
+             }
+           }
+           size:{}]];
 }
 
 @end

--- a/Examples/WildeGuess/WildeGuess/Components/SombreQuoteComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/SombreQuoteComponent.h
@@ -16,7 +16,7 @@
 /**
  A sombre quote component sandwiches a quote between two thick lines and puts them on top of a somwhat sombre background.
  */
-@interface SombreQuoteComponent : CKCompositeComponent
+@interface SombreQuoteComponent : CKSingleChildComponent
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context;
 

--- a/Examples/WildeGuess/WildeGuess/Components/SombreQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/SombreQuoteComponent.mm
@@ -15,35 +15,48 @@
 #import "QuoteContext.h"
 
 @implementation SombreQuoteComponent
+{
+  NSString *_text;
+  QuoteContext *_context;
+}
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context
 {
-  return [super newWithComponent:
-          [QuoteWithBackgroundComponent
-           newWithBackgroundImage:[context imageNamed:@"MarketStreet"]
-           quoteComponent:
-           [CKInsetComponent
-            newWithInsets:{.top = 40, .left = 30, .bottom = 40, .right = 30}
-            component:
-            [CKFlexboxComponent
-             newWithView:{}
-             size:{}
-             style:{.spacing = 50}
-             children:{
-               {lineComponent()},
-               {[CKLabelComponent
-                 newWithLabelAttributes:{
-                   .string = [text uppercaseString],
-                   .color = [UIColor whiteColor],
-                   .font = [UIFont fontWithName:@"Avenir-Black" size:25]
-                 }
-                 viewAttributes:{
-                   {@selector(setBackgroundColor:), [UIColor clearColor]},
-                   {@selector(setUserInteractionEnabled:), @NO},
-                 }
-                 size:{ }]},
-               {lineComponent()},
-             }]]]];;
+  auto const c = [super new];
+  if (c) {
+    c->_text = text;
+    c->_context = context;
+  }
+  return c;
+}
+
+- (CKComponent *)render:(id)state
+{
+  return [QuoteWithBackgroundComponent
+          newWithBackgroundImage:[_context imageNamed:@"MarketStreet"]
+          quoteComponent:
+          [CKInsetComponent
+           newWithInsets:{.top = 40, .left = 30, .bottom = 40, .right = 30}
+           component:
+           [CKFlexboxComponent
+            newWithView:{}
+            size:{}
+            style:{.spacing = 50}
+            children:{
+              {lineComponent()},
+              {[CKLabelComponent
+                newWithLabelAttributes:{
+                  .string = [_text uppercaseString],
+                  .color = [UIColor whiteColor],
+                  .font = [UIFont fontWithName:@"Avenir-Black" size:25]
+                }
+                viewAttributes:{
+                  {@selector(setBackgroundColor:), [UIColor clearColor]},
+                  {@selector(setUserInteractionEnabled:), @NO},
+                }
+                size:{ }]},
+              {lineComponent()},
+            }]]];
 }
 
 static CKComponent *lineComponent()

--- a/Examples/WildeGuess/WildeGuess/Components/SuccessIndicatorComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/SuccessIndicatorComponent.h
@@ -12,7 +12,7 @@
 #import <ComponentKit/ComponentKit.h>
 
 /** A component indicating whether a quote belongs to Oscar Wilde. */
-@interface SuccessIndicatorComponent : CKCompositeComponent
+@interface SuccessIndicatorComponent : CKSingleChildComponent
 
 + (instancetype)newWithIndicatesSuccess:(BOOL)indicatesSuccess
                             successText:(NSString *)successText

--- a/Examples/WildeGuess/WildeGuess/Components/SuccessIndicatorComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/SuccessIndicatorComponent.mm
@@ -12,20 +12,33 @@
 #import "SuccessIndicatorComponent.h"
 
 @implementation SuccessIndicatorComponent
+{
+  BOOL _indicatesSuccess;
+  NSString *_successText;
+  NSString *_failureText;
+}
 
 + (instancetype)newWithIndicatesSuccess:(BOOL)indicatesSuccess
                             successText:(NSString *)successText
                             failureText:(NSString *)failureText
 {
+  auto const c = [super newWithView:{[UIView class]} size:{}]; // Need a view so supercomponent can animate this component.
+  if (c) {
+    c->_indicatesSuccess = indicatesSuccess;
+    c->_successText = successText;
+    c->_failureText = failureText;
+  }
+  return c;
+}
+
+- (CKComponent *)render:(id)state
+{
   UIColor *color =
-  indicatesSuccess
+  _indicatesSuccess
   ? [UIColor colorWithRed:0.1 green:0.4 blue:0.1 alpha:0.9]
   : [UIColor colorWithRed:0.7 green:0.1 blue:0.1 alpha:0.9];
 
-  return [super
-          newWithView:{[UIView class]} // Need a view so supercomponent can animate this component.
-          component:
-          [CKInsetComponent
+  return [CKInsetComponent
            newWithInsets:{.left = 20, .right = 20}
            component:
            [CKCenterLayoutComponent
@@ -45,21 +58,21 @@
                }
                children:{
                  {[CKLabelComponent
-                    newWithLabelAttributes:{
-                      .string = (indicatesSuccess ? @"Yes" : @"No"),
-                      .color = [UIColor whiteColor],
-                      .font = [UIFont fontWithName:@"Cochin-Bold" size:45.0],
-                      .alignment = NSTextAlignmentCenter
-                    }
-                    viewAttributes:{
-                      {@selector(setBackgroundColor:), [UIColor clearColor]},
-                      {@selector(setUserInteractionEnabled:), @NO},
-                    }
-                    size:{ }]
+                   newWithLabelAttributes:{
+                     .string = (_indicatesSuccess ? @"Yes" : @"No"),
+                     .color = [UIColor whiteColor],
+                     .font = [UIFont fontWithName:@"Cochin-Bold" size:45.0],
+                     .alignment = NSTextAlignmentCenter
+                   }
+                   viewAttributes:{
+                     {@selector(setBackgroundColor:), [UIColor clearColor]},
+                     {@selector(setUserInteractionEnabled:), @NO},
+                   }
+                   size:{ }]
                  },
                  {[CKLabelComponent
                    newWithLabelAttributes:{
-                     .string = (indicatesSuccess ? successText : failureText),
+                     .string = (_indicatesSuccess ? _successText : _failureText),
                      .color = [UIColor whiteColor],
                      .font = [UIFont fontWithName:@"Cochin" size:20.0],
                      .alignment = NSTextAlignmentCenter
@@ -82,8 +95,21 @@
                 }
               }
               size:{}]]
-            size:{}]]];
+            size:{}]];
+}
 
+- (std::vector<CKComponentAnimation>)animationsOnInitialMount
+{
+  return {{self, scaleToAppear()}};
+}
+
+static CAAnimation *scaleToAppear()
+{
+  CABasicAnimation *scale = [CABasicAnimation animationWithKeyPath:@"transform"];
+  scale.fromValue = [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.0, 0.0, 0.0)];
+  scale.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+  scale.duration = 0.2;
+  return scale;
 }
 
 @end

--- a/Examples/WildeGuess/WildeGuess/Components/WarmQuoteComponent.h
+++ b/Examples/WildeGuess/WildeGuess/Components/WarmQuoteComponent.h
@@ -17,7 +17,7 @@
  A warm quote component is a fixed-ratio component that centers the quote within its height. It has a nice warm
  background on which it places the quote.
  */
-@interface WarmQuoteComponent : CKCompositeComponent
+@interface WarmQuoteComponent : CKSingleChildComponent
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context;
 

--- a/Examples/WildeGuess/WildeGuess/Components/WarmQuoteComponent.mm
+++ b/Examples/WildeGuess/WildeGuess/Components/WarmQuoteComponent.mm
@@ -15,32 +15,44 @@
 #import "QuoteContext.h"
 
 @implementation WarmQuoteComponent
+{
+  NSString *_text;
+  QuoteContext *_context;
+}
 
 + (instancetype)newWithText:(NSString *)text context:(QuoteContext *)context
 {
-  return [super newWithComponent:
-          [QuoteWithBackgroundComponent
-           newWithBackgroundImage:[context imageNamed:@"Powell"]
-           quoteComponent:
-           [CKRatioLayoutComponent
-            newWithRatio:1.3
-            size:{}
-            component:
-            [CKInsetComponent
-             // Left and right inset of 30pts; centered vertically:
-             newWithInsets:{.left = 30, .right = 30, .top = INFINITY, .bottom = INFINITY}
-             component:
-             [CKLabelComponent
-              newWithLabelAttributes:{
-                .string = text,
-                .font = [UIFont fontWithName:@"AmericanTypewriter" size:26],
-              }
-              viewAttributes:{
-                {@selector(setBackgroundColor:), [UIColor clearColor]},
-                {@selector(setUserInteractionEnabled:), @NO},
-              }
-              size:{ }]]]]];
+  auto const c = [super new];
+  if (c) {
+    c->_text = text;
+    c->_context = context;
+  }
+  return c;
+}
 
+- (CKComponent *)render:(id)state
+{
+  return [QuoteWithBackgroundComponent
+          newWithBackgroundImage:[_context imageNamed:@"Powell"]
+          quoteComponent:
+          [CKRatioLayoutComponent
+           newWithRatio:1.3
+           size:{}
+           component:
+           [CKInsetComponent
+            // Left and right inset of 30pts; centered vertically:
+            newWithInsets:{.left = 30, .right = 30, .top = INFINITY, .bottom = INFINITY}
+            component:
+            [CKLabelComponent
+             newWithLabelAttributes:{
+               .string = _text,
+               .font = [UIFont fontWithName:@"AmericanTypewriter" size:26],
+             }
+             viewAttributes:{
+               {@selector(setBackgroundColor:), [UIColor clearColor]},
+               {@selector(setUserInteractionEnabled:), @NO},
+             }
+             size:{ }]]]];
 }
 
 @end


### PR DESCRIPTION
* *Component Tree Creation*
    * After the root component's creation in `CKBuildComponent(..)`, the *infra* creates a component tree (`CKComponentTreeNode`) recursively with the new *render* method. `CKComponentTreeNode` is the equivalent of `CKComponentScopeFrame`; but the main difference is that every component has one.


* *State*
    * Instead of accessing the state from a scope, the infra will pass it down to the render method.
    * No need for scopes anymore
* *Changes in `CKComponent` classes*
    * `CKSingleChildComponent`
        * Introduce a new a component type that has a render method: 
      `- (CKComponent *)render:(id)state`.
            The default implementation returns {}.
    * `CKGroupComponent`
        * Introduce a new a component type that has a renderGroup method: 
        `- (std::vector<CKComponent *>)renderGroup:(id)state`.
        The default implementation returns {}.
    * `CKFlexboxComponent`
        * Subclass from CKGroupComponent
        * Override the render method and map from `{CKFlexboxChild} → {CKComponent}`