### PR TITLE
Replace to use `__BEGIN_DECLS ` and `__END_DECLS `

### DIFF
--- a/ComponentKit/LayoutComponents/CKComponentLayoutBaseline.h
+++ b/ComponentKit/LayoutComponents/CKComponentLayoutBaseline.h
@@ -15,10 +15,8 @@
  e.g. @{kCKComponentLayoutExtraBaselineKey : 20}
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+__BEGIN_DECLS
+
 extern NSString *const kCKComponentLayoutExtraBaselineKey;
-#ifdef __cplusplus
-}
-#endif
+
+__END_DECLS

--- a/ComponentKit/Utilities/CKWeakObjectContainer.h
+++ b/ComponentKit/Utilities/CKWeakObjectContainer.h
@@ -8,14 +8,12 @@
  *
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#import <Foundation/Foundation.h>
+
+__BEGIN_DECLS
 
 extern void ck_objc_setNonatomicAssociatedWeakObject(id container, void *key, id value);
 extern void ck_objc_setAssociatedWeakObject(id container, void *key, id value);
 extern id ck_objc_getAssociatedWeakObject(id container, void *key);
 
-#ifdef __cplusplus
-}
-#endif
+__END_DECLS


### PR DESCRIPTION
Replace all use cases of 
```
#ifdef __cplusplus
extern "C" {
#endif
...
#ifdef __cplusplus
}
#endif
```
with 
```
__BEGIN_DECLS 
...
__END_DECLS 
```
keep its usage consistent in the project.