### PR TITLE
FIX: wrong code in `component controllers`

### DIFF
--- a/_docs/12-component-controllers.md
+++ b/_docs/12-component-controllers.md
@@ -56,17 +56,16 @@ To pass data from a component to its controller, expose a `@property` on the com
   }
   return c;
 }
++ (Class<CKComponentControllerProtocol>)controllerClass
+{
+  return [MySongComponentController class];
+}
 @end
 @interface MySongComponentController : CKComponentController
 @end
 @implementation MySongComponentController
 {
   MySong *_song;
-}
-
-+ (Class<CKComponentControllerProtocol>)controllerClass
-{
-  return [MySongComponentController class];
 }
 
 - (instancetype)initWithComponent:(MySongComponent *)component


### PR DESCRIPTION
example code in this chapter is wrong. 

which `+ (Class<CKComponentControllerProtocol>)controllerClass` should be implemented in subclass of `CKCompositeComponent`