### PR TITLE
Fix new build system compatiblity

### DIFF
--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'ComponentKit/**/*', 'ComponentTextKit/**/*'
-  s.exclude_files = 'ComponentKit/Info.plist'
+  s.exclude_files = ['ComponentKit/Info.plist']
   s.frameworks = 'UIKit', 'CoreText'
   s.library = 'c++'
   s.xcconfig = {

--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'ComponentKit/**/*', 'ComponentTextKit/**/*'
+  s.exclude_files = 'ComponentKit/Info.plist'
   s.frameworks = 'UIKit', 'CoreText'
   s.library = 'c++'
   s.xcconfig = {


### PR DESCRIPTION
This issue
https://github.com/facebook/componentkit/issues/920

was being caused because the podspec includes all files, so the Info.plist was also being imported and the XCode warned that 2 info.plist were added the the project. 

This PR excludes the plist file