### PR TITLE
Fix a bunch of issues from the Xcode 14 upgrade

### DIFF
--- a/ComponentKit/Core/CKComponentGenerator.mm
+++ b/ComponentKit/Core/CKComponentGenerator.mm
@@ -425,11 +425,11 @@ static std::vector<CKComponentController *> _addedComponentControllersBetweenSco
   RCAssertMainThread();
 
   const auto enqueueStateUpdate = ^{
-    _inputsStore->acquireInputs(^(CKComponentGeneratorInputs &inputs){
+    self->_inputsStore->acquireInputs(^(CKComponentGeneratorInputs &inputs){
       inputs.stateUpdates[handle].push_back(stateUpdate);
       [[inputs.scopeRoot analyticsListener] didReceiveStateUpdateFromScopeHandle:handle rootIdentifier:rootIdentifier];
     });
-    [_delegate componentGenerator:self didReceiveComponentStateUpdateWithMode:mode];
+    [self->_delegate componentGenerator:self didReceiveComponentStateUpdateWithMode:mode];
   };
   if (_affinedQueue == dispatch_get_main_queue()) {
     enqueueStateUpdate();

--- a/ComponentKit/DataSources/CKCollectionViewDataSource.mm
+++ b/ComponentKit/DataSources/CKCollectionViewDataSource.mm
@@ -126,10 +126,10 @@ static void applyChangesToCollectionView(UICollectionView *collectionView,
     }
 
     void (^applyUpdatedState)(CKDataSourceState *) = ^(CKDataSourceState *updatedState) {
-      [_collectionView performBatchUpdates:^{
-        _currentState = updatedState;
+      [self->_collectionView performBatchUpdates:^{
+        self->_currentState = updatedState;
       } completion:^(BOOL finished) {
-        [_announcer dataSourceDidEndUpdates:self didModifyPreviousState:previousState withState:state byApplyingChanges:changes];
+        [self->_announcer dataSourceDidEndUpdates:self didModifyPreviousState:previousState withState:state byApplyingChanges:changes];
       }];
     };
 
@@ -151,9 +151,9 @@ static void applyChangesToCollectionView(UICollectionView *collectionView,
     CKComponentBoundsAnimationApply(boundsAnimation, ^{
       for (NSIndexPath *indexPath in changes.updatedIndexPaths) {
         CKDataSourceItem *item = [state objectAtIndexPath:indexPath];
-        CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *)[_collectionView cellForItemAtIndexPath:indexPath];
+        CKCollectionViewDataSourceCell *cell = (CKCollectionViewDataSourceCell *)[self->_collectionView cellForItemAtIndexPath:indexPath];
         if (cell) {
-          attachToCell(cell, item, _attachController, _cellToItemMap);
+          attachToCell(cell, item, self->_attachController, self->_cellToItemMap);
         }
       }
     }, nil);
@@ -168,7 +168,7 @@ static void applyChangesToCollectionView(UICollectionView *collectionView,
       // Update current state
       _currentState = state;
     } completion:^(BOOL finished){
-      [_announcer dataSourceDidEndUpdates:self didModifyPreviousState:previousState withState:state byApplyingChanges:changes];
+      [self->_announcer dataSourceDidEndUpdates:self didModifyPreviousState:previousState withState:state byApplyingChanges:changes];
     }];
   }
 }
@@ -201,7 +201,7 @@ static auto heightChange(CKDataSourceState *previousState, CKDataSourceState *st
   [removedSections enumerateIndexesUsingBlock:^(NSUInteger section, BOOL *stop) {
     [state enumerateObjectsInSectionAtIndex:section
                                  usingBlock:^(CKDataSourceItem *item, NSIndexPath *indexPath, BOOL *stop2) {
-      [_attachController detachComponentLayoutWithScopeIdentifier:[[item scopeRoot] globalIdentifier]];
+      [self->_attachController detachComponentLayoutWithScopeIdentifier:[[item scopeRoot] globalIdentifier]];
     }];
   }];
 }

--- a/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
+++ b/ComponentKit/DataSources/CKComponentBoundsAnimation+UICollectionView.mm
@@ -207,17 +207,17 @@ void CKComponentBoundsAnimationApplyAfterCollectionViewBatchUpdates(id context, 
   // Then move them back to their current positions with animation:
   void (^restore)(void) = ^{
     [indexPathsToAnimatingViews enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPath, UIView *view, BOOL *stop) {
-      UICollectionViewLayoutAttributes *attributes = [_collectionView layoutAttributesForItemAtIndexPath:indexPath];
+      UICollectionViewLayoutAttributes *attributes = [self->_collectionView layoutAttributesForItemAtIndexPath:indexPath];
       [view setBounds:attributes.bounds];
       [view setCenter:attributes.center];
     }];
     [indexPathsToAnimatingSupplementaryViews enumerateKeysAndObjectsUsingBlock:^(NSIndexPath *indexPath, UIView *view, BOOL *stop) {
       UICollectionViewLayoutAttributes *attributes =
-      [_collectionView layoutAttributesForSupplementaryElementOfKind:indexPathsToSupplementaryElementKinds[indexPath] atIndexPath:indexPath];
+      [self->_collectionView layoutAttributesForSupplementaryElementOfKind:indexPathsToSupplementaryElementKinds[indexPath] atIndexPath:indexPath];
       [view setBounds:attributes.bounds];
       [view setCenter:attributes.center];
     }];
-    [_collectionView setContentOffset:CGPointMake(_collectionView.contentOffset.x + contentOffsetAdjustment.x, _collectionView.contentOffset.y + contentOffsetAdjustment.y)];
+    [self->_collectionView setContentOffset:CGPointMake(self->_collectionView.contentOffset.x + contentOffsetAdjustment.x, self->_collectionView.contentOffset.y + contentOffsetAdjustment.y)];
   };
   void (^completion)(BOOL) = ^(BOOL finished){
     for (UIView *v in snapshotViewsToRemoveAfterAnimation) {

--- a/ComponentKit/HostingView/CKComponentHostingView.mm
+++ b/ComponentKit/HostingView/CKComponentHostingView.mm
@@ -309,14 +309,14 @@ static auto nilProvider(id<NSObject>, id<NSObject>) -> CKComponent * { return ni
 
   // Wait until the end of the run loop so that if multiple async updates are triggered we don't thrash.
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (!_scheduledAsynchronousComponentUpdate) {
+    if (!self->_scheduledAsynchronousComponentUpdate) {
       // A synchronous update was either scheduled or completed, so we can skip the async update.
       return;
     }
     // Sync trait collection in `componentGenerator` before building the next generation.
-    [_componentGenerator updateTraitCollection:self.traitCollection];
-    [_componentGenerator updateAccessibilityStatus:CK::Component::Accessibility::IsAccessibilityEnabled()];
-    [_componentGenerator generateComponentAsynchronously];
+    [self->_componentGenerator updateTraitCollection:self.traitCollection];
+    [self->_componentGenerator updateAccessibilityStatus:CK::Component::Accessibility::IsAccessibilityEnabled()];
+    [self->_componentGenerator generateComponentAsynchronously];
   });
 }
 

--- a/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
+++ b/ComponentKit/StatefulViews/CKStatefulViewReusePool.mm
@@ -162,7 +162,7 @@ struct PoolKeyHasher {
   }
 
   auto const addEntry = ^{
-    auto &poolItem = _pendingPool[std::make_pair(controllerClass, context)];
+    auto &poolItem = self->_pendingPool[std::make_pair(controllerClass, context)];
     poolItem.addEntry({view, mayRelinquishBlock});
   };
   if (!_clearingPendingPool) {

--- a/ComponentKit/TransactionalDataSources/Common/CKDataSource.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKDataSource.mm
@@ -627,12 +627,12 @@ static const NSUInteger kBackgroundThreadStackSizeInBytes = 1024 * 1024 * 2; // 
     CKSystraceScope applyModificationScope(asyncApplyModification);
     // If the first object in _pendingAsynchronousModifications is not still the modification,
     // it may have been canceled; don't apply it.
-    if ([_pendingAsynchronousModifications firstObject] == modificationPair.modification && self->_state == modificationPair.state) {
-      [_pendingAsynchronousModifications removeObjectAtIndex:0];
+    if ([self->_pendingAsynchronousModifications firstObject] == modificationPair.modification && self->_state == modificationPair.state) {
+      [self->_pendingAsynchronousModifications removeObjectAtIndex:0];
       [self _synchronouslyApplyChange:change qos:modificationPair.modification.qos];
     }
 
-    _processingAsynchronousModification = NO;
+    self->_processingAsynchronousModification = NO;
     [self _startAsynchronousModificationIfNeeded];
   });
 }

--- a/ComponentKit/TransactionalDataSources/Common/CKDataSourceChangesetApplicator.mm
+++ b/ComponentKit/TransactionalDataSources/Common/CKDataSourceChangesetApplicator.mm
@@ -195,13 +195,13 @@ struct CKDataSourceChangesetApplicatorPipelineItem {
       for (NSIndexPath *insertedIndex in [change.appliedChanges insertedIndexPaths]) {
         if ([newState numberOfSections] > insertedIndex.section && [newState numberOfObjectsInSection:insertedIndex.section] > insertedIndex.row) {
           CKDataSourceItem *insertedItem = [newState objectAtIndexPath:insertedIndex];
-          _treeLayoutCache->update([[insertedItem scopeRoot] globalIdentifier], insertedItem.rootLayout.cache());
+          self->_treeLayoutCache->update([[insertedItem scopeRoot] globalIdentifier], insertedItem.rootLayout.cache());
         }
       }
       for (NSIndexPath *updatedIndex in [change.appliedChanges finalUpdatedIndexPaths]) {
         if ([newState numberOfSections] > updatedIndex.section && [newState numberOfObjectsInSection:updatedIndex.section] > updatedIndex.row) {
           CKDataSourceItem *updatedItem = [newState objectAtIndexPath:updatedIndex];
-          _treeLayoutCache->update([[updatedItem scopeRoot] globalIdentifier], updatedItem.rootLayout.cache());
+          self->_treeLayoutCache->update([[updatedItem scopeRoot] globalIdentifier], updatedItem.rootLayout.cache());
         }
       }
     }
@@ -241,14 +241,14 @@ struct CKDataSourceChangesetApplicatorPipelineItem {
 - (void)setViewPort:(CKDataSourceViewport)viewport
 {
   dispatch_async(_queue, ^{
-    _viewport = viewport;
+    self->_viewport = viewport;
   });
 }
 
 - (void)setTraitCollection:(UITraitCollection *)traitCollection
 {
   dispatch_async(_queue, ^{
-    _traitCollection = [traitCollection copy];
+    self->_traitCollection = [traitCollection copy];
   });
 }
 

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceChangesetModification.mm
@@ -125,8 +125,8 @@ using namespace CKComponentControllerHelper;
                            @"Invalid section: %lu (>= %lu). Changeset: %@, user info: %@, state: %@",
                            (unsigned long)indexPath.section,
                            (unsigned long)newSections.count,
-                           _changeset,
-                           _userInfo,
+                           self->_changeset,
+                           self->_userInfo,
                            oldState);
     }
     NSMutableArray *const section = newSections[indexPath.section];
@@ -135,8 +135,8 @@ using namespace CKComponentControllerHelper;
                            @"Invalid item: %lu (>= %lu). Changeset: %@, user info: %@, state: %@",
                            (unsigned long)indexPath.item,
                            (unsigned long)section.count,
-                           _changeset,
-                           _userInfo,
+                           self->_changeset,
+                           self->_userInfo,
                            oldState);
     }
     CKDataSourceItem *const oldItem = section[indexPath.item];
