### PR TITLE
Fix `isEqual` method in `CKDataSourceChangeset `

### DIFF
--- a/ComponentKit/TransactionalDataSources/Common/CKDataSourceChangeset.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKDataSourceChangeset.mm
@@ -66,7 +66,7 @@
     [_removedSections isEqualToIndexSet:obj.removedSections] &&
     [_movedItems isEqualToDictionary:obj.movedItems] &&
     [_insertedSections isEqualToIndexSet:obj.insertedSections] &&
-    [_insertedItems isEqual:obj.insertedItems];
+    [_insertedItems isEqualToDictionary:obj.insertedItems];
   }
 }
 


### PR DESCRIPTION
Use `isEqualToDictionary` when comparing `insertedItems`