### PR TITLE
Fix removeListener in CKCollectionViewDataSourceListenerAnnouncer

### DIFF
--- a/ComponentKit/DataSources/CKCollectionViewDataSourceListenerAnnouncer.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSourceListenerAnnouncer.mm
@@ -21,7 +21,7 @@
 
 - (void)removeListener:(id<CKCollectionViewDataSourceListener>)listener
 {
-  CK::Component::AnnouncerHelper::addListener(self, _cmd, listener);
+  CK::Component::AnnouncerHelper::removeListener(self, _cmd, listener);
 }
 
 - (void)dataSourceWillBeginUpdates:(CKCollectionViewDataSource *)dataSource


### PR DESCRIPTION
Fix the `removeListener` method in the `CKCollectionViewDataSourceListenerAnnouncer` class