### PR TITLE
Keep CK_ARRAY_COUNT usage consistent

### DIFF
--- a/ComponentTextKit/TextKit/CKTextKitAttributes.mm
+++ b/ComponentTextKit/TextKit/CKTextKitAttributes.mm
@@ -11,6 +11,7 @@
 #import <ComponentKit/CKTextKitAttributes.h>
 
 #import <ComponentKit/CKEqualityHashHelpers.h>
+#import <ComponentKit/CKMacros.h>
 
 #include <functional>
 
@@ -32,5 +33,5 @@ size_t CKTextKitAttributes::hash() const
     std::hash<CGFloat>()(shadowOpacity),
     std::hash<CGFloat>()(shadowRadius),
   };
-  return CKIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
+  return CKIntegerArrayHash(subhashes, CK_ARRAY_COUNT(subhashes));
 }

--- a/ComponentTextKit/TextKit/CKTextKitRendererCache.mm
+++ b/ComponentTextKit/TextKit/CKTextKitRendererCache.mm
@@ -11,6 +11,7 @@
 #import <ComponentKit/CKTextKitRendererCache.h>
 
 #import <ComponentKit/CKEqualityHashHelpers.h>
+#import <ComponentKit/CKMacros.h>
 
 namespace CK {
   namespace TextKit {
@@ -32,7 +33,7 @@ namespace CK {
           std::hash<CGFloat>()(constrainedSize.width),
           std::hash<CGFloat>()(constrainedSize.height)
         };
-        hash = CKIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
+        hash = CKIntegerArrayHash(subhashes, CK_ARRAY_COUNT(subhashes));
       }
     }
   }


### PR DESCRIPTION
Use CK_ARRAY_COUNT for array counting, keep its usage consistent in the project.