### PR TITLE
Fix naming issue when adopting `CKDataSourceStateModifying` protocol

### DIFF
--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceChangesetModification.mm
@@ -81,16 +81,16 @@ using namespace CKComponentControllerHelper;
   _itemGenerator = itemGenerator;
 }
 
-- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)oldState
+- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)state
 {
-  CKDataSourceConfiguration *configuration = [oldState configuration];
+  CKDataSourceConfiguration *configuration = [state configuration];
   id<NSObject> context = [configuration context];
   const CKSizeRange sizeRange = [configuration sizeRange];
 
   NSMutableArray<CKComponentController *> *invalidComponentControllers = [NSMutableArray array];
 
   NSMutableArray *newSections = [NSMutableArray array];
-  [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
+  [[state sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     [newSections addObject:[items mutableCopy]];
   }];
 
@@ -103,7 +103,7 @@ using namespace CKComponentControllerHelper;
                          (unsigned long)newSections.count,
                          _changeset,
                          _userInfo,
-                         oldState);
+                         state);
   }
     NSMutableArray *const section = newSections[indexPath.section];
     if (indexPath.item >= section.count) {
@@ -113,7 +113,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)section.count,
                            _changeset,
                            _userInfo,
-                           oldState);
+                           state);
     }
     CKDataSourceItem *const oldItem = section[indexPath.item];
     CKDataSourceItem *const item = [self _buildDataSourceItemForPreviousRoot:[oldItem scopeRoot]
@@ -162,7 +162,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)newSections.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
     const auto fromSection = static_cast<NSArray *>(newSections[from.section]);
     if (from.item >= fromSection.count) {
@@ -172,7 +172,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)fromSection.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
     insertedItemsBySection[to.section][to.row] = fromSection[from.item];
   }];
@@ -195,7 +195,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)newSections.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
     const auto section = static_cast<NSMutableArray *>(newSections[it.first]);
 #if CK_ASSERTIONS_ENABLED
@@ -208,7 +208,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)it.first,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
 #endif
     [section removeObjectsAtIndexes:it.second];
@@ -231,7 +231,7 @@ using namespace CKComponentControllerHelper;
                          (unsigned long)newSections.count,
                          CK::changesetDescription(_changeset),
                          _userInfo,
-                         oldState);
+                         state);
   }
 #if CK_ASSERTIONS_ENABLED
     // Deep validation of the indexes we are going to insert for better logging.
@@ -244,7 +244,7 @@ using namespace CKComponentControllerHelper;
                        newSections,
                        CK::changesetDescription(_changeset),
                        _userInfo,
-                       oldState);
+                       state);
   }
 #endif
 
@@ -293,7 +293,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)newSections.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
 #if CK_ASSERTIONS_ENABLED
     const auto sectionItems = static_cast<NSArray *>([newSections objectAtIndex:sectionIt.first]);
@@ -306,7 +306,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)sectionIt.first,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
 #endif
     [[newSections objectAtIndex:sectionIt.first] insertObjects:items atIndexes:indexes];
@@ -326,7 +326,7 @@ using namespace CKComponentControllerHelper;
                                                        userInfo:_userInfo];
 
   return [[CKDataSourceChange alloc] initWithState:newState
-                                     previousState:oldState
+                                     previousState:state
                                     appliedChanges:appliedChanges
                                  deferredChangeset:nil
                        invalidComponentControllers:invalidComponentControllers];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceReloadModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceReloadModification.mm
@@ -40,16 +40,16 @@ using namespace CKComponentControllerHelper;
   return self;
 }
 
-- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)oldState
+- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)state
 {
-  CKDataSourceConfiguration *configuration = [oldState configuration];
+  CKDataSourceConfiguration *configuration = [state configuration];
   id<NSObject> context = [configuration context];
   const CKSizeRange sizeRange = [configuration sizeRange];
 
   NSMutableArray *newSections = [NSMutableArray array];
   NSMutableSet *updatedIndexPaths = [NSMutableSet set];
   NSMutableArray<CKComponentController *> *invalidComponentControllers = [NSMutableArray array];
-  [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
+  [[state sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     NSMutableArray *newItems = [NSMutableArray array];
     [items enumerateObjectsUsingBlock:^(CKDataSourceItem *item, NSUInteger itemIdx, BOOL *itemStop) {
       [updatedIndexPaths addObject:[NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx]];
@@ -79,7 +79,7 @@ using namespace CKComponentControllerHelper;
                                                        userInfo:_userInfo];
 
   return [[CKDataSourceChange alloc] initWithState:newState
-                                     previousState:oldState
+                                     previousState:state
                                     appliedChanges:appliedChanges
                                  deferredChangeset:nil
                        invalidComponentControllers:invalidComponentControllers];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceSplitChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceSplitChangesetModification.mm
@@ -59,9 +59,9 @@ using namespace CKComponentControllerHelper;
   return self;
 }
 
-- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)oldState
+- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)state
 {
-  CKDataSourceConfiguration *configuration = [oldState configuration];
+  CKDataSourceConfiguration *configuration = [state configuration];
   id<NSObject> context = [configuration context];
   const CKSizeRange sizeRange = [configuration sizeRange];
   const auto splitChangesetOptions = [configuration options].splitChangesetOptions;
@@ -73,7 +73,7 @@ using namespace CKComponentControllerHelper;
   NSMutableArray<CKComponentController *> *invalidComponentControllers = [NSMutableArray array];
 
   NSMutableArray *newSections = [NSMutableArray array];
-  [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
+  [[state sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     [newSections addObject:[items mutableCopy]];
   }];
 
@@ -92,7 +92,7 @@ using namespace CKComponentControllerHelper;
                       context,
                       _changeset,
                       _userInfo,
-                      oldState,
+                      state,
                       viewportSize,
                       splitChangesetOptions.layoutAxis,
                       _viewport.contentOffset);
@@ -112,7 +112,7 @@ using namespace CKComponentControllerHelper;
                              (unsigned long)newSections.count,
                              _changeset,
                              _userInfo,
-                             oldState);
+                             state);
       }
       NSMutableArray *const section = newSections[indexPath.section];
       if (indexPath.item >= section.count) {
@@ -122,7 +122,7 @@ using namespace CKComponentControllerHelper;
                              (unsigned long)section.count,
                              _changeset,
                              _userInfo,
-                             oldState);
+                             state);
       }
       CKDataSourceItem *const oldItem = section[indexPath.item];
       CKDataSourceItem *const item = CKBuildDataSourceItem([oldItem scopeRoot], {}, sizeRange, configuration, model, context);
@@ -155,7 +155,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)newSections.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
     const auto fromSection = static_cast<NSArray *>(newSections[from.section]);
     if (from.item >= fromSection.count) {
@@ -165,7 +165,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)fromSection.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
     insertedItemsBySection[to.section][to.row] = fromSection[from.item];
   }];
@@ -200,7 +200,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)newSections.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
     const auto section = static_cast<NSMutableArray *>(newSections[it.first]);
 #if CK_ASSERTIONS_ENABLED
@@ -213,7 +213,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)it.first,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
 #endif
     [section removeObjectsAtIndexes:it.second];
@@ -238,7 +238,7 @@ using namespace CKComponentControllerHelper;
                          (unsigned long)newSections.count,
                          CK::changesetDescription(_changeset),
                          _userInfo,
-                         oldState);
+                         state);
   }
 #if CK_ASSERTIONS_ENABLED
     // Deep validation of the indexes we are going to insert for better logging.
@@ -251,7 +251,7 @@ using namespace CKComponentControllerHelper;
                        newSections,
                        CK::changesetDescription(_changeset),
                        _userInfo,
-                       oldState);
+                       state);
   }
 #endif
   [newSections insertObjects:emptyMutableArrays([[_changeset insertedSections] count]) atIndexes:[_changeset insertedSections]];
@@ -323,7 +323,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)newSections.count,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
 #if CK_ASSERTIONS_ENABLED
     const auto sectionItems = static_cast<NSArray *>([newSections objectAtIndex:sectionIt.first]);
@@ -336,7 +336,7 @@ using namespace CKComponentControllerHelper;
                            (unsigned long)sectionIt.first,
                            CK::changesetDescription(_changeset),
                            _userInfo,
