### PR TITLE
Fix typo in `ComponentTextKit`

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitRenderer+Positioning.h
+++ b/ComponentTextKit/TextKit/CKTextKitRenderer+Positioning.h
@@ -17,12 +17,12 @@ typedef void (^ck_text_component_index_block_t)(NSUInteger characterIndex,
 /**
  Measure options are used to specify which type of line height measurement to use.
 
- ASTextNodeRendererMeasureOptionLineHeight is faster and will give the height from the baseline to the next line.
+ CKTextKitRendererMeasureOptionLineHeight is faster and will give the height from the baseline to the next line.
 
- ASTextNodeRendererMeasureOptionCapHeight is a more nuanced measure of the glyphs in the given range that attempts to
+ CKTextKitRendererMeasureOptionCapHeight is a more nuanced measure of the glyphs in the given range that attempts to
  produce a visually balanced rectangle above and below the glyphs to produce nice looking text highlights.
 
- ASTextNodeRendererMeasureOptionBlock uses the cap height option to generate each glyph index, but combines all but the
+ CKTextKitRendererMeasureOptionBlock uses the cap height option to generate each glyph index, but combines all but the
  first and last line rect into a single block.  Looks nice for multiline selection.
  */
 typedef NS_ENUM(NSUInteger, CKTextKitRendererMeasureOption) {

--- a/ComponentTextKit/TextKit/CKTextKitRendererCache.h
+++ b/ComponentTextKit/TextKit/CKTextKitRendererCache.h
@@ -108,8 +108,7 @@ namespace CK {
        in your application, no matter how many different text elements you may be drawing.  The maximum cost factor
        should be tuned based on which artifacts you're storing in this cache.  If you are storing raster buffers then it
        should likely be a couple MB.  If you are storing renderers it's a good idea to have it related to the visible
-       length of the string (as a proxy for number of glyph artifacts).  For an example of usage please see ASTextNode
-       or CKTextComponent.
+       length of the string (as a proxy for number of glyph artifacts).  For an example of usage please see CKTextComponent.
        */
       struct Cache {
       private:

--- a/ComponentTextKit/Utility/CKAsyncLayer.mm
+++ b/ComponentTextKit/Utility/CKAsyncLayer.mm
@@ -208,7 +208,7 @@
 
 #pragma mark - Drawing
 
-/// this method exists to provide an override point for ASDisplayNodeAsyncLayer where it can use its asyncDelegate in place
+/// this method exists to provide an override point for CKAsyncLayer where it can use its drawingDelegate in place
 /// of self for this implementation
 + (void)drawAsyncLayerInContext:(CGContextRef)context parameters:(NSObject *)parameters
 {

--- a/ComponentTextKit/Utility/CKHighlightOverlayLayer.mm
+++ b/ComponentTextKit/Utility/CKHighlightOverlayLayer.mm
@@ -106,7 +106,7 @@ static const UIEdgeInsets padding = {2, 4, 1.5, 4};
 
 @implementation CALayer (CKHighlightOverlayLayerSupport)
 
-// ASHighlightOverlayLayer compatibility
+// CKHighlightOverlayLayer compatibility
 static NSString *kAllowsHighlightDrawingKey = @"allows_highlight_drawing";
 
 - (BOOL)ck_allowsHighlightDrawing


### PR DESCRIPTION
Fix typo in `ComponentTextKit`