### PR TITLE
Removing Twitter analytics from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,8 +10,6 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-44373548-4', 'auto');
   ga('send', 'pageview');
-
-  !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
 </script>
 </body>
 </html>


### PR DESCRIPTION
Twitter analytics was causing loading issues on pages occasionally.
This diff removes that code from the footer