-                           oldState);
+                           state);
     }
 #endif
     [[newSections objectAtIndex:sectionIt.first] insertObjects:items atIndexes:indexes];
@@ -357,7 +357,7 @@ using namespace CKComponentControllerHelper;
                                                        userInfo:_userInfo];
 
   return [[CKDataSourceChange alloc] initWithState:newState
-                                     previousState:oldState
+                                     previousState:state
                                     appliedChanges:appliedChanges
                                  deferredChangeset:createDeferredChangeset(deferredInsertedItems, computeDeferredItems(sectionsForDeferredUpdatedItems))
                        invalidComponentControllers:invalidComponentControllers];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceUpdateConfigurationModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceUpdateConfigurationModification.mm
@@ -43,18 +43,18 @@ using namespace CKComponentControllerHelper;
   return self;
 }
 
-- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)oldState
+- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)state
 {
   id<NSObject> context = [_configuration context];
   const CKSizeRange sizeRange = [_configuration sizeRange];
 
   // If only the size range changed, we don't need to regenerate the component; we can simply re-layout the existing one.
-  const BOOL onlySizeRangeChanged = [_configuration hasSameComponentProviderAndContextAs:oldState.configuration];
+  const BOOL onlySizeRangeChanged = [_configuration hasSameComponentProviderAndContextAs:state.configuration];
 
   NSMutableArray *newSections = [NSMutableArray array];
   NSMutableSet *updatedIndexPaths = [NSMutableSet set];
   NSMutableArray<CKComponentController *> *invalidComponentControllers = [NSMutableArray array];
-  [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
+  [[state sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     NSMutableArray *newItems = [NSMutableArray array];
     [items enumerateObjectsUsingBlock:^(CKDataSourceItem *item, NSUInteger itemIdx, BOOL *itemStop) {
       [updatedIndexPaths addObject:[NSIndexPath indexPathForItem:itemIdx inSection:sectionIdx]];
@@ -92,7 +92,7 @@ using namespace CKComponentControllerHelper;
                                                        userInfo:_userInfo];
 
   return [[CKDataSourceChange alloc] initWithState:newState
-                                     previousState:oldState
+                                     previousState:state
                                     appliedChanges:appliedChanges
                                  deferredChangeset:nil
                        invalidComponentControllers:invalidComponentControllers];

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceUpdateStateModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceUpdateStateModification.mm
@@ -41,9 +41,9 @@ using namespace CKComponentControllerHelper;
   return self;
 }
 
-- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)oldState
+- (CKDataSourceChange *)changeFromState:(CKDataSourceState *)state
 {
-  CKDataSourceConfiguration *configuration = [oldState configuration];
+  CKDataSourceConfiguration *configuration = [state configuration];
   id<NSObject> context = [configuration context];
   const CKSizeRange sizeRange = [configuration sizeRange];
 
@@ -51,7 +51,7 @@ using namespace CKComponentControllerHelper;
   NSMutableSet *updatedIndexPaths = [NSMutableSet set];
   NSMutableArray<CKComponentController *> *invalidComponentControllers = [NSMutableArray array];
   __block CKComponentScopeRootIdentifier globalIdentifier = 0;
-  [[oldState sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
+  [[state sections] enumerateObjectsUsingBlock:^(NSArray *items, NSUInteger sectionIdx, BOOL *sectionStop) {
     NSMutableArray *newItems = [NSMutableArray array];
     [items enumerateObjectsUsingBlock:^(CKDataSourceItem *item, NSUInteger itemIdx, BOOL *itemStop) {
       const auto stateUpdatesForItem = _stateUpdates.find([[item scopeRoot] globalIdentifier]);
@@ -90,7 +90,7 @@ using namespace CKComponentControllerHelper;
                                                        userInfo:@{@"updatedComponentIdentifier":@(globalIdentifier)}];
 
   return [[CKDataSourceChange alloc] initWithState:newState
-                                     previousState:oldState
+                                     previousState:state
                                     appliedChanges:appliedChanges
                                  deferredChangeset:nil
                        invalidComponentControllers:invalidComponentControllers];


### PR DESCRIPTION
Fix parameter naming issue when adopting `CKDataSourceStateModifying` protocol