@@ -146,7 +146,7 @@ using namespace CKComponentControllerHelper;
                                                                configuration:configuration
                                                                        model:model
                                                                      context:context
-                                                                 layoutCache:_treeLayoutCache ? _treeLayoutCache->find([[oldItem scopeRoot] globalIdentifier]) : nullptr
+                                                                 layoutCache:self->_treeLayoutCache ? self->_treeLayoutCache->find([[oldItem scopeRoot] globalIdentifier]) : nullptr
                                                                     itemType:CKDataSourceChangesetModificationItemTypeUpdate];
     [section replaceObjectAtIndex:indexPath.item withObject:item];
     for (auto componentController : addedControllersFromPreviousScopeRootMatchingPredicate(item.scopeRoot,
@@ -248,7 +248,7 @@ using namespace CKComponentControllerHelper;
 
   // Insert items
   const auto buildItem = ^CKDataSourceItem *(id model) {
-    const auto scopeRoot = CKComponentScopeRootWithPredicates(_stateListener,
+    const auto scopeRoot = CKComponentScopeRootWithPredicates(self->_stateListener,
                                                               configuration.analyticsListener,
                                                               configuration.componentPredicates,
                                                               configuration.componentControllerPredicates);
@@ -258,7 +258,7 @@ using namespace CKComponentControllerHelper;
                                        configuration:configuration
                                                model:model
                                              context:context
-                                         layoutCache:_treeLayoutCache ? _treeLayoutCache->find([scopeRoot globalIdentifier]) : nullptr
+                                         layoutCache:self->_treeLayoutCache ? self->_treeLayoutCache->find([scopeRoot globalIdentifier]) : nullptr
                                             itemType:CKDataSourceChangesetModificationItemTypeInsert];
   };
 

--- a/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceSplitChangesetModification.mm
+++ b/ComponentKit/TransactionalDataSources/Common/Internal/CKDataSourceSplitChangesetModification.mm
@@ -281,7 +281,7 @@ using namespace CKComponentControllerHelper;
 
   // Insert items
   const auto buildItem = ^CKDataSourceItem *(id model) {
-    return CKBuildDataSourceItem(CKComponentScopeRootWithPredicates(_stateListener,
+    return CKBuildDataSourceItem(CKComponentScopeRootWithPredicates(self->_stateListener,
                                                                     configuration.analyticsListener,
                                                                     configuration.componentPredicates,
                                                                     configuration.componentControllerPredicates), {},

--- a/ComponentTextKit/TextKit/CKTextKitTailTruncater.mm
+++ b/ComponentTextKit/TextKit/CKTextKitTailTruncater.mm
@@ -169,7 +169,7 @@
                                                               actualGlyphRange:NULL];
 
     // Check if text is truncated, and if so apply our truncation string
-    if (visibleCharacterRange.length < originalStringLength && _truncationAttributedString.length > 0) {
+    if (visibleCharacterRange.length < originalStringLength && self->_truncationAttributedString.length > 0) {
       NSInteger firstCharacterIndexToReplace = [self _calculateCharacterIndexBeforeTruncationMessage:layoutManager
                                                                                          textStorage:textStorage
                                                                                        textContainer:textContainer];
@@ -184,10 +184,10 @@
                                                        textStorage.length - firstCharacterIndexToReplace);
       // Replace the end of the visible message with the truncation string
       [textStorage replaceCharactersInRange:truncationReplacementRange
-                       withAttributedString:_truncationAttributedString];
+                       withAttributedString:self->_truncationAttributedString];
     }
 
-    _visibleRanges = { visibleCharacterRange };
+    self->_visibleRanges = { visibleCharacterRange };
   }];
 }
 

--- a/ComponentTextKit/Utility/CKAsyncLayer.mm
+++ b/ComponentTextKit/Utility/CKAsyncLayer.mm
@@ -189,7 +189,7 @@
                                                                                        drawParameters:drawParameters];
   ck_async_transaction_operation_completion_block_t completionBlock = ^(id<NSObject> value, BOOL canceled) {
     RCCAssertMainThread();
-    if (!canceled && (_displaySentinel == displaySentinelValue)) {
+    if (!canceled && (self->_displaySentinel == displaySentinelValue)) {
       [self didDisplayAsynchronously:value withDrawParameters:drawParameters];
       self.contents = value;
     }

--- a/ComponentTextKit/Utility/CKAsyncTransaction.mm
+++ b/ComponentTextKit/Utility/CKAsyncTransaction.mm
@@ -87,11 +87,11 @@
   CKAsyncTransactionOperation *operation = [[CKAsyncTransactionOperation alloc] initWithOperationCompletionBlock:completion];
   [_operations addObject:operation];
   dispatch_group_async(_group, queue, ^{
-    if (_state != CKAsyncTransactionStateCanceled) {
-      dispatch_group_enter(_group);
+    if (self->_state != CKAsyncTransactionStateCanceled) {
+      dispatch_group_enter(self->_group);
       block(^(id<NSObject> value){
         operation.value = value;
-        dispatch_group_leave(_group);
+        dispatch_group_leave(self->_group);
       });
     }
   });
@@ -109,7 +109,7 @@
   CKAsyncTransactionOperation *operation = [[CKAsyncTransactionOperation alloc] initWithOperationCompletionBlock:completion];
   [_operations addObject:operation];
   dispatch_group_async(_group, queue, ^{
-    if (_state != CKAsyncTransactionStateCanceled) {
+    if (self->_state != CKAsyncTransactionStateCanceled) {
       operation.value = block();
     }
   });
@@ -145,12 +145,12 @@
   } else {
     RCAssert(_group != NULL, @"If there are operations, dispatch group should have been created");
     dispatch_group_notify(_group, _callbackQueue, ^{
-      BOOL isCanceled = (_state == CKAsyncTransactionStateCanceled);
-      for (CKAsyncTransactionOperation *operation in _operations) {
+      BOOL isCanceled = (self->_state == CKAsyncTransactionStateCanceled);
+      for (CKAsyncTransactionOperation *operation in self->_operations) {
         [operation callAndReleaseCompletionBlock:isCanceled];
       }
-      if (_completionBlock) {
-        _completionBlock(self, isCanceled);
+      if (self->_completionBlock) {
+        self->_completionBlock(self, isCanceled);
       }
     });
   }

--- a/RenderCore/Base/CKOptional.h
+++ b/RenderCore/Base/CKOptional.h
@@ -165,6 +165,7 @@ namespace OptionalDetail {
 
     constexpr Storage() : HasValue<sizeof(T)>{false}, value{} {}
     Storage(const Storage &) = default;
+    Storage& operator=(const Storage&) = default;
 
     void clear() {
       this->hasValue = false;


### PR DESCRIPTION
The clang-14 in Xcode 14 introduces a bunch of new errors including many
missing `self->` and a couple missing copy-assignment/copy-constructors.
Fix them all here so that WildeGuess builds with Xcode14.