### PR TITLE
Leak the global static mutex in CKTextKitContext to avoid static destructor fiasco

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitContext.mm
+++ b/ComponentTextKit/TextKit/CKTextKitContext.mm
@@ -30,8 +30,8 @@
 {
   if (self = [super init]) {
     // Concurrently initialising TextKit components crashes (rdar://18448377) so we use a global lock.
-    static std::mutex __static_mutex;
-    std::lock_guard<std::mutex> l(__static_mutex);
+    static std::mutex *__static_mutex = new std::mutex;
+    std::lock_guard<std::mutex> l(*__static_mutex);
     // Create the TextKit component stack with our default configuration.
     _textStorage = (attributedString ? [[NSTextStorage alloc] initWithAttributedString:attributedString] : [[NSTextStorage alloc] init]);
     _layoutManager = layoutManagerFactory ? layoutManagerFactory() : [[NSLayoutManager alloc] init];


### PR DESCRIPTION
I haven't tested this code, but this is what I would try to resolve https://github.com/facebook/componentkit/issues/892. Someone should run some smoke tests with something like the above