### PR TITLE
[ComponentKit] Fix the failing test on CKComponentLayoutTests

### DIFF
--- a/ComponentKitTests/CKComponentLayoutTests.mm
+++ b/ComponentKitTests/CKComponentLayoutTests.mm
@@ -18,20 +18,26 @@
 #import <ComponentKit/CKFlexboxComponent.h>
 #import <ComponentKitTestHelpers/CKTestRunLoopRunning.h>
 
+@interface CKComponentLayoutTestComponentController : CKComponentController
+@end
+
 @interface CKComponentLayoutTestComponent : CKComponent
 @end
 @implementation CKComponentLayoutTestComponent
-+ (instancetype)newWithView:(const CKComponentViewConfiguration &)view size:(const CKComponentSize &)size
++ (instancetype)newWithView:(const CKComponentViewConfiguration &)view
+                       size:(const CKComponentSize &)size
 {
   // Just a hack for the test as we don't really care about this scope id in this case.
   static int counter = 0;
   CKComponentScope scope (self, @(counter++));
   return [super newWithView:view size:size];
 }
++ (Class<CKComponentControllerProtocol>)controllerClass
+{
+  return [CKComponentLayoutTestComponentController class];
+}
 @end
 
-@interface CKComponentLayoutTestComponentController : CKComponentController
-@end
 @implementation CKComponentLayoutTestComponentController
 @end
 
@@ -120,35 +126,27 @@
 
 - (void)testWhenLayoutIsBeingDeallocated_LayoutCacheIsBeingDeallocatedToo
 {
-  NSPointerArray *weakChildren = [NSPointerArray weakObjectsPointerArray];
+  __block __weak CKComponent *rootComponent;
+  __block __weak CKComponent *childComponent;
 
   @autoreleasepool {
-    __block NSArray<CKComponent *> *children;
     __block CKFlexboxComponent *c;
 
     CKBuildComponentResult results = CKBuildComponent(CKComponentScopeRootWithDefaultPredicates(nil, nil), {}, ^{
-      children = createChildrenArray(YES);
+      NSArray<CKComponent *> *children = createChildrenArray(YES);
       c = flexboxComponentWithScopedChildren(children);
+      rootComponent = c;
+      childComponent = [children firstObject];
       return c;
     });
 
     const CKComponentLayout layout = CKComputeRootComponentLayout(c, {{200, 0}, {200, INFINITY}}, nil, YES);
-
-    for (CKComponent *child in children) {
-      [weakChildren addPointer:(void *)child];
-    }
+    c = nil;
   }
 
   // Make sure all the children have been released.
-  XCTAssertTrue(CKRunRunLoopUntilBlockIsTrue(^BOOL{
-    NSUInteger weakChildrenCounter = 0;
-    for (id child in weakChildren) {
-      if (child) {
-        weakChildrenCounter++;
-      }
-    }
-    return weakChildrenCounter == 0;
-  }));
+  XCTAssertNil(rootComponent);
+  XCTAssertNil(childComponent);
 }
 
 #pragma mark - Helpers
@@ -161,14 +159,15 @@ static CKFlexboxComponent* flexboxComponentWithScopedChildren(NSArray<CKComponen
 }
 
 static NSArray<CKComponent *>* createChildrenArray(BOOL scoped) {
-  Class componentClass = scoped ? [CKComponentLayoutTestComponent class] : [CKComponent class];
-  return @[
-    [componentClass newWithView:{} size:{}],
-    [componentClass newWithView:{} size:{}],
-    [componentClass newWithView:{} size:{}],
-    [componentClass newWithView:{} size:{}],
-    [componentClass newWithView:{} size:{}],
-  ];
+  NSMutableArray<CKComponent *> *components = [NSMutableArray array];
+  for (NSUInteger i=0; i<5; i++) {
+    if (scoped) {
+      [components addObject:[CKComponentLayoutTestComponent newWithView:{} size:{}]];
+    } else {
+      [components addObject:[CKComponent newWithView:{} size:{}]];
+    }
+  }
+  return components;
 }
 
 @end


### PR DESCRIPTION
Using a block to verify that the component have been deallocated instead of `NSPointerArray`.
