### PR TITLE
Allow CKFlexboxBuilder to render children without initial child

### DIFF
--- a/ComponentKit/LayoutComponents/FlexboxComponentBuilder.h
+++ b/ComponentKit/LayoutComponents/FlexboxComponentBuilder.h
@@ -369,11 +369,11 @@ class __attribute__((__may_alias__)) FlexboxComponentBuilder
    */
   auto &child(NS_RELEASES_ARGUMENT CKComponent *c)
   {
-    if (PropBitmap::isSet(PropsBitmap, FlexboxComponentPropId::hasActiveChild)) {
-      _children.push_back(_currentChild);
+    if (!PropBitmap::isSet(PropsBitmap, FlexboxComponentPropId::hasActiveChild)) {
+      _currentChild = {c};
     }
 
-    _currentChild = {c};
+    _children.push_back(_currentChild);
     return reinterpret_cast<FlexboxComponentBuilder<PropsBitmap | FlexboxComponentPropId::hasActiveChild> &>(*this);
   }
 


### PR DESCRIPTION
I found that `CKFlexboxComponentBuilder()` will never render its children if it's not initially constructed with an explicit child. For example:
 
```
auto flexbox = CKFlexboxComponentBuilder();
flexbox.child(componentA);
flexbox.build(); // componentA will not render
```

```
auto flexbox = CKFlexboxComponentBuilder().child(nil);
flexbox.child(componentA);
flexbox.build(); // componentA renders
```

I suspect it’s due to the logic here: https://fburl.com/diffusion/is68e3zp

Since hasActiveChild is false in the absence of an initial child prop, the new child isn’t pushed back, which prevents hasActiveChild from correctly recomputing, and no new children will ever be pushed onto the _children vector.

